### PR TITLE
[hotfix] Blocksparse mask moved to half

### DIFF
--- a/xformers/components/attention/blocksparse.py
+++ b/xformers/components/attention/blocksparse.py
@@ -174,6 +174,9 @@ if _use_triton:
             q_dtype = q.dtype
             q, k, v = q.half(), k.half(), v.half()
 
+            if att_mask is not None:
+                att_mask = att_mask.half()
+
             # Self-attend: (B, nh, S, hs) x (B, nh, hs, S) -> (B, nh, S, S)
             # When the computations are block sparse, the matrix types change along the way:
             # - (sparse) attention matrix = (dense) Kt * (dense) Q


### PR DESCRIPTION
## What does this PR do?
Move the blocksparse mask to half, same as the rest.
Not visible before because this test was not run on CI, the other PR enabling Triton on circle CI landed in between and rightly exposed it

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
