### PR TITLE
[fix] Move mask type assertion in Nystrom

### DIFF
--- a/tests/test_attention_utils.py
+++ b/tests/test_attention_utils.py
@@ -1,0 +1,40 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+
+from xformers.components.attention.utils import (
+    maybe_merge_masks,
+    reshape_key_padding_mask,
+)
+
+
+def test_reshape_key_padding_mask():
+    batch_size = 2
+    num_heads = 2
+    seq_len = 4
+
+    batched_dim = batch_size * num_heads
+
+    key_padding_mask = torch.randint(0, 2, (batch_size, seq_len)).to(dtype=torch.bool)
+    reshaped_mask = reshape_key_padding_mask(
+        key_padding_mask=key_padding_mask, batched_dim=batched_dim
+    )
+    assert reshaped_mask.size() == (batched_dim, 1, seq_len)
+
+    merged_mask = maybe_merge_masks(
+        att_mask=None,
+        key_padding_mask=key_padding_mask,
+        batch_size=batch_size,
+        src_len=seq_len,
+        num_heads=num_heads,
+    )
+    assert torch.equal(merged_mask, reshaped_mask)
+
+    key_padding_mask = torch.randint(0, 2, (batched_dim, seq_len)).to(dtype=torch.bool)
+    reshaped_mask = reshape_key_padding_mask(
+        key_padding_mask=key_padding_mask, batched_dim=batched_dim
+    )
+    assert reshaped_mask.size() == (batched_dim, 1, seq_len)

--- a/tests/test_nystrom_attention.py
+++ b/tests/test_nystrom_attention.py
@@ -69,17 +69,19 @@ def test_nystrom_attention(
         nystrom_attention = NystromAttention(**nystrom_config)
         sdp_attention = ScaledDotProduct(**sdp_config)
 
-        key_padding_mask = torch.randint(0, 2, (b // num_heads, s)).to(dtype=torch.bool)
+        key_padding_mask = None
         att_mask = torch.randint(0, 2, (s, s)).to(dtype=torch.bool)
-        mask = maybe_merge_masks(
-            att_mask,
-            key_padding_mask,
+        sdp_mask = maybe_merge_masks(
+            att_mask=None,
+            key_padding_mask=key_padding_mask,
             batch_size=b // num_heads,
             src_len=s,
             num_heads=num_heads,
         )
-        r_nystrom = nystrom_attention(a, a, a, att_mask=mask)
-        r_sdp = sdp_attention(a, a, a, att_mask=None)
+        r_nystrom = nystrom_attention(
+            a, a, a, att_mask=att_mask, key_padding_mask=key_padding_mask
+        )
+        r_sdp = sdp_attention(a, a, a, att_mask=sdp_mask)
         assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
 
     def test_masking():
@@ -90,14 +92,15 @@ def test_nystrom_attention(
         sdp_attention = ScaledDotProduct(**sdp_config)
 
         key_padding_mask = torch.randint(0, 2, (b // num_heads, s)).to(dtype=torch.bool)
+        att_mask = None
         mask = maybe_merge_masks(
-            None,
+            att_mask,
             key_padding_mask,
             batch_size=b // num_heads,
             src_len=s,
             num_heads=num_heads,
         )
-        r_nystrom = nystrom_attention(a, a, a, att_mask=mask)
+        r_nystrom = nystrom_attention(a, a, a, key_padding_mask=key_padding_mask)
         r_sdp = sdp_attention(a, a, a, att_mask=mask)
         # account for when nan != nan
         if r_nystrom.isnan().any() or r_sdp.isnan().any():
@@ -109,6 +112,11 @@ def test_nystrom_attention(
         assert torch.allclose(
             r_nystrom, r_sdp, rtol=0.1, atol=0.5
         ), f"max diff {torch.max(torch.abs(r_nystrom-r_sdp))}"
+
+        # Error when key padding mask doesn't have expected dimensions.
+        key_padding_mask = torch.randint(0, 2, (s, b)).to(dtype=torch.bool)
+        with pytest.raises(AssertionError):
+            nystrom_attention(a, a, a, key_padding_mask=key_padding_mask)
 
     test_close_to_sdp()
     test_att_mask_ignored()

--- a/xformers/components/attention/base.py
+++ b/xformers/components/attention/base.py
@@ -36,7 +36,6 @@ class Attention(nn.Module, metaclass=ABCMeta):
         super().__init__()
         self.requires_input_projection = True
         self.requires_head_dimension = False
-        self.accepts_att_mask = True
         # key padding mask and attention mask must be passed in as separate arguments instead of a merged attention mask
         self.requires_separate_masks = False
 


### PR DESCRIPTION
## What does this PR do?
Don't assert on mask type if attention mask will be ignored.
Issue in #33 

Updated - last commit removed att_mask as an argument and only accepts a key_padding mask. This keeps behavior consistent with Linformer and Blocksparse attentions.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
