### PR TITLE
[minor] bump v number for current main

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ copyright = "2021, Facebook AI Research"
 author = "Facebook AI Research"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.3"
+release = "0.0.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/xformers/__init__.py
+++ b/xformers/__init__.py
@@ -6,7 +6,7 @@
 import logging
 
 # Please update the doc version in docs/source/conf.py as well.
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 _is_sparse_available = True
 
@@ -58,8 +58,8 @@ try:
     _register_extensions()
 except (ImportError, OSError) as e:
     print(e)
-    logging.error(
-        f"ERROR: {e}\nNeed to compile C++ extensions to get sparse attention suport."
-        + "Please run python setup.py build develop"
+    logging.warning(
+        f"WARNING: {e}\nNeed to compile C++ extensions to get sparse attention suport."
+        + " Please run python setup.py build develop"
     )
     _is_sparse_available = False


### PR DESCRIPTION
## What does this PR do?
Moves current main to v0.0.4, so that we can make a difference in between `pip install xformers` and `pip install -e .`

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
