### PR TITLE
Use Hydra to build xformer model/block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ my_runs.md
 
 # Pyre cache.
 .pyre/
+
+# Hydra defaults output dir
+multirun
+outputs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Example requirement, can be anything that pip knows
 # install with `pip install -r requirements.txt`, and make sure that CI does the same
 torch >= 1.8.1
+hydra-core >= 1.1.1

--- a/xformers/components/attention/__init__.py
+++ b/xformers/components/attention/__init__.py
@@ -73,7 +73,11 @@ def build_attention(config: Union[Dict[str, Any], AttentionConfig]):
 
     To instantiate an attention from a configuration file, see :func:`build_attention`."""
 register_attention: Callable[[str, Any], Callable[[Any], Any]] = get_registry_decorator(
-    ATTENTION_REGISTRY, ATTENTION_CLASS_NAMES, Attention, AttentionConfig
+    ATTENTION_REGISTRY,
+    ATTENTION_CLASS_NAMES,
+    Attention,
+    AttentionConfig,
+    "xformers/attention",
 )
 
 

--- a/xformers/components/attention/global_tokens.py
+++ b/xformers/components/attention/global_tokens.py
@@ -5,7 +5,7 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
@@ -26,7 +26,9 @@ from xformers.components.attention.core import scaled_dot_product_attention
 
 @dataclass
 class GlobalAttentionConfig(AttentionConfig):
-    attention_query_mask: torch.Tensor  # Mark the queries which have global attention
+    # Mark the queries which have global attention
+    # should be torch.Tensor, but OmegaConf does not support this typing
+    attention_query_mask: Any
     causal: Optional[bool]
     force_sparsity: Optional[bool]
 

--- a/xformers/components/attention/nystrom.py
+++ b/xformers/components/attention/nystrom.py
@@ -5,7 +5,7 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 import torch
 import torch.nn as nn
@@ -43,11 +43,13 @@ class NystromSelfAttentionConfig(AttentionConfig):
 
     num_heads: int
     num_landmarks: Optional[int]
-    landmark_pooling: Optional[nn.Module]
+    # should be nn.Module, OmegaConf does not support the typing
+    landmark_pooling: Optional[Any]
     causal: Optional[bool]
     pinverse_original_init: Optional[bool]
     inv_iterations: Optional[int]
-    v_skip_connection: Optional[nn.Module]
+    # should be nn.Module, OmegaConf does not support the typing
+    v_skip_connection: Optional[Any]
     conv_kernel_size: Optional[int]
     use_razavi_pinverse: Optional[bool]
 

--- a/xformers/components/feedforward/__init__.py
+++ b/xformers/components/feedforward/__init__.py
@@ -62,7 +62,11 @@ def build_feedforward(config: Union[Dict[str, Any], FeedforwardConfig]):
 register_feedforward: Callable[
     [str, Any], Callable[[Any], Any]
 ] = get_registry_decorator(
-    FEEDFORWARD_REGISTRY, FEEDFORWARD_CLASS_NAMES, Feedforward, FeedforwardConfig
+    FEEDFORWARD_REGISTRY,
+    FEEDFORWARD_CLASS_NAMES,
+    Feedforward,
+    FeedforwardConfig,
+    "xformers/feedforward",
 )
 
 try:

--- a/xformers/components/positional_embedding/__init__.py
+++ b/xformers/components/positional_embedding/__init__.py
@@ -66,6 +66,7 @@ register_positional_embedding: Callable[
     POSITION_EMBEDDING_CLASS_NAMES,
     PositionEmbedding,
     PositionEmbeddingConfig,
+    "xformers/positional_embedding",
 )
 
 

--- a/xformers/examples/factory/block/encoder.py
+++ b/xformers/examples/factory/block/encoder.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict, List
+import hydra
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from xformers.factory.block_factory import xFormerEncoderBlock, xFormerEncoderConfig
+
+BATCH = 8
+
+
+@hydra.main(config_path=".", config_name="encoder_config")
+def my_app(cfg: DictConfig) -> None:
+    # resolve to standard python dict
+    config = OmegaConf.to_container(cfg.encoder, resolve=True)
+    encoder_config: xFormerEncoderConfig = xFormerEncoderConfig(**config)  # type: ignore
+    encoder = xFormerEncoderBlock(encoder_config)
+
+    #  Test out with dummy inputs
+    x = (torch.rand((BATCH, cfg.seq_len)) * cfg.vocab_size).abs().to(torch.int)
+    y = encoder(x, x, x)
+    print(y)
+
+
+if __name__ == "__main__":
+    my_app()

--- a/xformers/examples/factory/block/encoder_config.yaml
+++ b/xformers/examples/factory/block/encoder_config.yaml
@@ -1,0 +1,26 @@
+seq_len: 1024
+dim_model: 384
+vocab_size: 64
+
+encoder:
+  dim_model: ${dim_model}
+  layer_norm_style: pre  # Optional pre/post
+  position_encoding_config:
+    name: vocab  # whatever position encodinhg makes sense
+    seq_len: ${seq_len}
+    vocab_size: ${vocab_size}
+
+  multi_head_config:
+    num_heads: 4
+    residual_dropout: 0
+    attention:
+      name: linformer  # whatever attention mechanism
+      dropout: 0
+      seq_len: ${seq_len}
+
+  feedforward_config:
+    name: MLP
+    dropout: 0
+    activation: relu
+    hidden_layer_multiplier: 4
+    

--- a/xformers/examples/factory/model/conf/config.yaml
+++ b/xformers/examples/factory/model/conf/config.yaml
@@ -1,0 +1,17 @@
+defaults:
+  # Use encoder/decoder schema to validate corresponding configs
+  - /xformers/encoder_schema@encoder.block_config
+  - /xformers/decoder_schema@decoder.block_config
+  # extend base_config from ConfigStore for primary config validation
+  - base_config
+  # encoder stack config, put them under encoder package
+  - stack@encoder: encoder_stack
+  # decoder stack config, put them under decoder package
+  - stack@decoder: decoder_stack
+  # lastly compose the configs outside of defaults list.
+  - _self_
+
+dim_model: 384
+vocab_size: 64
+seq_len: 1024
+

--- a/xformers/examples/factory/model/conf/stack/base_stack.yaml
+++ b/xformers/examples/factory/model/conf/stack/base_stack.yaml
@@ -1,0 +1,26 @@
+defaults:
+  # Move schemas provided by xformer to corresponding config package for schema validation.
+  - /xformers/positional_embedding/vocab_schema@block_config.position_encoding_config
+  - /xformers/feedforward/MLP_schema@block_config.feedforward_config
+  - /xformers/stack_schema@_here_
+
+reversible: False
+num_layers: 3
+block_config:
+  block_type: ???
+  dim_model: ${dim_model}
+  layer_norm_style: Pre  # Optional pre/post
+  use_triton: True
+  seq_len: ${seq_len}
+  position_encoding_config:
+    name: vocab  # whatever position encodinhg makes sense
+    seq_len: ${seq_len}
+    vocab_size: ${vocab_size}
+    dropout: 0
+    dim_model: ${dim_model}
+  feedforward_config:
+    dim_model: ${dim_model}
+    name: MLP
+    dropout: 0
+    activation: ReLU
+    hidden_layer_multiplier: 4

--- a/xformers/examples/factory/model/conf/stack/decoder_stack.yaml
+++ b/xformers/examples/factory/model/conf/stack/decoder_stack.yaml
@@ -1,0 +1,25 @@
+defaults:
+  # Move schema form xformers to black_config package for schema validation
+  - /xformers/decoder_schema@block_config
+  # extend the configs and typing from base_stack.yaml
+  - base_stack
+
+block_config:
+  block_type: Decoder
+  multi_head_config_masked:
+    num_heads: 4
+    residual_dropout: 0
+    attention:
+      name: nystrom  # whatever attention mechanism
+      dropout: 0
+      causal: True
+      seq_len: ${seq_len}
+
+  multi_head_config_cross:
+    num_heads: 4
+    residual_dropout: 0
+    attention:
+      name: favor  # whatever attention mechanism
+      dropout: 0
+      causal: True
+      seq_len: ${seq_len}

--- a/xformers/examples/factory/model/conf/stack/encoder_stack.yaml
+++ b/xformers/examples/factory/model/conf/stack/encoder_stack.yaml
@@ -1,0 +1,15 @@
+defaults:
+  # extend configs/schema from base_stack.yaml
+  - base_stack
+
+block_config:
+  block_type: Encoder
+  multi_head_config:
+    num_heads: 4
+    residual_dropout: 0
+    dim_model: ${dim_model}
+    attention:
+      name: linformer  # whatever attention mechanism
+      dropout: 0
+      causal: False
+      seq_len: ${seq_len}

--- a/xformers/examples/factory/model/my_model.py
+++ b/xformers/examples/factory/model/my_model.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+
+import hydra
+import torch
+from hydra.core.config_store import ConfigStore
+from omegaconf import OmegaConf
+
+from xformers.factory.model_factory import xFormer, xFormerConfig, xFormerStackConfig
+
+BATCH = 8
+SEQ = 1024
+EMB = 384
+VOCAB = 64
+
+
+@dataclass
+class Config:
+    encoder: xFormerStackConfig
+    decoder: xFormerStackConfig
+    dim_model: int
+    vocab_size: int
+    seq_len: int
+
+
+cs = ConfigStore.instance()
+
+# base_config will validate the schema/typing in primary config - conf/config.yaml
+cs.store(name="base_config", node=Config)
+
+
+@hydra.main(config_path="conf", config_name="config")
+def my_app(cfg: Config) -> None:
+    encoder_cfg = OmegaConf.to_container(cfg.encoder, resolve=True)
+    decoder_cfg = OmegaConf.to_container(cfg.decoder, resolve=True)
+    config = xFormerConfig([encoder_cfg, decoder_cfg])  # type: ignore
+    model = xFormer.from_config(config)
+    print(f"build model with encoder attention {type(model.encoders[0].mha.attention)}")
+    #  Test out with dummy inputs
+    x = (torch.rand((BATCH, SEQ)) * VOCAB).abs().to(torch.int)
+    y = model(src=x, tgt=x)
+    print(type(y))
+
+
+if __name__ == "__main__":
+    my_app()

--- a/xformers/factory/__init__.py
+++ b/xformers/factory/__init__.py
@@ -1,10 +1,20 @@
+# register factory configs
+from hydra.core.config_store import ConfigStore
+
 from xformers.components import MultiHeadDispatchConfig  # noqa
 from xformers.components.attention import AttentionConfig  # noqa
 from xformers.components.feedforward import FeedforwardConfig  # noqa
 from xformers.components.positional_embedding import PositionEmbeddingConfig  # noqa
 
-from .block_factory import xFormerDecoderBlock  # noqa
-from .block_factory import xFormerDecoderConfig  # noqa
-from .block_factory import xFormerEncoderBlock  # noqa
+from .block_factory import xFormerDecoderConfig  # noqa; noqa
+from .block_factory import xFormerEncoderBlock, xFormerDecoderBlock  # noqa
 from .block_factory import xFormerEncoderConfig  # noqa
-from .model_factory import xFormer, xFormerConfig  # noqa
+from .block_factory import xFormerBlockConfig
+from .model_factory import xFormer, xFormerConfig, xFormerStackConfig  # noqa
+
+cs = ConfigStore.instance()
+cs.store(name="decoder_schema", group="xformers", node=xFormerDecoderConfig)
+cs.store(name="encoder_schema", group="xformers", node=xFormerEncoderConfig)
+cs.store(name="block_schema", group="xformers", node=xFormerBlockConfig)
+cs.store(name="xformers_schema", group="xformers", node=xFormerConfig)
+cs.store(name="stack_schema", group="xformers", node=xFormerStackConfig)

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -98,8 +98,8 @@ class xFormerBlockConfig:
     position_encoding_config: Optional[PositionEmbeddingConfig]
     block_type: BlockType
     layer_norm_style: LayerNormStyle
-    layer_position: LayerPosition
     use_triton: bool
+    seq_len: int
 
     def __init__(
         self,

--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -5,13 +5,14 @@
 
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import torch
 
 from xformers.components import reversible as rv
 from xformers.factory.block_factory import (
     BlockType,
+    xFormerBlockConfig,
     xFormerDecoderBlock,
     xFormerDecoderConfig,
     xFormerEncoderBlock,
@@ -25,7 +26,7 @@ class xFormerStackConfig:
     A stack is defined by the definition of a given block, and an optional repetition factor
     """
 
