### PR TITLE
[feat] Add shape types to sine.py.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,8 +7,8 @@ black == 20.8b1
 flake8 == 3.8.4
 isort == 5.7.0
 mypy == 0.812
-pyre-check == 0.9.6
-pyre-extensions == 0.0.22
+pyre-check == 0.9.8
+pyre-extensions == 0.0.23
 
 # Tools for unit tests & coverage.
 pytest == 5.4.1

--- a/stubs/torch/__init__.pyi
+++ b/stubs/torch/__init__.pyi
@@ -94,7 +94,6 @@ class device:
 _just_device = device
 _device = Union[device, str]
 
-# pyre-fixme[39]: Tuple is not a valid parent class.
 class Size(Tuple[builtins.int, ...]):
     @overload
     def __getitem__(self: Size, key: builtins.int) -> builtins.int: ...
@@ -213,6 +212,7 @@ class Tensor(Generic[DType, Unpack[Ts]]):
         self: Tensor[DType, Unpack[Rs]], *sizes: Unpack[Rs2]
     ) -> Tensor[DType, Unpack[Broadcast[Tuple[Unpack[Rs]], Tuple[Unpack[Rs2]]]]]: ...
     def detach(self: T) -> T: ...
+    # pyre-ignore[24]: Pyre is unable to find the custom stubs for numpy.
     def numpy(self) -> ndarray[DType, Unpack[Ts]]: ...
     shape: Tuple[Unpack[Ts]]
     ndim: builtins.int

--- a/stubs/torch_stub_tests.py
+++ b/stubs/torch_stub_tests.py
@@ -700,11 +700,8 @@ def test_argsort() -> None:
 def test_functional_pad() -> None:
     x: torch.Tensor[torch.float32, L[2], L[3], L[4]]
 
-    # pyre-ignore[9]: Fixed in the latest version of Pyre.
     good: torch.Tensor[torch.float32, L[2], L[3], L[5]] = nn.functional.pad(x, (1, 0))
-    # pyre-fixme[9]: bad has type `Tensor[torch.float32, typing_extensions.Literal[99...
     bad: torch.Tensor[torch.float32, L[99], L[3], L[5]] = nn.functional.pad(x, (1, 0))
-    # pyre-ignore[9]: Fixed in the latest version of Pyre.
     good2: torch.Tensor[torch.float32, L[2], L[10], L[7]] = nn.functional.pad(
         x, (1, 2, 3, 4), "constant", value=0.0
     )
@@ -1187,7 +1184,6 @@ def test_repeat_interleave() -> None:
 
     # Too dynamic because the output shape depends on the contents of repeats.
 
-    # pyre-ignore[9]: Fixed in the latest version of Pyre.
     y5: torch.Tensor[torch.float32, L[0], L[3], L[4]] = torch.repeat_interleave(
         x, repeats, dim=0
     )

--- a/xformers/components/positional_embedding/__init__.py
+++ b/xformers/components/positional_embedding/__init__.py
@@ -70,7 +70,7 @@ register_positional_embedding: Callable[
 
 
 from .rotary import RotaryEmbedding  # noqa
-from .sine import SinePositionalEmbedding  # noqa
+from .sine import SinePositionalEmbedding  # type: ignore  # noqa
 from .vocab import VocabEmbedding  # noqa
 
 __all__ = [

--- a/xformers/components/positional_embedding/sine.py
+++ b/xformers/components/positional_embedding/sine.py
@@ -4,9 +4,17 @@
 # LICENSE file in the root directory of this source tree.
 
 
+# Silence Mypy errors in this file.
+# type: ignore
+
+from __future__ import annotations
+
 import math
+from typing import TypeVar
 
 import torch
+from pyre_extensions import Generic
+from typing_extensions import Literal as L
 
 from xformers.components.positional_embedding import (
     PositionEmbedding,
@@ -14,22 +22,27 @@ from xformers.components.positional_embedding import (
     register_positional_embedding,
 )
 
+N = TypeVar("N", bound=int)
+DimModel = TypeVar("DimModel", bound=int)
+
 
 @register_positional_embedding("sine", PositionEmbeddingConfig)
-class SinePositionalEmbedding(PositionEmbedding):
-    def __init__(self, dim_model: int, *args, **kwargs):
+class SinePositionalEmbedding(PositionEmbedding, Generic[DimModel]):
+    def __init__(self, dim_model: DimModel, *args, **kwargs):
         super().__init__()
-        self.dim_model = dim_model
+        self.dim_model: DimModel = dim_model
 
-    def forward(self, x: torch.Tensor):
+    def forward(
+        self, x: torch.Tensor[torch.float, N, N]
+    ) -> torch.Tensor[torch.float, N, N, DimModel]:
         seq_len = x.shape[1]
         pos = (
-            torch.arange(0.0, seq_len, device=x.device)
+            torch.arange(0, seq_len, device=x.device, dtype=torch.float32)
             .unsqueeze(1)
             .repeat(1, self.dim_model)
         )
         dim = (
-            torch.arange(0.0, self.dim_model, device=x.device)
+            torch.arange(0, self.dim_model, device=x.device, dtype=torch.float32)
             .unsqueeze(0)
             .repeat(seq_len, 1)
         )
@@ -38,8 +51,10 @@ class SinePositionalEmbedding(PositionEmbedding):
         pos[:, 0::2] = torch.sin(pos[:, 0::2])
         pos[:, 1::2] = torch.cos(pos[:, 1::2])
 
-        if x.ndim == 2:
-            # Handle a non-existing embedding dimension
-            x = x.unsqueeze(-1)
+        # pyre-ignore[9]: x was declared as N x N but is expected as N * N * 1.
+        # Handle a non-existing embedding dimension
+        output: torch.Tensor[torch.float32, N, N, L[1]] = (
+            x.unsqueeze(-1) if x.ndim == 2 else x
+        )
 
-        return x + pos.unsqueeze(0)
+        return output + pos.unsqueeze(0)


### PR DESCRIPTION
The main changes are:

+ Make the class generic in a variable `DimModel` and set the type of
`self.dim_model` as `DimModel`. That way, when it is initialized with
`self.dim_model`, Pyre will store the type. We have to add
`Generic[DimModel]` in this class because `self.dim_model` is defined in
this class.

+ Annotate `forward` as accepting a Tensor of shape N x N and returning
a Tensor of shape N x N x DimModel.

This is about as straightforward as it gets for shape types. There were no
major complications in this class. If even this is too cumbersome or hard to
follow, it will not get easier in other classes :) So, feedback welcome on the
understandability.

Note:

+ I added `from __future__ import annotations` so that the type
annotations are not evaluated at runtime. This is necessary because the
runtime Tensor class is not generic and cannot take arguments like
`Tensor[torch.float32, N]`, etc.

+ I changed `torch.arange(0.0, seq_len)` to `torch.arange(0, seq_len,
dtype=torch.float32)` because Pyre won't be able to calculate the
resulting Tensor shape using floats like 0.0. It is able to do so with
integers like 0. Note that I can't make it `dtype=x.dtype` because 
`x.dtype` can sometimes be int, as in the unit tests.

+ An inconvenience is that we check if x.ndim == 2 and then unsqueeze
the last dimension. However, this means that there could be two possible
shapes for x, whereas we have declared that it has exactly shape N x N.
So, I added a local variable `output` with the desired shape after
unsqueezing and suppressed the Pyre error with a comment.

I'll try to see if Pyre can allow such idioms in the future.

## What does this PR do?
Works towards #43 

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
