### PR TITLE
[LRA] Minor helper when fetching batch logs

### DIFF
--- a/xformers/benchmarks/LRA/batch_fetch_results.py
+++ b/xformers/benchmarks/LRA/batch_fetch_results.py
@@ -28,6 +28,8 @@ if __name__ == "__main__":
     parser.add_argument("-ck", "--checkpoint_path", required=True)
     args = parser.parse_args()
 
+    logging.getLogger().setLevel(logging.INFO)
+
     # Go through all the data in the given repo, try to find the end results
     root = Path(args.checkpoint_path)
 


### PR DESCRIPTION
## What does this PR do?
Small papercuts for the `batch_fetch_results` utils for the LRA integration, prompted by current tests for the rotary embeddings:
- printout as logging by default
- when no result (either final or ongoing) look for the error logs and display the last N lines, so that it's easy to get what went wrong

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
