### PR TITLE
[Minor] Triton softmax 2D/3D compatible, ease of use

### DIFF
--- a/tests/test_triton_softmax.py
+++ b/tests/test_triton_softmax.py
@@ -21,6 +21,7 @@ except ImportError as e:
     _triton_available = False
 
 SHAPES = [
+    (384, 384),
     (2, 384, 384),
     (1, 784, 784),
     (1, 1024, 1024),


### PR DESCRIPTION
## What does this PR do?
Makes sure that the triton-based softmax that we use by default is compatible with 2d (batch-less) tensors

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
