### PR TITLE
[Minor] FusedLayerNorm enabled by default in the factory

### DIFF
--- a/examples/microViT.py
+++ b/examples/microViT.py
@@ -148,7 +148,7 @@ class VisionTransformer(pl.LightningModule):
         x = self.patch_emb(x)
 
         # flatten patches into sequence
-        x = x.flatten(2, 3).transpose(1, 2)  # B HW C
+        x = x.flatten(2, 3).transpose(1, 2).contiguous()  # B HW C
 
         if self.hparams.classifier == Classifier.TOKEN:
             # prepend classification token

--- a/xformers/components/residual.py
+++ b/xformers/components/residual.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 # NOTE: The Triton layernorm can be activated/deactivated from here
-_is_triton_available = False  # torch.cuda.is_available()
+_is_triton_available = torch.cuda.is_available()
 
 if _is_triton_available:
     try:


### PR DESCRIPTION
## What does this PR do?
Enables FusedLayerNorm by default in the factory (if triton is available and the gpu is compatible), brings a little more speed and same accuracy in the microViT dummy test.

Somewhat related to https://github.com/facebookresearch/xformers/issues/76

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