-    block_config: Union[xFormerEncoderConfig, xFormerDecoderConfig]
+    block_config: xFormerBlockConfig
     num_layers: int
     reversible: bool
 
@@ -57,9 +58,7 @@ class xFormerConfig:
 
 
 class xFormer(torch.nn.Module):
-    def __init__(
-        self, stack_configs: List[Union[xFormerStackConfig, xFormerStackConfig]]
-    ):
+    def __init__(self, stack_configs: List[xFormerStackConfig]):
         """
         Given a serialized configuration, generate the corresponding model.
         This is only a helper and can easily be bypassed

--- a/xformers/utils.py
+++ b/xformers/utils.py
@@ -13,7 +13,10 @@ from collections import namedtuple
 from dataclasses import fields
 from typing import Any, Callable, Dict, Generator, List
 
+from hydra.core.config_store import ConfigStore
+
 Item = namedtuple("Item", ["constructor", "config"])
+cs = ConfigStore.instance()
 
 
 # credit: snippet used in ClassyVision (and probably other places)
@@ -31,7 +34,7 @@ def import_all_modules(root: str, base_module: str) -> List[str]:
 
 
 def get_registry_decorator(
-    class_registry, name_registry, reference_class, default_config
+    class_registry, name_registry, reference_class, default_config, config_group
 ) -> Callable[[str, Any], Callable[[Any], Any]]:
     def register_item(name: str, config: Any = default_config):
         """Registers a subclass.
