### PR TITLE
Automate binary releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,13 +313,44 @@ workflows:
             ignore:
               - gh-pages
       - binary_linux_wheel:
-        filters:
-          branches:
-            only: binaries_job
-        #name: binary_linux_wheel_py38_cu102
+          python_version: "3.7"
+          name: binary_linux_wheel_py37_cu102
+          filters:
+            branches:
+              only: binaries_job
       - test_binary:
+          python_version: "3.7"
+          name: test_binary_linux_wheel_py37_cu102
           requires:
-            - binary_linux_wheel
+            - binary_linux_wheel_py37_cu102
+          filters:
+            branches:
+              only: binaries_job
+      - binary_linux_wheel:
+          python_version: "3.8"
+          name: binary_linux_wheel_py38_cu102
+          filters:
+            branches:
+              only: binaries_job
+      - test_binary:
+          python_version: "3.8"
+          name: test_binary_linux_wheel_py38_cu102
+          requires:
+            - binary_linux_wheel_py38_cu102
+          filters:
+            branches:
+              only: binaries_job
+      - binary_linux_wheel:
+          python_version: "3.9"
+          name: binary_linux_wheel_py39_cu102
+          filters:
+            branches:
+              only: binaries_job
+      - test_binary:
+          python_version: "3.9"
+          name: test_binary_linux_wheel_py39_cu102
+          requires:
+            - binary_linux_wheel_py39_cu102
           filters:
             branches:
               only: binaries_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,24 @@ jobs:
       - store_test_results:
           path: test-results
 
+  binary_linux_wheel:
+    docker:
+      - image: "pytorch/manylinux-cuda102"
+    resource_class: 2xlarge+
+    environment:
+      CU_VERSION: "cu102"
+      PYTHON_VERSION: "3.8"
+      PYTORCH_VERSION: "1.10"
+      XFORMERS_VERSION_SUFFIX: ""
+    steps:
+      - checkout
+      - run: packaging/build_wheel.sh
+      - store_artifacts:
+          path: wheels
+      - persist_to_workspace:
+          root: wheels
+          paths:
+            - "*"
 
 workflows:
   version: 2
@@ -240,3 +258,7 @@ workflows:
           branches:
             ignore:
               - gh-pages
+      - binary_linux_wheel:
+        filters:
+          branches:
+            only: binaries_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,31 @@ gpu_cu112: &gpu_cu112
     image: ubuntu-2004-cuda-11.2:202103-01
     resource_class: gpu.nvidia.medium
 
+
+binary_common: &binary_common
+  parameters:
+    pytorch_version:
+      description: "PyTorch version to build against"
+      type: string
+      default: "1.10.0"
+    python_version:
+      description: "Python version to build against (e.g., 3.7)"
+      type: string
+      default: "3.8"
+    cu_version:
+      description: "CUDA version to build against, in CU format (e.g., cpu or cu100)"
+      type: string
+      default: "cu102"
+    wheel_docker_image:
+      description: "Wheel only: what docker image to use"
+      type: string
+      default: "pytorch/manylinux-cuda102"
+  environment:
+      CU_VERSION: << parameters.cu_version >>
+      PYTHON_VERSION: << parameters.python_version >>
+      PYTORCH_VERSION: << parameters.pytorch_version >>
+      XFORMERS_VERSION_SUFFIX: ""
+
 # -------------------------------------------------------------------------------------
 # Re-usable commands
 # -------------------------------------------------------------------------------------
@@ -142,8 +167,10 @@ commands:
            command: |
              git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
              pyenv update
-             pyenv install -f <<parameters.version>>
-             pyenv global <<parameters.version>>
+             # figure out the latest python version given a subversion, like 3.8
+             LATEST_PY_VERSION=$(pyenv install --list | sed 's/^  //' | grep -E '^[0-9].[0-9].[0-9]' | grep <<parameters.version>> | tail -1)
+             pyenv install -f $LATEST_PY_VERSION
+             pyenv global $LATEST_PY_VERSION
 
 # -------------------------------------------------------------------------------------
 # Jobs to run
@@ -225,14 +252,10 @@ jobs:
           path: test-results
 
   binary_linux_wheel:
+    <<: *binary_common
     docker:
-      - image: "pytorch/manylinux-cuda102"
+      - image: << parameters.wheel_docker_image >>
     resource_class: 2xlarge+
