### PR TITLE
[CI] Triton code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,4 @@ omit =
     tests/*
     setup.py
     xformers/benchmarks/*
+    xformers/triton/k_*

--- a/xformers/triton/dropout.py
+++ b/xformers/triton/dropout.py
@@ -9,60 +9,9 @@
 
 import torch
 import triton
-import triton.language as tl
 from torch.cuda.amp import custom_bwd, custom_fwd
 
-
-# fmt: off
-@triton.autotune(
-    configs=[
-        triton.Config({"BLOCK_SIZE" : 256}, num_warps=1),
-        triton.Config({"BLOCK_SIZE" : 512}, num_warps=2),
-        triton.Config({"BLOCK_SIZE" : 1024}, num_warps=4),
-        triton.Config({"BLOCK_SIZE" : 2048}, num_warps=8),
-        triton.Config({"BLOCK_SIZE" : 4096}, num_warps=8),
-    ],
-    key=["N"],
-)
-@triton.jit
-def k_dropout(
-    Y, X, S,
-    stride,
-    N,
-    p,
-    **meta,
-):
-    """
-    Apply dropout on an input tensor
-    Y : Output (M, N)
-    X : Input (M, N)
-    S : Seeds (M,)
-    p : dropout probability
-    """
-    # fmt: on
-
-    # compute memory offsets of elements handled by this instance
-    BLOCK_SIZE = meta["BLOCK_SIZE"]
-    row = tl.program_id(axis=0)
-    col = tl.program_id(axis=1)
-    offsets = row * stride + col * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = col * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE) < N
-
-    # load data from x
-    x_ptrs = X + offsets
-    x = tl.load(x_ptrs, mask=mask)
-
-    # randomly prune it
-    seed = S + row
-    random = tl.rand(seed.to(tl.int32), offsets)
-    x_keep = random > p
-
-    # write-back
-    zero = 0.
-    zero = zero.to(x.dtype)
-    output = tl.where(x_keep, (x / (1 - p)).to(x.dtype), zero)
-    y_ptrs = Y + offsets
-    tl.store(y_ptrs, output, mask=mask)
+from xformers.triton.k_dropout import k_dropout
 
 
 # Helper to handle the SPMD launch grid and error cases

--- a/xformers/triton/k_dropout.py
+++ b/xformers/triton/k_dropout.py
@@ -1,0 +1,63 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# CREDITS: This comes almost as-is from the Triton dropout tutorial
+# https://raw.githubusercontent.com/openai/triton/master/python/tutorials/04-low-memory-dropout.py
+
+import triton
+import triton.language as tl
+
+
+# fmt: off
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE" : 256}, num_warps=1),
+        triton.Config({"BLOCK_SIZE" : 512}, num_warps=2),
+        triton.Config({"BLOCK_SIZE" : 1024}, num_warps=4),
+        triton.Config({"BLOCK_SIZE" : 2048}, num_warps=8),
+        triton.Config({"BLOCK_SIZE" : 4096}, num_warps=8),
+    ],
+    key=["N"],
+)
+@triton.jit
+def k_dropout(
+    Y, X, S,
+    stride,
+    N,
+    p,
+    **meta,
+):
+    """
+    Apply dropout on an input tensor
+    Y : Output (M, N)
+    X : Input (M, N)
+    S : Seeds (M,)
+    p : dropout probability
+    """
+    # fmt: on
+
+    # compute memory offsets of elements handled by this instance
+    BLOCK_SIZE = meta["BLOCK_SIZE"]
+    row = tl.program_id(axis=0)
+    col = tl.program_id(axis=1)
+    offsets = row * stride + col * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE) < N
+
+    # load data from x
+    x_ptrs = X + offsets
+    x = tl.load(x_ptrs, mask=mask)
+
+    # randomly prune it
+    seed = S + row
+    random = tl.rand(seed.to(tl.int32), offsets)
+    x_keep = random > p
+
+    # write-back
+    zero = 0.
+    zero = zero.to(x.dtype)
+    output = tl.where(x_keep, (x / (1 - p)).to(x.dtype), zero)
+    y_ptrs = Y + offsets
+    tl.store(y_ptrs, output, mask=mask)

--- a/xformers/triton/k_softmax.py
+++ b/xformers/triton/k_softmax.py
@@ -1,0 +1,178 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+import triton
+import triton.language as tl
+
+# CREDITS: This is adapted from the vanilla Triton example. See https://openai.com/blog/triton/
+# and https://triton-lang.org/getting-started/tutorials/02-fused-softmax.html
+
+
+def get_depth(*args, **_):
+    return triton.next_power_of_2(args[-1])
+
+
+# autotune: Triton will test out these configurations, and automatically pick the fastest one.
+# heuristic: add arguments to the kernel call automatically given some heuristics. These arguments are passed in "meta"
+# fmt: off
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+        triton.Config({}, num_warps=16),
+        triton.Config({}, num_warps=32),
+    ],
+    key=["K"],
+)
+@triton.heuristics(values={"depth": get_depth , "is_fp16": lambda *args, **_: args[0].dtype == torch.float16})
+@triton.jit
+def _softmax(
+    Y, X, M,
+    stride_ym, stride_yn,
+    stride_xm, stride_xn,
+    stride_mn,
+    K,
+    **meta,  # extra parameters which can be automatically filled in given some heuristics
+):
+    # fmt: om
+
+    """
+    Fused softmax kernel over a 3d tensor.
+    The softmax is applied over the last dimension, meaning that this is equivalent to torch.softmax(tensor, dim=-1)
+
+    Note, if the last dimension is large, say 128K elements, the kernel compile time can shot up to many minutes when
+    the kernel is run for the first time.
+    """
+
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+
+    # col indices
+    k = tl.arange(0, meta["depth"])
+
+    # the memory address of all the elements that we want to load can be computed as follows
+    x_ptrs = X + m * stride_xm + n * stride_xn + k
+
+    # load input data; pad out-of-bounds elements with 0
+    io_mask = k < K
+
+    # Causal - 1: skip on the loads directly
+    if meta["causal"]:
+        io_mask = io_mask & (k <= n)
+
+    x = tl.load(x_ptrs, mask=io_mask, other=float("-inf"))
+
+    # Causal - 2: enforce correctness over a couple of misloaded values
+    if meta["causal"]:
+        off = float("-inf")
+        off = off.to(x.dtype)
+        x = tl.where(k > n, off, x)
+
+    if meta["use_mask"]:
+        mask_ptrs = M + n * stride_mn + k
+        add_mask = tl.load(mask_ptrs, io_mask, other=float("-inf"))
+        x += add_mask
+
+    # compute numerically-stable softmax
+    z = x - tl.max(x, axis=0)
+
+    if meta["is_fp16"]:
+        # tl.exp() crashes on fp16 values
+        # See https://github.com/openai/triton/issues/241
+        z = z.to(tl.float32)
+
+    num = tl.exp(z)
+    denom = tl.sum(num, axis=0)
+
+    if meta["log"]:
+        y = z - tl.log(denom)
+    else:
+        y = num / denom
+
+    # write back to Y.
+    # we only write once, hence the "fused" softmax naming
+    y_ptrs = Y + m * stride_ym + n * stride_yn + k
+
+    # technically we could write only the lower triangular matrix in the causal case
+    # but this is deemed to error prone
+    tl.store(y_ptrs, y, mask=k < K)
+
+
+# fmt: off
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+        triton.Config({}, num_warps=16),
+    ],
+    key=["K"],
+)
+@triton.heuristics(values={"is_fp16": lambda *args, **_: args[0].dtype == torch.float16})
+@triton.jit
+def _softmax_backward(
+    GradIn, GradOut, Out,
+    stride_bm, stride_bn,
+    stride_gm, stride_gn,
+    stride_om, stride_on,
+    K,
+    **meta,
+):
+    # fmt: on
+
+    """
+    Compute the softmax gradients.
+    ..Note: Not autotuning for now because this would lead to broken accumulated gradients
+    """
+
+    m = tl.program_id(0)
+    n = tl.program_id(1)
+
+    # col indices
+    k = tl.arange(0, meta["depth"])
+
+    # the memory address of all the elements that we want to load can be computed as follows
+    grad_out_ptrs = GradOut + m * stride_gm + n * stride_gn + k
+    out_ptrs = Out + m * stride_om + n * stride_on + k
+
+    # load input data; pad out-of-bounds elements with 0
+    io_mask = k < K
+
+    # Causal - 1: skip on the loads directly
+    if meta["causal"]:
+        io_mask = io_mask & (k <= n)
+
+    g = tl.load(grad_out_ptrs, mask=io_mask, other=float(0))
+    o = tl.load(out_ptrs, mask=io_mask, other=float(0))
+
+    # Causal - 2: enforce correctness over a couple of misloaded values
+    if meta["causal"]:
+        zero = float(0)
+        zero = zero.to(g.dtype)
+        g = tl.where(k > n, zero, g)
+        o = tl.where(k > n, zero, o)
+
+    if meta["log"]:
+        s = tl.sum(g, 0)
+        if meta["is_fp16"]:
+            o = o.to(tl.float32)
+        grad_in = g - tl.exp(o) * s
+    else:
+        # Step 1: Compute the intermediate sum used for the gradient
+        s = tl.sum(g * o, 0)
+
+        # Step 2: Compute the gradients
+        grad_in = o * (g - s)
+
+    # write back to the input gradients
+    # technically we could write only the lower triangular matrix in the causal case
+    # but this is deemed to error prone
+    grad_in_ptrs = GradIn + m * stride_bm + n * stride_bn + k
+    tl.store(grad_in_ptrs, grad_in, mask=k < K)

--- a/xformers/triton/softmax.py
+++ b/xformers/triton/softmax.py
@@ -10,8 +10,9 @@ from typing import Optional
 
 import torch
 import triton
-import triton.language as tl
 from torch.cuda.amp import custom_bwd, custom_fwd
+
+from xformers.triton.k_softmax import _softmax, _softmax_backward
 
 # CREDITS: This is adapted from the vanilla Triton example. See https://openai.com/blog/triton/
 # and https://triton-lang.org/getting-started/tutorials/02-fused-softmax.html
@@ -25,172 +26,6 @@ _triton_softmax_fp16_enabled = False  # NOTE: PyTorch keeps softmax as fp32
 class MaskType(str, Enum):
     ADD = "add"
     MUL = "mul"
-
-
-def get_depth(*args, **_):
-    return triton.next_power_of_2(args[-1])
-
-
-# autotune: Triton will test out these configurations, and automatically pick the fastest one.
-# heuristic: add arguments to the kernel call automatically given some heuristics. These arguments are passed in "meta"
-# fmt: off
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=1),
-        triton.Config({}, num_warps=2),
-        triton.Config({}, num_warps=4),
-        triton.Config({}, num_warps=8),
-        triton.Config({}, num_warps=16),
-        triton.Config({}, num_warps=32),
-    ],
-    key=["K"],
-)
-@triton.heuristics(values={"depth": get_depth , "is_fp16": lambda *args, **_: args[0].dtype == torch.float16})
-@triton.jit
-def _softmax(
-    Y, X, M,
-    stride_ym, stride_yn,
-    stride_xm, stride_xn,
-    stride_mn,
-    K,
-    **meta,  # extra parameters which can be automatically filled in given some heuristics
-):
-    # fmt: om
-
-    """
-    Fused softmax kernel over a 3d tensor.
-    The softmax is applied over the last dimension, meaning that this is equivalent to torch.softmax(tensor, dim=-1)
-
-    Note, if the last dimension is large, say 128K elements, the kernel compile time can shot up to many minutes when
-    the kernel is run for the first time.
-    """
-
-    m = tl.program_id(0)
-    n = tl.program_id(1)
-
-    # col indices
-    k = tl.arange(0, meta["depth"])
-
-    # the memory address of all the elements that we want to load can be computed as follows
-    x_ptrs = X + m * stride_xm + n * stride_xn + k
-
-    # load input data; pad out-of-bounds elements with 0
-    io_mask = k < K
-
-    # Causal - 1: skip on the loads directly
-    if meta["causal"]:
-        io_mask = io_mask & (k <= n)
-
-    x = tl.load(x_ptrs, mask=io_mask, other=float("-inf"))
-
-    # Causal - 2: enforce correctness over a couple of misloaded values
-    if meta["causal"]:
-        off = float("-inf")
-        off = off.to(x.dtype)
-        x = tl.where(k > n, off, x)
-
-    if meta["use_mask"]:
-        mask_ptrs = M + n * stride_mn + k
-        add_mask = tl.load(mask_ptrs, io_mask, other=float("-inf"))
-        x += add_mask
-
-    # compute numerically-stable softmax
-    z = x - tl.max(x, axis=0)
-
-    if meta["is_fp16"]:
-        # tl.exp() crashes on fp16 values
-        # See https://github.com/openai/triton/issues/241
-        z = z.to(tl.float32)
-
-    num = tl.exp(z)
-    denom = tl.sum(num, axis=0)
-
-    if meta["log"]:
-        y = z - tl.log(denom)
-    else:
-        y = num / denom
-
-    # write back to Y.
-    # we only write once, hence the "fused" softmax naming
-    y_ptrs = Y + m * stride_ym + n * stride_yn + k
-
-    # technically we could write only the lower triangular matrix in the causal case
-    # but this is deemed to error prone
-    tl.store(y_ptrs, y, mask=k < K)
-
-
-# fmt: off
-@triton.autotune(
-    configs=[
-        triton.Config({}, num_warps=1),
-        triton.Config({}, num_warps=2),
-        triton.Config({}, num_warps=4),
-        triton.Config({}, num_warps=8),
-        triton.Config({}, num_warps=16),
-    ],
-    key=["K"],
-)
-@triton.heuristics(values={"is_fp16": lambda *args, **_: args[0].dtype == torch.float16})
-@triton.jit
-def _softmax_backward(
-    GradIn, GradOut, Out,
-    stride_bm, stride_bn,
-    stride_gm, stride_gn,
-    stride_om, stride_on,
-    K,
-    **meta,
-):
-    # fmt: on
-
-    """
-    Compute the softmax gradients.
-    ..Note: Not autotuning for now because this would lead to broken accumulated gradients
-    """
-
-    m = tl.program_id(0)
-    n = tl.program_id(1)
-
-    # col indices
-    k = tl.arange(0, meta["depth"])
-
-    # the memory address of all the elements that we want to load can be computed as follows
-    grad_out_ptrs = GradOut + m * stride_gm + n * stride_gn + k
-    out_ptrs = Out + m * stride_om + n * stride_on + k
-
-    # load input data; pad out-of-bounds elements with 0
-    io_mask = k < K
-
-    # Causal - 1: skip on the loads directly
-    if meta["causal"]:
-        io_mask = io_mask & (k <= n)
-
-    g = tl.load(grad_out_ptrs, mask=io_mask, other=float(0))
-    o = tl.load(out_ptrs, mask=io_mask, other=float(0))
-
-    # Causal - 2: enforce correctness over a couple of misloaded values
-    if meta["causal"]:
-        zero = float(0)
-        zero = zero.to(g.dtype)
-        g = tl.where(k > n, zero, g)
-        o = tl.where(k > n, zero, o)
-
-    if meta["log"]:
-        s = tl.sum(g, 0)
-        if meta["is_fp16"]:
-            o = o.to(tl.float32)
-        grad_in = g - tl.exp(o) * s
-    else:
-        # Step 1: Compute the intermediate sum used for the gradient
-        s = tl.sum(g * o, 0)
-
-        # Step 2: Compute the gradients
-        grad_in = o * (g - s)
-
-    # write back to the input gradients
-    # technically we could write only the lower triangular matrix in the causal case
-    # but this is deemed to error prone
-    grad_in_ptrs = GradIn + m * stride_bm + n * stride_bn + k
-    tl.store(grad_in_ptrs, grad_in, mask=k < K)
 
 
 # Helper to handle the SPMD launch grid and error cases
@@ -210,7 +45,9 @@ class _softmax_triton(torch.autograd.Function):
             x_ = x_.contiguous()
 
         y = torch.empty_like(x_)
-        assert y.stride(2) == 1 and x_.stride(2) == 1, f"{x.shape} - {x_.shape} - {x_.stride()}"
+        assert (
+            y.stride(2) == 1 and x_.stride(2) == 1
+        ), f"{x.shape} - {x_.shape} - {x_.stride()}"
 
         # SPMD launch grid
         grid_2d = (
@@ -229,14 +66,18 @@ class _softmax_triton(torch.autograd.Function):
             assert mask.dtype == x.dtype, "An additive mask is requested"
 
         _softmax[grid_2d](
-            y, x_, mask,
-            y.stride(0), y.stride(1),
-            x_.stride(0), x_.stride(1),
+            y,
+            x_,
+            mask,
+            y.stride(0),
+            y.stride(1),
+            x_.stride(0),
+            x_.stride(1),
             mask.stride(0),
             x_.shape[2],
             log=log_outputs,
             use_mask=use_mask,
-            causal=causal
+            causal=causal,
         )
 
         ctx.save_for_backward(y)
@@ -259,7 +100,9 @@ class _softmax_triton(torch.autograd.Function):
         )
 
         depth = triton.next_power_of_2(grad_out_.shape[2])
-        grad_in = torch.empty_like(out)  # torch.zeros is measurably slower, we'll zero out in the kernel
+        grad_in = torch.empty_like(
+            out
+        )  # torch.zeros is measurably slower, we'll zero out in the kernel
 
         # Make sure that the tensor are contiguous
         grad_in, grad_out, out = map(lambda x: x.contiguous(), [grad_in, grad_out, out])
@@ -279,7 +122,9 @@ class _softmax_triton(torch.autograd.Function):
         return grad_in.reshape_as(grad_out), None, None, None
 
 
-def softmax(x: torch.Tensor, mask: Optional[torch.Tensor] = None, causal: bool = False) -> torch.Tensor:
+def softmax(
+    x: torch.Tensor, mask: Optional[torch.Tensor] = None, causal: bool = False
+) -> torch.Tensor:
     r"""Applies the Softmax function to an 3-dimensional input Tensor
     rescaling them so that the elements of the n-dimensional output Tensor
     lie in the range [0,1] and sum to 1.
@@ -304,7 +149,9 @@ def softmax(x: torch.Tensor, mask: Optional[torch.Tensor] = None, causal: bool =
     return _softmax_dispatch(x, log=False, mask=mask, causal=causal)
 
 
-def log_softmax(x: torch.Tensor, mask: Optional[torch.Tensor] = None, causal: bool = False) -> torch.Tensor:
+def log_softmax(
+    x: torch.Tensor, mask: Optional[torch.Tensor] = None, causal: bool = False
+) -> torch.Tensor:
     r"""Applies the :math:`\log(\text{Softmax}(x))` function to an 3-dimensional
     input Tensor. The LogSoftmax formulation can be simplified as:
 
@@ -321,7 +168,9 @@ def log_softmax(x: torch.Tensor, mask: Optional[torch.Tensor] = None, causal: bo
     return _softmax_dispatch(x, log=True, mask=mask, causal=causal)
 
 
-def _softmax_dispatch(x: torch.Tensor, log: bool, mask: Optional[torch.Tensor], causal: bool = False) -> torch.Tensor:
+def _softmax_dispatch(
+    x: torch.Tensor, log: bool, mask: Optional[torch.Tensor], causal: bool = False
+) -> torch.Tensor:
     # Triton is used if
     # - CUDA
     # - there's enough data to make it faster than pytorch. This could change over time, Triton is improving
@@ -331,11 +180,7 @@ def _softmax_dispatch(x: torch.Tensor, log: bool, mask: Optional[torch.Tensor], 
     global _triton_registered_warnings
 
     try:
-        if (
-            torch.cuda.is_available()
-            and x.is_cuda
-            and not _triton_registered_overflow
-        ):
+        if torch.cuda.is_available() and x.is_cuda and not _triton_registered_overflow:
             return _softmax_triton.apply(x, mask, log, causal)
     except triton.code_gen.OutOfResources:
         # Catch cases where the current GPU does not have enough registers to hold a full tensor line


### PR DESCRIPTION
## What does this PR do?
The code coverage is not properly handled over all the @jit parts of the code, these are mapped to cuda binary and this is not tracked. Splitting all the triton calls into to, one with a `k_` prepend to host the triton code (not part of the coverage), and the other one being pure python

## Before submitting

- [~] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
