### PR TITLE
[refactor][Minor] Moving the residual path to the components

### DIFF
--- a/xformers/components/__init__.py
+++ b/xformers/components/__init__.py
@@ -13,6 +13,7 @@ from xformers.utils import import_all_modules
 from .activations import Activation, build_activation  # noqa
 from .attention import Attention, build_attention  # noqa
 from .multi_head_dispatch import MultiHeadDispatch, MultiHeadDispatchConfig  # noqa
+from .residual import LayerNormStyle, PostNorm, PreNorm, Residual  # noqa
 
 __all__ = ["MultiHeadDispatch", "Activation"]
 

--- a/xformers/components/residual.py
+++ b/xformers/components/residual.py
@@ -1,0 +1,97 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from enum import Enum
+from typing import List, Union
+
+import torch
+import torch.nn as nn
+
+# NOTE: The Triton layernorm can be activated/deactivated from here
+_is_triton_available = False
+
+if _is_triton_available:
+    try:
+        from xformers.triton.layer_norm import FusedLayerNorm
+    except ImportError as e:
+        import logging
+
+        logging.warning(
+            f"Triton is not available, some optimizations will not be enabled.\n{e}"
+        )
+        _is_triton_available = False
+
+
+def _to_tensor_list(
+    inputs: Union[torch.Tensor, List[torch.Tensor]]
+) -> List[torch.Tensor]:
+    if not isinstance(inputs, list):
+        inputs = [inputs]
+    return inputs
+
+
+class LayerNormStyle(str, Enum):
+    """Support different layer norm styles.
+    See "On Layer Normalization in the Transformer Architecture",
+    Xiong et al., https://arxiv.org/pdf/2002.04745v1.pdf
+    """
+
+    Pre = "pre"
+    Post = "post"
+
+
+# CREDITS: the following is inspired by FastAI's Transformer implementation
+class Residual(nn.Module):
+    """Object-oriented handling of the residual path"""
+
+    def __init__(self, layer: nn.Module):
+        super().__init__()
+        self.layer = layer
+
+    def forward(self, inputs: Union[torch.Tensor, List[torch.Tensor]], *args, **kwargs):
+        inputs = _to_tensor_list(inputs)
+
+        return inputs[0] + self.layer(*inputs, *args, **kwargs)
+
+
+class PreNorm(nn.Module):
+    """Adds LayerNorm before computing attention
+
+    ..Note: If a list of inputs is passed, all of them get normalized"""
+
+    def __init__(self, d_model: int, sublayer: nn.Module, use_triton: bool = True):
+        super().__init__()
+        if _is_triton_available and use_triton:
+            self.norm: Union[nn.LayerNorm, FusedLayerNorm] = FusedLayerNorm(d_model)
+        else:
+            self.norm = nn.LayerNorm(d_model)
+
+        self.sublayer = sublayer
+
+    def forward(self, inputs: Union[torch.Tensor, List[torch.Tensor]], *args, **kwargs):
+        inputs = _to_tensor_list(inputs)
+
+        x_norm = [self.norm(x_) for x_ in inputs]
+        return self.sublayer(*x_norm, *args, **kwargs)
+
+
+class PostNorm(nn.Module):
+    """Adds LayerNorm after computing attention"""
+
+    def __init__(self, d_model: int, sublayer: nn.Module, use_triton: bool = True):
+        super().__init__()
+        if _is_triton_available and use_triton:
+            self.norm: Union[nn.LayerNorm, FusedLayerNorm] = FusedLayerNorm(d_model)
+        else:
+            self.norm = nn.LayerNorm(d_model)
+
+        self.sublayer = sublayer
+
+    def forward(self, inputs: Union[torch.Tensor, List[torch.Tensor]], *args, **kwargs):
+        inputs = _to_tensor_list(inputs)
+
+        x = self.sublayer(*inputs, *args, **kwargs)
+        return self.norm(x)


### PR DESCRIPTION
## What does this PR do?
- Move the Pre/Post residual paths to the components, so that a full transformer can be built from /components alone
- makes it possible to submit a fused version in the future, with Triton

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
