### PR TITLE
[CI] skip gh builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,5 +229,14 @@ workflows:
   version: 2
   build:
     jobs:
-      - cpu_tests_py38
-      - gpu_tests_190
+      - cpu_tests_py38:
+        filters:
+          branches:
+            ignore:
+              - gh-pages
+
+      - gpu_tests_190:
+        filters:
+          branches:
+            ignore:
+              - gh-pages


### PR DESCRIPTION
## What does this PR do?
Skips builds (which were [broken](https://app.circleci.com/pipelines/github/facebookresearch/xformers?branch=gh-pages)) to the gh-pages branch, which is just there to host the documentation
cc @dianaml0 @jieru-hu @fmassa , landing directly if the CI agrees to save you some time

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
