### PR TITLE
[bugfix] Small fix in case the sequence is smaller than the saved mask

### DIFF
--- a/xformers/components/attention/favor.py
+++ b/xformers/components/attention/favor.py
@@ -131,6 +131,7 @@ class FavorAttention(Attention):
         *args,
         **kwargs,
     ):
+
         # Project key and queries onto the feature map space
         k_prime = self.feature_map_key(k)
         q_prime = self.feature_map_query(q)


### PR DESCRIPTION
## What does this PR do?
If an attention was declared causal, then a mask is saved whose size is based on the expected max sequence length. This is then not updated at forward time, so it can happen that the mask overshoots the attention matrix

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