@@ -57,7 +60,11 @@ def get_registry_decorator(
                 )
 
             class_registry[name] = Item(constructor=cls, config=config)
+
             name_registry.add(cls.__name__)
+
+            cs.store(name=f"{name}_schema", node=config, group=config_group)
+
             return cls
 
         return register_cls


### PR DESCRIPTION
TODO
- [ ] tests
- [ ] doc updates

Recreated the two examples from the [tutorial](https://facebookresearch.github.io/xformers/tutorials/pytorch_encoder.html) for building a block and a model.
Goal here is allow users to use Hydra to build xformers components with option to opt in type checking

xFormers already has dataclasses representing the config schema, so it's quite easy to add those to Hydra for schema validation. for now, I put all the dataclass config (aka the schema) under `xformers` config [package](https://hydra.cc/docs/advanced/overriding_packages), so anyone depends on xformers would have access to those schemas. 

- the block example is very minimal, added node [interpolation](https://omegaconf.readthedocs.io/en/latest/usage.html#variable-interpolation) for configuring some of the repeated config (`dim_model`), no typing validation
- the model example is more sophisticated, it provide typing validation with the schema dataclasses provided by xformer

### running the my_model.py example
#### typing validation
try to override activation with a non-existent option
```
$ python xformers/examples/factory/model/my_model.py encoder.block_config.feedforward_config.activation=typo
Error merging override encoder.block_config.feedforward_config.activation=typo
Invalid value 'typo', expected one of [SquaredReLU, GeLU, LeakyReLU, ReLU]
    full_key: encoder.block_config.feedforward_config.activation
    reference_type=FeedforwardConfig
    object_type=MlpConfig

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

#### view final composed
using Hydra's commandline flag, we see interpolations of dim_model, vocab_size, seq_len resolved 


<details><summary>CLICK ME</summary>
<p>


```
(xformers-hydra) 04:41:59 Fri Oct 29 ~/workspace/fair-xformers/xformers $ python xformers/examples/factory/model/my_model.py --cfg job --resolve
WARNING:root:Unsupported device, Triton code generation may fail
WARNING:root:Blocksparse is not available: the current GPU does not expose Tensor cores
encoder:
  block_config:
    dim_model: 384
    feedforward_config:
      name: MLP
      dim_model: 384
      dropout: 0.0
      activation: ReLU
      hidden_layer_multiplier: 4
    position_encoding_config:
      name: vocab
      dim_model: 384
      seq_len: 1024
      vocab_size: 64
      dropout: 0.0
    block_type: Encoder
    layer_norm_style: Pre
    use_triton: true
    seq_len: 1024
    multi_head_config:
      num_heads: 4
      residual_dropout: 0
      dim_model: 384
      attention:
        name: linformer
        dropout: 0
        causal: false
        seq_len: 1024
  num_layers: 3
  reversible: false
decoder:
  block_config:
    dim_model: 384
    feedforward_config:
      name: MLP
      dim_model: 384
      dropout: 0.0
      activation: ReLU
      hidden_layer_multiplier: 4
    position_encoding_config:
      name: vocab
      dim_model: 384
      seq_len: 1024
      vocab_size: 64
      dropout: 0.0
    block_type: Decoder
    layer_norm_style: Pre
    use_triton: true
    seq_len: 1024
    multi_head_config_masked:
      num_heads: 4
      residual_dropout: 0
      attention:
        name: nystrom
        dropout: 0
        causal: true
        seq_len: 1024
    multi_head_config_cross:
      num_heads: 4
      residual_dropout: 0
      attention:
        name: favor
        dropout: 0
        causal: true
        seq_len: 1024
  num_layers: 3
  reversible: false
dim_model: 384
vocab_size: 64
seq_len: 1024
```


</p>
</details>

### sweeping
```
python xformers/examples/factory/model/my_model.py --multirun \
encoder.block_config.multi_head_config.attention.name=linformer,favor,nystrom
```

output
```
[2021-10-29 16:47:57,551][HYDRA] Launching 3 jobs locally
[2021-10-29 16:47:57,551][HYDRA]        #0 : encoder.block_config.multi_head_config.attention.name=linformer
build model with encoder attention <class 'xformers.components.attention.linformer.LinformerAttention'>
[W LegacyTypeDispatch.h:74] Warning: AutoNonVariableTypeMode is deprecated and will be removed in 1.10 release. For kernel implementations please use AutoDispatchBelowADInplaceOrView instead, If you are looking for a user facing API to enable running your inference-only workload, please use c10::InferenceMode. Using AutoDispatchBelowADInplaceOrView in user code is under risk of producing silent wrong result in some edge cases. See Note [AutoDispatchBelowAutograd] for more details. (function operator())
<class 'torch.Tensor'>
[2021-10-29 16:47:58,062][HYDRA]        #1 : encoder.block_config.multi_head_config.attention.name=favor
build model with encoder attention <class 'xformers.components.attention.favor.FavorAttention'>
<class 'torch.Tensor'>
[2021-10-29 16:47:58,508][HYDRA]        #2 : encoder.block_config.multi_head_config.attention.name=nystrom
build model with encoder attention <class 'xformers.components.attention.nystrom.NystromAttention'>
<class 'torch.Tensor'>
```

