### PR TITLE
[nit][dropbox] Add a no-op codepath for p=0

### DIFF
--- a/tests/test_triton_dropout.py
+++ b/tests/test_triton_dropout.py
@@ -55,7 +55,7 @@ def test_dropout(shape, amp):
 
         # Check that 0 means no dropout
         y = dropout(x, p=0)
-        assert torch.allclose(x.to(y.dtype), y, rtol=tol)
+        assert torch.allclose(x.to(y.dtype), y, rtol=tol), f"{x[x>y]}"
 
         # Check that 1 means dropout for sure
         y = dropout(x, p=1)

--- a/xformers/triton/dropout.py
+++ b/xformers/triton/dropout.py
@@ -69,4 +69,7 @@ class _dropout(torch.autograd.Function):
 
 
 def dropout(x: torch.Tensor, p: float):
-    return _dropout.apply(x, p)
+    if p > 0.0:
+        return _dropout.apply(x, p)
+
+    return x

--- a/xformers/triton/k_dropout.py
+++ b/xformers/triton/k_dropout.py
@@ -24,7 +24,7 @@ import triton.language as tl
 )
 @triton.jit
 def k_dropout(
-    Y, X, S,
+    Y, X, SEEDS,
     stride,
     N,
     p,
@@ -51,7 +51,7 @@ def k_dropout(
     x = tl.load(x_ptrs, mask=mask)
 
     # randomly prune it
-    seed = S + row
+    seed = SEEDS + row
     random = tl.rand(seed.to(tl.int32), offsets)
     x_keep = random > p
 


### PR DESCRIPTION
## What does this PR do?
Fixes #56, could be that the unit test was a little strict (check that the tensor is the same when the dropout probability is 0. An example of a faulty run is [there](https://app.circleci.com/pipelines/github/facebookresearch/xformers/212/workflows/8988c71c-84f5-4bd0-bd59-ac7d293c2370/jobs/398/tests#failed-test-1), not obvious where the difference is, I've added a printout for hypothetical future issues

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