-    environment:
-      CU_VERSION: "cu102"
-      PYTHON_VERSION: "3.8"
-      PYTORCH_VERSION: "1.10"
-      XFORMERS_VERSION_SUFFIX: ""
     steps:
       - checkout
       - run: packaging/build_wheel.sh
@@ -242,6 +265,37 @@ jobs:
           root: wheels
           paths:
             - "*"
+
+  test_binary:
+    machine:
+      image: ubuntu-2004-cuda-11.2:202103-01
+      resource_class: gpu.nvidia.medium
+    <<: *binary_common
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - setup_pyenv:
+          version: << parameters.python_version >>
+
+      - <<: *setup_venv
+      - run:
+          name: Install dependencies + xformers from binary
+          command: |
+            set -ex
+            echo "torch==${PYTORCH_VERSION}+${CU_VERSION}"
+            export PYTORCH_CONSTRAINT="torch==${PYTORCH_VERSION}+${CU_VERSION}"
+            pip install --progress-bar off "${PYTORCH_CONSTRAINT}" -f https://download.pytorch.org/whl/torch_stable.html
+            pip install --progress-bar off numpy pytest
+            echo $(ls ~/workspace)
+            pip install --progress-bar off $(ls -d ~/workspace/*)
+
+      - checkout
+
+      - run:
+          name: Smoke test binary
+          command: |
+            set -ex
+            pytest --import-mode=importlib tests/test_custom_ops.py
 
 workflows:
   version: 2
@@ -262,3 +316,10 @@ workflows:
         filters:
           branches:
             only: binaries_job
+        #name: binary_linux_wheel_py38_cu102
+      - test_binary:
+          requires:
+            - binary_linux_wheel
+          filters:
+            branches:
+              only: binaries_job

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+# Taken with modifications from https://github.com/facebookresearch/detectron2/blob/main/dev/packaging/build_wheel.sh
+set -ex
+
+ldconfig  # https://github.com/NVIDIA/nvidia-docker/issues/854
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+. "$script_dir/pkg_helpers.bash"
+
+echo "Build Settings:"
+echo "CU_VERSION: $CU_VERSION"                             # e.g. cu101
+echo "XFORMERS_VERSION_SUFFIX: $XFORMERS_VERSION_SUFFIX"   # e.g. +cu101 or ""
+echo "PYTHON_VERSION: $PYTHON_VERSION"                     # e.g. 3.6
+echo "PYTORCH_VERSION: $PYTORCH_VERSION"                   # e.g. 1.4
+
+setup_cuda
+setup_wheel_python
+
+yum install ninja-build -y
+ln -sv /usr/bin/ninja-build /usr/bin/ninja || true
+
+pip_install pip  -U
+pip_install "torch==$PYTORCH_VERSION" \
+	-f https://download.pytorch.org/whl/"$CU_VERSION"/torch_stable.html
+
+# use separate directories to allow parallel build
+BASE_BUILD_DIR=build/$CU_VERSION-py$PYTHON_VERSION-pt$PYTORCH_VERSION
+python setup.py \
+  build -b "$BASE_BUILD_DIR" \
+  bdist_wheel -b "$BASE_BUILD_DIR/build_dist" -d "wheels/$CU_VERSION/torch$PYTORCH_VERSION"
+rm -rf "$BASE_BUILD_DIR"

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -28,5 +28,5 @@ pip_install "torch==$PYTORCH_VERSION" \
 BASE_BUILD_DIR=build/$CU_VERSION-py$PYTHON_VERSION-pt$PYTORCH_VERSION
 python setup.py \
   build -b "$BASE_BUILD_DIR" \
-  bdist_wheel -b "$BASE_BUILD_DIR/build_dist" -d "wheels/$CU_VERSION/torch$PYTORCH_VERSION"
+  bdist_wheel -b "$BASE_BUILD_DIR/build_dist" -d "wheels"
 rm -rf "$BASE_BUILD_DIR"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -1,0 +1,77 @@
+#!/bin/bash -e
+# Copyright (c) Facebook, Inc. and its affiliates.
+# Taken from https://github.com/facebookresearch/detectron2/blob/main/dev/packaging/pkg_helpers.bash
+
+# Function to retry functions that sometimes timeout or have flaky failures
+retry () {
+    $*  || (sleep 1 && $*) || (sleep 2 && $*) || (sleep 4 && $*) || (sleep 8 && $*)
+}
+# Install with pip a bit more robustly than the default
+pip_install() {
+  retry pip install --progress-bar off "$@"
+}
+
+
+setup_cuda() {
+  # Now work out the CUDA settings
+  # Like other torch domain libraries, we choose common GPU architectures only.
+  # See https://github.com/pytorch/pytorch/blob/master/torch/utils/cpp_extension.py
+  # and https://github.com/pytorch/vision/blob/main/packaging/pkg_helpers.bash for reference.
+  export FORCE_CUDA=1
+  case "$CU_VERSION" in
+    cu113)
+      export CUDA_HOME=/usr/local/cuda-11.3/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+      ;;
+    cu112)
+      export CUDA_HOME=/usr/local/cuda-11.2/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+      ;;
+    cu111)
+      export CUDA_HOME=/usr/local/cuda-11.1/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0;8.6+PTX"
+      ;;
+    cu110)
+      export CUDA_HOME=/usr/local/cuda-11.0/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX;8.0+PTX"
+      ;;
+    cu102)
+      export CUDA_HOME=/usr/local/cuda-10.2/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
+      ;;
+    cu101)
+      export CUDA_HOME=/usr/local/cuda-10.1/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
+      ;;
+    cu100)
+      export CUDA_HOME=/usr/local/cuda-10.0/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0;7.5+PTX"
+      ;;
+    cu92)
+      export CUDA_HOME=/usr/local/cuda-9.2/
+      export TORCH_CUDA_ARCH_LIST="3.7;5.0;5.2;6.0;6.1+PTX;7.0+PTX"
+      ;;
+    cpu)
+      unset FORCE_CUDA
+      export CUDA_VISIBLE_DEVICES=
+      ;;
+    *)
+      echo "Unrecognized CU_VERSION=$CU_VERSION"
+      exit 1
+      ;;
+  esac
+}
+
+setup_wheel_python() {
+  case "$PYTHON_VERSION" in
+    3.6) python_abi=cp36-cp36m ;;
+    3.7) python_abi=cp37-cp37m ;;
+    3.8) python_abi=cp38-cp38 ;;
+    3.9) python_abi=cp39-cp39 ;;
+    *)
+      echo "Unrecognized PYTHON_VERSION=$PYTHON_VERSION"
+      exit 1
+      ;;
+  esac
+  export PATH="/opt/python/$python_abi/bin:$PATH"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Example requirement, can be anything that pip knows
 # install with `pip install -r requirements.txt`, and make sure that CI does the same
 torch >= 1.8.1
+numpy
 pyre-extensions == 0.0.23

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,11 @@ def find_version(version_file_path):
         version_match = re.search(
             r"^__version__ = ['\"]([^'\"]*)['\"]", version_file.read(), re.M
         )
+        # The following is used to build release packages.
+        # Users should never use it.
+        suffix = os.getenv("XFORMERS_VERSION_SUFFIX", "")
         if version_match:
-            return version_match.group(1)
+            return version_match.group(1) + suffix
         raise RuntimeError("Unable to find version string.")
 
 
@@ -118,7 +121,7 @@ if __name__ == "__main__":
     setuptools.setup(
         name="xformers",
         description="XFormers: A collection of composable Transformer building blocks.",
-        version=find_version("xformers/__init__.py"),
+        version=find_version(os.path.join(this_dir, "xformers", "__init__.py")),
         setup_requires=[],
         install_requires=fetch_requirements(),
         packages=setuptools.find_packages(exclude=("tests", "tests.*")),


### PR DESCRIPTION
This PR sets up CircleCI jobs that automatically build wheels for xformers, for different Python versions.

In order to kick the builds, the following is needed:
- create a branch named `release/v0.0.2`  (one can change the release version)
- apply needed modifications for the release (if needed)
- create a pull request (which don't need to be merged)

The pull request will launch the build jobs, together with a set of jobs to validate that the extensions have been properly built and can be loaded.

~In order to test this PR, I've temporarily changed the name of the branch to be `binaries_job` (the name of this branch), but last commits in this PR changes it to the corresponding regex for `release/...`~

EDIT: in order to facilitate testing / reviewing, I propose to for now merge this PR with the `binaries_job` in the requirement for branch name, and then send a follow-up PR on top of a branch named `release/0.0.0` with the changes in the regex.

I'll be using the following regex `/release\/[0-9]+(\.[0-9]+)+/` in a follow-up PR