### PR TITLE
[fix] Nystrom + microGPT + some additive masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ my_runs.md
 
 # Watchman config files
 .watchmanconfig
+
+# examples demo files
+examples/input.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## NEXT - TBD
 ### Fixed
+- Nystrom causal attention [#75]
 
 ### Added
 

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -273,7 +273,7 @@ if __name__ == "__main__":
     REF_BATCH = 512
     BATCH = 256  # adjust depending on the avaiable memory on your machine
     WORKERS = 8
-    EPOCHS = 2
+    EPOCHS = 1
     BLOCK = 128
     WARMUP = 20
 
@@ -298,10 +298,11 @@ if __name__ == "__main__":
     model = GPT(
         vocab_size=train_dataset.vocab_size,
         block_size=train_dataset.block_size,
-        attention="scaled_dot_product",
+        attention="nystrom",
         warmup_tokens=REF_BATCH * WARMUP,
         final_tokens=EPOCHS * len(train_dataset) * BLOCK,
     )
+    print(model)
 
     trainer = Trainer(
         gpus=1,

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -271,7 +271,7 @@ def sample(model, x, steps, temperature=1.0, sample=False, top_k=None):
 if __name__ == "__main__":
     seed_everything(42)
     REF_BATCH = 512
-    BATCH = 256  # adjust depending on the avaiable memory on your machine
+    BATCH = 64  # adjust depending on the avaiable memory on your machine
     WORKERS = 8
     EPOCHS = 1
     BLOCK = 128

--- a/tests/test_core_attention.py
+++ b/tests/test_core_attention.py
@@ -30,7 +30,7 @@ def test_core_attention():
 def test_core_attention_mask_types():
 
     b, s, d = 8, 900, 32
-    prob = 0.5
+    prob = 0.8  # make sure that we trigger the sparse kernels
 
     a = torch.rand(b, s, d)
     mask = torch.rand(b, s, s) > prob
@@ -39,12 +39,6 @@ def test_core_attention_mask_types():
     r_dense_bool = scaled_dot_product_attention(a, a, a, mask)
     r_sparse_bool = scaled_dot_product_attention(a, a, a, mask.to_sparse())
     assert torch.allclose(r_dense_bool, r_sparse_bool)
-
-    # Test multiplicative float mask. Mask of 0's and 1's.
-    float_mask_mult = mask.to(dtype=torch.float)
-    r_dense_mult = scaled_dot_product_attention(a, a, a, float_mask_mult)
-    r_sparse_mult = scaled_dot_product_attention(a, a, a, float_mask_mult.to_sparse())
-    assert torch.allclose(r_dense_mult, r_sparse_mult)
 
     # Test additive mask. Mask of 0's and -infs.
     float_mask_add = torch.zeros_like(mask, dtype=torch.float)

--- a/tests/test_core_attention.py
+++ b/tests/test_core_attention.py
@@ -53,8 +53,8 @@ def test_core_attention_mask_types():
     r_dense_add = scaled_dot_product_attention(a, a, a, float_mask_add)
     r_sparse_add = scaled_dot_product_attention(a, a, a, float_mask_add.to_sparse())
 
-    # Fails because all nans returned.
-    assert not torch.allclose(r_dense_add, r_sparse_add)
+    # Now properly handled
+    assert torch.allclose(r_dense_add, r_sparse_add)
 
 
 @pytest.mark.parametrize("device", _devices)

--- a/xformers/components/attention/_sputnik_sparse.py
+++ b/xformers/components/attention/_sputnik_sparse.py
@@ -202,6 +202,10 @@ class SparseCS:
         return self.values.device
 
     @property
+    def ndim(self):
+        return len(self.shape)
+
+    @property
     def dtype(self):
         return self.values.dtype
 

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -17,7 +17,7 @@ if _is_sparse_available:
     from ._sputnik_sparse import SparseCS
 
 # NOTE: Could do with a better option on when to use triton and not
-_use_triton = torch.cuda.is_available()
+_use_triton = False and torch.cuda.is_available()
 if _use_triton:
     try:
         from xformers.triton.softmax import softmax as triton_softmax

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -17,7 +17,7 @@ if _is_sparse_available:
     from ._sputnik_sparse import SparseCS
 
 # NOTE: Could do with a better option on when to use triton and not
-_use_triton = False and torch.cuda.is_available()
+_use_triton = torch.cuda.is_available()
 if _use_triton:
     try:
         from xformers.triton.softmax import softmax as triton_softmax

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -17,7 +17,7 @@ if _is_sparse_available:
     from ._sputnik_sparse import SparseCS
 
 # NOTE: Could do with a better option on when to use triton and not
-_use_triton = True
+_use_triton = torch.cuda.is_available()
 if _use_triton:
     try:
         from xformers.triton.softmax import softmax as triton_softmax
@@ -195,8 +195,12 @@ def scaled_query_key_softmax(
 
     # Self-attend: (N, S, hs) x (N, hs, S) -> (N, S, S)
     q = q / math.sqrt(k.size(-1))
-    att = _matmul_with_mask(q, k.transpose(-2, -1), att_mask)
 
+    # Matmul with mask, if boolean
+    is_bool_mask = att_mask is not None and att_mask.dtype == torch.bool
+    att = _matmul_with_mask(q, k.transpose(-2, -1), att_mask if is_bool_mask else None)
+
+    # Could also be that the mask was additive
     if att_mask is not None and att_mask.dtype != torch.bool:
         att = att + att_mask
 
@@ -219,20 +223,27 @@ def scaled_dot_product_attention(
         or (att_mask is not None and att_mask.is_sparse)
     )
 
-    if att_mask is not None and q.shape[-2] < att_mask.shape[0]:
-        # The sequence is smaller than the mask
+    # Try to handle a case where the sequence is smaller than the mask
+    if (
+        att_mask is not None
+        and q.shape[-2] == k.shape[-2]
+        and q.shape[-2] < att_mask.shape[0]
+    ):
         seq = q.shape[-2]
+        if att_mask.ndim == 2:
+            att_mask = att_mask.unsqueeze(0)
 
         if not att_mask.is_sparse:
-            att_mask = att_mask[:seq, :seq]
+            att_mask = att_mask[:, :seq, :seq]
         else:
             logging.warning(
                 "Mismatching attention mask and sequence length. On the fly correction but this will be slow"
             )
             # Loosing sparsity on purpose,
             # expectation is that moving back and forth dense/sparse will negate the speedup
-            att_mask = att_mask.to_dense().squeeze(0)[:seq, :seq]
+            att_mask = att_mask.to_dense().squeeze(0)[:, :seq, :seq]
 
+    # The actual attention
     with torch.cuda.amp.autocast(enabled=False) if autocast_disabled else nullcontext():
         if autocast_disabled:
             q, k, v = q.float(), k.float(), v.float()

--- a/xformers/components/attention/nystrom.py
+++ b/xformers/components/attention/nystrom.py
@@ -180,8 +180,6 @@ class NystromAttention(Attention):
                 )
                 key_padding_mask = bool_mask_to_additive(key_padding_mask)
 
-            assert key_padding_mask is not None  # mypy is drunk
-
             if key_padding_mask.ndim == 2:
                 key_padding_mask = reshape_key_padding_mask(
                     key_padding_mask, batched_dim

--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -64,14 +64,15 @@ class ScaledDotProduct(Attention):
         att_mask    A 2D or 3D mask which ignores attention at certain positions.
 
                     - If the mask is boolean, a value of True will keep the value,
-                    while a value of False will mask the value.
+                        while a value of False will mask the value.
 
-                    Key padding masks (dimension: batch x sequence length) and attention masks
-                    (dimension: sequence length x sequence length OR batch x sequence length x sequence length)
-                    can be combined and passed in here. Method maybe_merge_masks provided in the utils can be
-                    used for that merging.
+                        Key padding masks (dimension: batch x sequence length) and attention masks
+                        (dimension: sequence length x sequence length OR batch x sequence length x sequence length)
+                        can be combined and passed in here. Method maybe_merge_masks provided in the utils can be
+                        used for that merging.
 
                     - If the mask has the float type, then an additive mask is expected (masked values are -inf)
+
         """
         # Mask-aware attention
         if self.mask is not None:

--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -61,12 +61,17 @@ class ScaledDotProduct(Attention):
         **kwargs,
     ) -> torch.Tensor:
         r"""
-        att_mask    A 2D or 3D mask which ignores attention at certain positions. A value of True will keep the
-                    value, while a value of False will mask the value. Key padding masks
-                    (dimension: batch x sequence length) and attention masks
+        att_mask    A 2D or 3D mask which ignores attention at certain positions.
+
+                    - If the mask is boolean, a value of True will keep the value,
+                    while a value of False will mask the value.
+
+                    Key padding masks (dimension: batch x sequence length) and attention masks
                     (dimension: sequence length x sequence length OR batch x sequence length x sequence length)
                     can be combined and passed in here. Method maybe_merge_masks provided in the utils can be
-                    used for that merging. Additive masks are not yet supported.
+                    used for that merging.
+
+                    - If the mask has the float type, then an additive mask is expected (masked values are -inf)
         """
         # Mask-aware attention
         if self.mask is not None:

--- a/xformers/components/attention/utils.py
+++ b/xformers/components/attention/utils.py
@@ -91,7 +91,7 @@ def iterative_pinv(softmax_mat: torch.Tensor, n_iter=6, pinverse_original_init=F
 
 def bool_mask_to_additive(
     mask: torch.Tensor, dtype: Optional[torch.dtype] = torch.float32
-):
+) -> torch.Tensor:
     assert (
         mask.dtype == torch.bool
     ), "This util is meant to convert in between bool masks and additive ones"

--- a/xformers/components/attention/utils.py
+++ b/xformers/components/attention/utils.py
@@ -87,3 +87,15 @@ def iterative_pinv(softmax_mat: torch.Tensor, n_iter=6, pinverse_original_init=F
             13 * i - torch.matmul(kv, 15 * i - torch.matmul(kv, 7 * i - kv)),
         )
     return v
+
+
+def bool_mask_to_additive(
+    mask: torch.Tensor, dtype: Optional[torch.dtype] = torch.float32
+):
+    assert (
+        mask.dtype == torch.bool
+    ), "This util is meant to convert in between bool masks and additive ones"
+
+    mask_ = torch.zeros_like(mask, dtype=dtype)
+    mask_[~mask] = float("-inf")
+    return mask_


### PR DESCRIPTION
## What does this PR do?
- Fixes https://github.com/facebookresearch/xformers/issues/74, microGPT and causal attention work properly with Nystrom
- Fix attention masks being bool or additive (not all the codepaths probably, but at least the ones that Nystrom touched)
- Fix the small-sequence handling for sparse masks, this was broken prior to this PR and probably explains the hanging CI yesterday

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
