### PR TITLE
Take 2: use Hydra to build xformer model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ my_runs.md
 # examples demo files
 examples/input.txt
 examples/lightning_logs
+examples/data
+
+# Hydra default output dir
+multirun
+outputs

--- a/docs/source/tutorials/pytorch_encoder.rst
+++ b/docs/source/tutorials/pytorch_encoder.rst
@@ -98,7 +98,7 @@ Building full models
 ====================
 
 
- Now let's build a full Tranformer/xFormer model. Please note that this is just an example, because building the whole model from explicit parts is always an option, from pure PyTorch building blocks or adding some xFormers primitives.
+ Now let's build a full Tranformers/xFormer model. Please note that this is just an example, because building the whole model from explicit parts is always an option, from pure PyTorch building blocks or adding some xFormers primitives.
 
 PyTorch Transformer
 -------------------
@@ -260,7 +260,10 @@ Build an `xFormer` model with Hydra
 Alternatively, you can use [Hydra](https://hydra.cc/) to build an xFormer model. 
 We've included an example [here](https://github.com/facebookresearch/xformers/tree/main/examples/build_model).
 The example replicates the model from the above example and demonstrates one way to use Hydra to minimize config duplication. 
-
+The example is built on top of some more advanced Hydra features. If you are new to Hydra, you can start these docs:  
+[basic tutorials](https://hydra.cc/docs/tutorials/intro/), [extending configs](https://hydra.cc/docs/patterns/extending_configs/), 
+[Hydra packages](https://hydra.cc/docs/advanced/overriding_packages/) and 
+[instantiation API](https://hydra.cc/docs/advanced/instantiate_objects/overview/)
 
 
 .. code-block:: yaml

--- a/docs/source/tutorials/pytorch_encoder.rst
+++ b/docs/source/tutorials/pytorch_encoder.rst
@@ -98,7 +98,7 @@ Building full models
 ====================
 
 
-This is the last example in the series, and goes one level up again, so that we consider building a whole Tranformer/xFormer model. Please note that this is just an example, because building the whole model from explicit parts is always an option, from pure PyTorch building blocks or adding some xFormers primitives.
+ Now let's build a full Tranformer/xFormer model. Please note that this is just an example, because building the whole model from explicit parts is always an option, from pure PyTorch building blocks or adding some xFormers primitives.
 
 PyTorch Transformer
 -------------------
@@ -155,72 +155,68 @@ There's also an added flexibility with xFormers in that attention mechanisms can
         # Note that a sequence of different encoder blocks can be used, same for decoders
         {
             "reversible": False,  # Optionally make these layers reversible, to save memory
-            "block_config": {
-                "block_type": "encoder",
-                "num_layers": 3,  # Optional, this means that this config will repeat N times
-                "dim_model": EMB,
-                "layer_norm_style": "pre",  # Optional, pre/post
-                "position_encoding_config": {
-                    "name": "vocab",  # whatever position encodinhg makes sense
-                    "seq_len": 1024,
-                    "vocab_size": VOCAB,
-                },
-                "multi_head_config": {
-                    "num_heads": 4,
-                    "residual_dropout": 0,
-                    "attention": {
-                        "name": "linformer",  # whatever attention mechanism
-                        "dropout": 0,
-                        "causal": False,
-                        "seq_len": SEQ,
-                    },
-                },
-                "feedforward_config": {
-                    "name": "MLP",
+            "block_type": "encoder",
+            "num_layers": 3,  # Optional, this means that this config will repeat N times
+            "dim_model": EMB,
+            "layer_norm_style": "pre",  # Optional, pre/post
+            "position_encoding_config": {
+                "name": "vocab",  # whatever position encodinhg makes sense
+                "seq_len": 1024,
+                "vocab_size": VOCAB,
+            },
+            "multi_head_config": {
+                "num_heads": 4,
+                "residual_dropout": 0,
+                "attention": {
+                    "name": "linformer",  # whatever attention mechanism
                     "dropout": 0,
-                    "activation": "relu",
-                    "hidden_layer_multiplier": 4,
+                    "causal": False,
+                    "seq_len": SEQ,
                 },
+            },
+            "feedforward_config": {
+                "name": "MLP",
+                "dropout": 0,
+                "activation": "relu",
+                "hidden_layer_multiplier": 4,
             },
         },
         {
             "reversible": False,  # Optionally make these layers reversible, to save memory
-            "block_config": {
-                "block_type": "decoder",
-                "num_layers": 3,  # Optional, this means that this config will repeat N times
-                "dim_model": EMB,
-                "layer_norm_style": "pre",  # Optional, pre/post
-                "position_encoding_config": {
-                    "name": "vocab",  # whatever position encodinhg makes sense
-                    "seq_len": SEQ,
-                    "vocab_size": VOCAB,
-                },
-                "multi_head_config_masked": {
-                    "num_heads": 4,
-                    "residual_dropout": 0,
-                    "attention": {
-                        "name": "nystrom",  # whatever attention mechanism
-                        "dropout": 0,
-                        "causal": True,
-                        "seq_len": SEQ,
-                    },
-                },
-                "multi_head_config_cross": {
-                    "num_heads": 4,
-                    "residual_dropout": 0,
-                    "attention": {
-                        "name": "favor",  # whatever attention mechanism
-                        "dropout": 0,
-                        "causal": True,
-                        "seq_len": SEQ,
-                    },
-                },
-                "feedforward_config": {
-                    "name": "MLP",
+            "block_type": "decoder",
+            "num_layers": 3,  # Optional, this means that this config will repeat N times
+            "dim_model": EMB,
+            "layer_norm_style": "pre",  # Optional, pre/post
+            "position_encoding_config": {
+                "name": "vocab",  # whatever position encodinhg makes sense
+                "seq_len": SEQ,
+                "vocab_size": VOCAB,
+            },
+            "multi_head_config_masked": {
+                "num_heads": 4,
+                "residual_dropout": 0,
+                "attention": {
+                    "name": "nystrom",  # whatever attention mechanism
                     "dropout": 0,
-                    "activation": "relu",
-                    "hidden_layer_multiplier": 4,
+                    "causal": True,
+                    "seq_len": SEQ,
                 },
+            },
+            "multi_head_config_cross": {
+                "num_heads": 4,
+                "residual_dropout": 0,
+                "attention": {
+                    "name": "favor",  # whatever attention mechanism
+                    "dropout": 0,
+                    "causal": True,
+                    "seq_len": SEQ,
+                },
+            },
+            "feedforward_config": {
+                "name": "MLP",
+                "dropout": 0,
+                "activation": "relu",
+                "hidden_layer_multiplier": 4,
             },
         },
     ]
@@ -255,3 +251,225 @@ Current results are as follows, on a nVidia V100 (PyTorch 1.9, Triton 1.1, xForm
     | --------- | ----------------- | ------------------ | ------------------ |
     | xformers  | 89                | 1182               | 2709               |
     | pytorch   | 155               | 1950               | 4117               |
+
+
+
+Build an `xFormer` model with Hydra
+-----------------------------------
+
+Alternatively, you can use [Hydra](https://hydra.cc/) to build an xFormer model. 
+We've included an example [here](https://github.com/facebookresearch/xformers/tree/main/examples/build_model).
+The example replicates the model from the above example and demonstrates one way to use Hydra to minimize config duplication. 
+
+
+
+.. code-block:: yaml
+
+    defaults:
+        - /stack@xformer.stack_configs: 
+            - encoder_local
+            - encoder_random
+            - decoder_nystrom_favor
+        - _self_
+
+    xformer:
+        _target_: xformers.factory.model_factory.xFormer 
+
+
+Building a model this way makes it possible for you to leverage many features Hydra has to offer. 
+For example, you can override the model architecture from the commandline:
+
+.. code-block:: bash
+
+    python examples/build_model/my_model.py  'stack@xformer.stack_configs=[encoder_local]'
+
+    Built a model with 1 stack: dict_keys(['encoder_local'])
+        xFormer(
+        (encoders): ModuleList(
+            (0): xFormerEncoderBlock(
+            (pose_encoding): VocabEmbedding(
+                (dropout): Dropout(p=0, inplace=False)
+                (position_embeddings): Embedding(1024, 384)
+                (word_embeddings): Embedding(64, 384)
+            )
+            (mha): MultiHeadDispatch(
+                (attention): LocalAttention(
+                (attn_drop): Dropout(p=0.0, inplace=False)
+                )
+                (in_proj_container): InProjContainer()
+                (resid_drop): Dropout(p=0, inplace=False)
+                (proj): Linear(in_features=384, out_features=384, bias=True)
+            )
+            (feedforward): MLP(
+                (mlp): Sequential(
+                (0): Linear(in_features=384, out_features=1536, bias=True)
+                (1): ReLU()
+                (2): Dropout(p=0, inplace=False)
+                (3): Linear(in_features=1536, out_features=384, bias=True)
+                (4): Dropout(p=0, inplace=False)
+                )
+            )
+            (wrap_att): Residual(
+                (layer): PreNorm(
+                (norm): FusedLayerNorm()
+                (sublayer): MultiHeadDispatch(
+                    (attention): LocalAttention(
+                    (attn_drop): Dropout(p=0.0, inplace=False)
+                    )
+                    (in_proj_container): InProjContainer()
+                    (resid_drop): Dropout(p=0, inplace=False)
+                    (proj): Linear(in_features=384, out_features=384, bias=True)
+                )
+                )
+            )
+            (wrap_ff): PostNorm(
+                (norm): FusedLayerNorm()
+                (sublayer): Residual(
+                (layer): PreNorm(
+                    (norm): FusedLayerNorm()
+                    (sublayer): MLP(
+                    (mlp): Sequential(
+                        (0): Linear(in_features=384, out_features=1536, bias=True)
+                        (1): ReLU()
+                        (2): Dropout(p=0, inplace=False)
+                        (3): Linear(in_features=1536, out_features=384, bias=True)
+                        (4): Dropout(p=0, inplace=False)
+                    )
+                    )
+                )
+                )
+            )
+            )
+        )
+        (decoders): ModuleList()
+        )
+
+
+You can also launch multiple runs of your application with different architectures:
+
+.. code-block:: bash
+    
+    $ python my_model.py  --multirun 'stack@xformer.stack_configs=[encoder_local], [encoder_random]'
+    [HYDRA] Launching 2 jobs locally
+    [HYDRA]        #0 : stack@xformer.stack_configs=[encoder_local]
+    Built a model with 1 stack: dict_keys(['encoder_local'])
+    xFormer(
+    (encoders): ModuleList(
+        (0): xFormerEncoderBlock(
+        (pose_encoding): VocabEmbedding(
+            (dropout): Dropout(p=0, inplace=False)
+            (position_embeddings): Embedding(1024, 384)
+            (word_embeddings): Embedding(64, 384)
+        )
+        (mha): MultiHeadDispatch(
+            (attention): LocalAttention(
+            (attn_drop): Dropout(p=0.0, inplace=False)
+            )
+            (in_proj_container): InProjContainer()
+            (resid_drop): Dropout(p=0, inplace=False)
+            (proj): Linear(in_features=384, out_features=384, bias=True)
+        )
+        (feedforward): MLP(
+            (mlp): Sequential(
+            (0): Linear(in_features=384, out_features=1536, bias=True)
+            (1): ReLU()
+            (2): Dropout(p=0, inplace=False)
+            (3): Linear(in_features=1536, out_features=384, bias=True)
+            (4): Dropout(p=0, inplace=False)
+            )
+        )
+        (wrap_att): Residual(
+            (layer): PreNorm(
+            (norm): FusedLayerNorm()
+            (sublayer): MultiHeadDispatch(
+                (attention): LocalAttention(
+                (attn_drop): Dropout(p=0.0, inplace=False)
+                )
+                (in_proj_container): InProjContainer()
+                (resid_drop): Dropout(p=0, inplace=False)
+                (proj): Linear(in_features=384, out_features=384, bias=True)
+            )
+            )
+        )
+        (wrap_ff): PostNorm(
+            (norm): FusedLayerNorm()
+            (sublayer): Residual(
+            (layer): PreNorm(
+                (norm): FusedLayerNorm()
+                (sublayer): MLP(
+                (mlp): Sequential(
+                    (0): Linear(in_features=384, out_features=1536, bias=True)
+                    (1): ReLU()
+                    (2): Dropout(p=0, inplace=False)
+                    (3): Linear(in_features=1536, out_features=384, bias=True)
+                    (4): Dropout(p=0, inplace=False)
+                )
+                )
+            )
+            )
+        )
+        )
+    )
+    (decoders): ModuleList()
+    )
+    [HYDRA]        #1 : stack@xformer.stack_configs=[encoder_random]
+    Built a model with 1 stack: dict_keys(['encoder_random'])
+    xFormer(
+    (encoders): ModuleList(
+        (0): xFormerEncoderBlock(
+        (pose_encoding): VocabEmbedding(
+            (dropout): Dropout(p=0, inplace=False)
+            (position_embeddings): Embedding(1024, 384)
+            (word_embeddings): Embedding(64, 384)
+        )
+        (mha): MultiHeadDispatch(
+            (attention): RandomAttention(
+            (attn_drop): Dropout(p=0.0, inplace=False)
+            )
+            (in_proj_container): InProjContainer()
+            (resid_drop): Dropout(p=0, inplace=False)
+            (proj): Linear(in_features=384, out_features=384, bias=True)
+        )
+        (feedforward): MLP(
+            (mlp): Sequential(
+            (0): Linear(in_features=384, out_features=1536, bias=True)
+            (1): ReLU()
+            (2): Dropout(p=0, inplace=False)
+            (3): Linear(in_features=1536, out_features=384, bias=True)
+            (4): Dropout(p=0, inplace=False)
+            )
+        )
+        (wrap_att): Residual(
+            (layer): PreNorm(
+            (norm): FusedLayerNorm()
+            (sublayer): MultiHeadDispatch(
+                (attention): RandomAttention(
+                (attn_drop): Dropout(p=0.0, inplace=False)
+                )
+                (in_proj_container): InProjContainer()
+                (resid_drop): Dropout(p=0, inplace=False)
+                (proj): Linear(in_features=384, out_features=384, bias=True)
+            )
+            )
+        )
+        (wrap_ff): PostNorm(
+            (norm): FusedLayerNorm()
+            (sublayer): Residual(
+            (layer): PreNorm(
+                (norm): FusedLayerNorm()
+                (sublayer): MLP(
+                (mlp): Sequential(
+                    (0): Linear(in_features=384, out_features=1536, bias=True)
+                    (1): ReLU()
+                    (2): Dropout(p=0, inplace=False)
+                    (3): Linear(in_features=1536, out_features=384, bias=True)
+                    (4): Dropout(p=0, inplace=False)
+                )
+                )
+            )
+            )
+        )
+        )
+    )
+    (decoders): ModuleList()
+    )

--- a/examples/build_model/conf/attention/favor.yaml
+++ b/examples/build_model/conf/attention/favor.yaml
@@ -1,0 +1,7 @@
+defaults:
+   # validate schema using xFormer's config dataclass
+   - /xformers/attention/favor_schema@_here_
+
+name: favor
+dropout: 0
+

--- a/examples/build_model/conf/attention/local.yaml
+++ b/examples/build_model/conf/attention/local.yaml
@@ -1,0 +1,6 @@
+defaults:
+   # validate schema using xFormer's config dataclass
+   - /xformers/attention/local_schema@_here_
+
+name: local
+dropout: 0

--- a/examples/build_model/conf/attention/nystrom.yaml
+++ b/examples/build_model/conf/attention/nystrom.yaml
@@ -1,0 +1,4 @@
+name: nystrom
+dropout: 0
+causal: True
+seq_len: ${seq}

--- a/examples/build_model/conf/attention/random.yaml
+++ b/examples/build_model/conf/attention/random.yaml
@@ -1,0 +1,8 @@
+defaults:
+   - /xformers/attention/random_schema@_here_
+
+name: random
+dropout: 0
+r: 0.01
+constant_masking: True
+force_sparsity: False

--- a/examples/build_model/conf/config.yaml
+++ b/examples/build_model/conf/config.yaml
@@ -1,0 +1,13 @@
+emb: 384
+seq: 1024
+vocab: 64
+
+defaults:
+  - /stack@xformer.stack_configs: 
+     - encoder_local
+     - encoder_random
+     - decoder_nystrom_favor
+  - _self_
+
+xformer:
+  _target_: xformers.factory.model_factory.xFormer

--- a/examples/build_model/conf/stack/base_decoder.yaml
+++ b/examples/build_model/conf/stack/base_decoder.yaml
@@ -1,0 +1,27 @@
+# base encoder settings that can be extended and overriden
+# we leave out the attention part for other config to override
+
+_target_: xformers.factory.block_factory.xFormerDecoderConfig
+reversible: False  # Optionally make these layers reversible to save memory
+num_layers: 3  # Optional this means that this config will repeat N times
+block_type: decoder
+dim_model: ${emb}
+layer_norm_style: pre  # Optional pre/post
+position_encoding_config: 
+  name: vocab  # whatever position encodinhg makes sense
+  seq_len: ${seq}
+  vocab_size: ${vocab}
+  dropout: 0
+multi_head_config_masked: 
+  num_heads: 4
+  residual_dropout: 0
+  attention: ???
+multi_head_config_cross: 
+  num_heads: 4
+  residual_dropout: 0
+  attention: ???
+feedforward_config: 
+  name: MLP
+  dropout: 0
+  activation: relu
+  hidden_layer_multiplier: 4

--- a/examples/build_model/conf/stack/base_encoder.yaml
+++ b/examples/build_model/conf/stack/base_encoder.yaml
@@ -1,0 +1,23 @@
+# base encoder settings that can be extended and overriden
+# we leave out the attention part for other config to override
+
+_target_: xformers.factory.block_factory.xFormerEncoderConfig
+reversible: False
+num_layers: 4
+user_triton: True
+dim_model: ${emb}
+layer_norm_style: pre
+position_encoding_config:
+  name: vocab
+  seq_len: 1024
+  vocab_size: ${vocab}
+  dropout: 0
+multi_head_config: 
+  num_heads: 4
+  residual_dropout: 0
+  attention: ???
+feedforward_config: 
+  name: MLP
+  dropout: 0
+  activation: relu
+  hidden_layer_multiplier: 4

--- a/examples/build_model/conf/stack/decoder_nystrom_favor.yaml
+++ b/examples/build_model/conf/stack/decoder_nystrom_favor.yaml
@@ -1,0 +1,16 @@
+defaults:
+  # move configs from base_decoder to decoder_nystrom_favor package
+  # resulting config would look like
+  #
+  # decoder_nystrom_favor:
+  #  _target_: xformers.factory.block_factory.xFormerDecoderConfig
+  #  reversible: False  
+  #  ...
+  #
+  # this helps with organizing the configs at a model level
+  # the package name is arbitrary but should be unique within the stacks groups
+  # to avoid conficts.
+  - base_decoder@decoder_nystrom_favor
+  # override the attentions :)
+  - /attention@decoder_nystrom_favor.multi_head_config_masked.attention: nystrom
+  - /attention@decoder_nystrom_favor.multi_head_config_cross.attention: favor

--- a/examples/build_model/conf/stack/encoder_local.yaml
+++ b/examples/build_model/conf/stack/encoder_local.yaml
@@ -1,0 +1,8 @@
+defaults:
+  # move configs from base_encoder to under encoder_local package
+  # this helps with merging the configs at a model level
+  # the package name is arbitrary but should be unique within the stacks config groups
+  # to avoid conflicts.
+  - base_encoder@encoder_local
+  # override the attention
+  - /attention@encoder_local.multi_head_config.attention: local

--- a/examples/build_model/conf/stack/encoder_random.yaml
+++ b/examples/build_model/conf/stack/encoder_random.yaml
@@ -1,0 +1,8 @@
+defaults:
+  # move configs from base_encoder to under encoder_local package
+  # this helps with merging the configs at a model level
+  # the package name is arbitrary but should be unique within the stacks config groups
+  # to avoid conflicts.
+  - base_encoder@encoder_random
+  # override the attention
+  - /attention@encoder_random.multi_head_config.attention: random

--- a/examples/build_model/my_model.py
+++ b/examples/build_model/my_model.py
@@ -1,0 +1,17 @@
+import hydra
+from omegaconf import DictConfig
+
+from xformers.factory.hydra_helper import import_xformer_config_schema
+
+
+@hydra.main(config_path="conf", config_name="config")
+def my_app(cfg: DictConfig) -> None:
+    model = hydra.utils.instantiate(cfg.xformer, _convert_="all")
+    print(model)
+
+
+if __name__ == "__main__":
+    # optional - only needed when you want to use xformer config dataclass
+    # to validate config values.
+    import_xformer_config_schema()
+    my_app()

--- a/examples/build_model/my_model.py
+++ b/examples/build_model/my_model.py
@@ -7,6 +7,9 @@ from xformers.factory.hydra_helper import import_xformer_config_schema
 @hydra.main(config_path="conf", config_name="config")
 def my_app(cfg: DictConfig) -> None:
     model = hydra.utils.instantiate(cfg.xformer, _convert_="all")
+    print(
+        f"Built a model with {len(cfg.xformer.stack_configs)} stack: {cfg.xformer.stack_configs.keys()}"
+    )
     print(model)
 
 

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -49,10 +49,7 @@ class GPT(pl.LightningModule):
         # A list of the encoder or decoder blocks which constitute the Transformer.
         xformer_config = [
             {
-<<<<<<< HEAD
                 "reversible": False,  # Turn on to test the effect of using reversible layers
-=======
->>>>>>> 0512194 (fix lints)
                 "block_type": "encoder",
                 "num_layers": self.hparams.n_layer,
                 "dim_model": self.hparams.n_embd,

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -49,7 +49,10 @@ class GPT(pl.LightningModule):
         # A list of the encoder or decoder blocks which constitute the Transformer.
         xformer_config = [
             {
+<<<<<<< HEAD
                 "reversible": False,  # Turn on to test the effect of using reversible layers
+=======
+>>>>>>> 0512194 (fix lints)
                 "block_type": "encoder",
                 "num_layers": self.hparams.n_layer,
                 "dim_model": self.hparams.n_embd,

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -50,33 +50,31 @@ class GPT(pl.LightningModule):
         xformer_config = [
             {
                 "reversible": False,  # Turn on to test the effect of using reversible layers
-                "block_config": {
-                    "block_type": "encoder",
-                    "num_layers": self.hparams.n_layer,
-                    "dim_model": self.hparams.n_embd,
-                    "layer_norm_style": "pre",
-                    "position_encoding_config": {
-                        "name": "vocab",
+                "block_type": "encoder",
+                "num_layers": self.hparams.n_layer,
+                "dim_model": self.hparams.n_embd,
+                "layer_norm_style": "pre",
+                "position_encoding_config": {
+                    "name": "vocab",
+                    "seq_len": self.hparams.block_size,
+                    "vocab_size": self.hparams.vocab_size,
+                },
+                "multi_head_config": {
+                    "num_heads": self.hparams.n_head,
+                    "residual_dropout": self.hparams.resid_pdrop,
+                    "use_rotary_embeddings": True,
+                    "attention": {
+                        "name": self.hparams.attention,
+                        "dropout": self.hparams.attn_pdrop,
+                        "causal": True,
                         "seq_len": self.hparams.block_size,
-                        "vocab_size": self.hparams.vocab_size,
                     },
-                    "multi_head_config": {
-                        "num_heads": self.hparams.n_head,
-                        "residual_dropout": self.hparams.resid_pdrop,
-                        "use_rotary_embeddings": True,
-                        "attention": {
-                            "name": self.hparams.attention,
-                            "dropout": self.hparams.attn_pdrop,
-                            "causal": True,
-                            "seq_len": self.hparams.block_size,
-                        },
-                    },
-                    "feedforward_config": {
-                        "name": "FusedMLP",  # Use MLP if Triton is not available
-                        "dropout": self.hparams.mlp_pdrop,
-                        "activation": "gelu",
-                        "hidden_layer_multiplier": self.hparams.hidden_layer_multiplier,
-                    },
+                },
+                "feedforward_config": {
+                    "name": "FusedMLP",  # Use MLP if Triton is not available
+                    "dropout": self.hparams.mlp_pdrop,
+                    "activation": "gelu",
+                    "hidden_layer_multiplier": self.hparams.hidden_layer_multiplier,
                 },
             }
         ]

--- a/examples/microViT.py
+++ b/examples/microViT.py
@@ -64,30 +64,29 @@ class VisionTransformer(pl.LightningModule):
         xformer_config = [
             {
                 "reversible": False,  # Turn on to test the effect of using reversible layers
-                "block_config": {
-                    "block_type": "encoder",
-                    "num_layers": n_layer,
-                    "dim_model": dim,
-                    "seq_len": num_patches,
-                    "layer_norm_style": "pre",
-                    "multi_head_config": {
-                        "num_heads": n_head,
-                        "residual_dropout": resid_pdrop,
-                        "use_rotary_embeddings": True,
-                        "attention": {
-                            "name": attention,
-                            "dropout": attn_pdrop,
-                            "causal": False,
-                        },
-                    },
-                    "feedforward_config": {
-                        "name": "FusedMLP",  # Use MLP if Triton is not available
-                        "dropout": mlp_pdrop,
-                        "activation": "gelu",
-                        "hidden_layer_multiplier": hidden_layer_multiplier,
+                "block_type": "encoder",
+                "num_layers": n_layer,
+                "dim_model": dim,
+                "seq_len": num_patches,
+                "layer_norm_style": "pre",
+                "multi_head_config": {
+                    "num_heads": n_head,
+                    "residual_dropout": resid_pdrop,
+                    "use_rotary_embeddings": True,
+                    "attention": {
+                        "name": attention,
+                        "dropout": attn_pdrop,
+                        "causal": False,
                     },
                 },
+                "feedforward_config": {
+                    "name": "FusedMLP",
+                    "dropout": mlp_pdrop,
+                    "activation": "gelu",
+                    "hidden_layer_multiplier": hidden_layer_multiplier,
+                },
             }
+            
         ]
 
         config = xFormerConfig(xformer_config)

--- a/examples/microViT.py
+++ b/examples/microViT.py
@@ -86,7 +86,6 @@ class VisionTransformer(pl.LightningModule):
                     "hidden_layer_multiplier": hidden_layer_multiplier,
                 },
             }
-            
         ]
 
         config = xFormerConfig(xformer_config)

--- a/examples/microViT.py
+++ b/examples/microViT.py
@@ -67,7 +67,6 @@ class VisionTransformer(pl.LightningModule):
                 "block_type": "encoder",
                 "num_layers": n_layer,
                 "dim_model": dim,
-                "seq_len": num_patches,
                 "layer_norm_style": "pre",
                 "multi_head_config": {
                     "num_heads": n_head,

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,1 +1,2 @@
+hydra-core>1.1
 lightning-bolts

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,3 +16,6 @@ pytest-cov == 2.10.0
 pytest-mpi == 0.4
 pytest-timeout == 1.4.2
 timm >= 0.4.5
+
+# Dependency for factory
+hydra-core >= 1.1

--- a/tests/test_hydra_helper.py
+++ b/tests/test_hydra_helper.py
@@ -1,0 +1,14 @@
+from hydra.core.config_store import ConfigStore
+
+from xformers.factory.hydra_helper import import_xformer_config_schema
+
+
+def test_import_schema():
+    import_xformer_config_schema()
+    cs = ConfigStore.instance()
+    groups = cs.list("xformers")
+    # check all groups registered
+    assert groups == ["attention", "ff", "pe"]
+    # check the attention is registered
+    attentions = cs.list("xformers/attention")
+    assert "favor_schema.yaml" in attentions

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -23,77 +23,73 @@ test_configs = [
     [
         {
             "reversible": False,
-            "block_config": {
-                "block_type": "encoder",
-                "dim_model": 384,
-                "position_encoding_config": {
-                    "name": "vocab",
-                    "seq_len": SEQ,
-                    "vocab_size": 64,
-                    "dim_model": EMB,
-                },
-                "num_layers": 3,
-                "multi_head_config": {
-                    "num_heads": 4,
-                    "residual_dropout": 0,
-                    "attention": {
-                        "name": "linformer",
-                        "dropout": 0,
-                        "causal": True,
-                        "seq_len": 512,
-                    },
-                    "dim_model": EMB,
-                },
-                "feedforward_config": {
-                    "name": "MLP",
+            "block_type": "encoder",
+            "dim_model": 384,
+            "position_encoding_config": {
+                "name": "vocab",
+                "seq_len": SEQ,
+                "vocab_size": 64,
+                "dim_model": EMB,
+            },
+            "num_layers": 3,
+            "multi_head_config": {
+                "num_heads": 4,
+                "residual_dropout": 0,
+                "attention": {
+                    "name": "linformer",
                     "dropout": 0,
-                    "activation": "relu",
-                    "hidden_layer_multiplier": 4,
-                    "dim_model": EMB,
+                    "causal": True,
+                    "seq_len": 512,
                 },
+                "dim_model": EMB,
+            },
+            "feedforward_config": {
+                "name": "MLP",
+                "dropout": 0,
+                "activation": "relu",
+                "hidden_layer_multiplier": 4,
+                "dim_model": EMB,
             },
         },
         {
-            "block_config": {
-                "block_type": "decoder",
-                "dim_model": 384,
-                "position_encoding_config": {
-                    "name": "vocab",
-                    "seq_len": SEQ,
-                    "vocab_size": 64,
-                    "dim_model": EMB,
-                },
-                "num_layers": 2,
-                "multi_head_config_masked": {
-                    "num_heads": 4,
-                    "residual_dropout": 0,
-                    "dim_model": EMB,
-                    "attention": {
-                        "name": "linformer",
-                        "dropout": 0,
-                        "causal": True,
-                        "seq_len": 512,
-                    },
-                },
-                "multi_head_config_cross": {
-                    "num_heads": 4,
-                    "residual_dropout": 0,
-                    "dim_model": EMB,
-                    "attention": {
-                        "name": "linformer",
-                        "dropout": 0,
-                        "causal": True,
-                        "seq_len": 512,
-                    },
-                },
-                "feedforward_config": {
-                    "name": "MLP",
+            "block_type": "decoder",
+            "dim_model": 384,
+            "position_encoding_config": {
+                "name": "vocab",
+                "seq_len": SEQ,
+                "vocab_size": 64,
+                "dim_model": EMB,
+            },
+            "num_layers": 2,
+            "multi_head_config_masked": {
+                "num_heads": 4,
+                "residual_dropout": 0,
+                "dim_model": EMB,
+                "attention": {
+                    "name": "linformer",
                     "dropout": 0,
-                    "activation": "relu",
-                    "hidden_layer_multiplier": 4,
-                    "dim_model": EMB,
+                    "causal": True,
+                    "seq_len": 512,
                 },
-            }
+            },
+            "multi_head_config_cross": {
+                "num_heads": 4,
+                "residual_dropout": 0,
+                "dim_model": EMB,
+                "attention": {
+                    "name": "linformer",
+                    "dropout": 0,
+                    "causal": True,
+                    "seq_len": 512,
+                },
+            },
+            "feedforward_config": {
+                "name": "MLP",
+                "dropout": 0,
+                "activation": "relu",
+                "hidden_layer_multiplier": 4,
+                "dim_model": EMB,
+            },
         },
     ]
 ]

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -19,91 +19,94 @@ DEVICES = (
     ]  # save a bit on CI for now, we have seperate cpu and gpu jobs
 )
 
-test_configs = [
-    [
-        {
-            "reversible": False,
-            "block_type": "encoder",
-            "dim_model": 384,
-            "position_encoding_config": {
-                "name": "vocab",
-                "seq_len": SEQ,
-                "vocab_size": 64,
-                "dim_model": EMB,
-            },
-            "num_layers": 3,
-            "multi_head_config": {
-                "num_heads": 4,
-                "residual_dropout": 0,
-                "attention": {
-                    "name": "linformer",
-                    "dropout": 0,
-                    "causal": True,
-                    "seq_len": 512,
-                },
-                "dim_model": EMB,
-            },
-            "feedforward_config": {
-                "name": "MLP",
-                "dropout": 0,
-                "activation": "relu",
-                "hidden_layer_multiplier": 4,
-                "dim_model": EMB,
-            },
+encoder_configs = {
+    "reversible": False,
+    "block_type": "encoder",
+    "dim_model": 384,
+    "position_encoding_config": {
+        "name": "vocab",
+        "seq_len": SEQ,
+        "vocab_size": 64,
+        "dim_model": EMB,
+    },
+    "num_layers": 3,
+    "multi_head_config": {
+        "num_heads": 4,
+        "residual_dropout": 0,
+        "attention": {
+            "name": "linformer",
+            "dropout": 0,
+            "causal": True,
+            "seq_len": 512,
         },
-        {
-            "block_type": "decoder",
-            "dim_model": 384,
-            "position_encoding_config": {
-                "name": "vocab",
-                "seq_len": SEQ,
-                "vocab_size": 64,
-                "dim_model": EMB,
-            },
-            "num_layers": 2,
-            "multi_head_config_masked": {
-                "num_heads": 4,
-                "residual_dropout": 0,
-                "dim_model": EMB,
-                "attention": {
-                    "name": "linformer",
-                    "dropout": 0,
-                    "causal": True,
-                    "seq_len": 512,
-                },
-            },
-            "multi_head_config_cross": {
-                "num_heads": 4,
-                "residual_dropout": 0,
-                "dim_model": EMB,
-                "attention": {
-                    "name": "linformer",
-                    "dropout": 0,
-                    "causal": True,
-                    "seq_len": 512,
-                },
-            },
-            "feedforward_config": {
-                "name": "MLP",
-                "dropout": 0,
-                "activation": "relu",
-                "hidden_layer_multiplier": 4,
-                "dim_model": EMB,
-            },
-        },
-    ]
-]
+        "dim_model": EMB,
+    },
+    "feedforward_config": {
+        "name": "MLP",
+        "dropout": 0,
+        "activation": "relu",
+        "hidden_layer_multiplier": 4,
+        "dim_model": EMB,
+    },
+}
 
+decoder_configs = {
+    "block_type": "decoder",
+    "dim_model": 384,
+    "position_encoding_config": {
+        "name": "vocab",
+        "seq_len": SEQ,
+        "vocab_size": 64,
+        "dim_model": EMB,
+    },
+    "num_layers": 2,
+    "multi_head_config_masked": {
+        "num_heads": 4,
+        "residual_dropout": 0,
+        "dim_model": EMB,
+        "attention": {
+            "name": "linformer",
+            "dropout": 0,
+            "causal": True,
+            "seq_len": 512,
+        },
+    },
+    "multi_head_config_cross": {
+        "num_heads": 4,
+        "residual_dropout": 0,
+        "dim_model": EMB,
+        "attention": {
+            "name": "linformer",
+            "dropout": 0,
+            "causal": True,
+            "seq_len": 512,
+        },
+    },
+    "feedforward_config": {
+        "name": "MLP",
+        "dropout": 0,
+        "activation": "relu",
+        "hidden_layer_multiplier": 4,
+        "dim_model": EMB,
+    },
+}
+
+test_configs_list = [encoder_configs, decoder_configs]
+test_configs_dict = {"encoder": encoder_configs, "decoder": decoder_configs}
 
 """ Test all the model configurations saved in model_presets. """
 
 
-@pytest.mark.parametrize("config", test_configs)
+@pytest.mark.parametrize("config", [test_configs_list, test_configs_dict])
 @pytest.mark.parametrize("reversible", [True, False])
 @pytest.mark.parametrize("device", DEVICES)
 def test_presets(config, reversible, device):
     # Build the model
-    config[0]["reversible"] = reversible
+    if isinstance(config, list):
+        config[0]["reversible"] = reversible
+    else:
+        config["encoder"]["reversible"] = reversible
+
     model = xFormer.from_config(xFormerConfig(config)).to(device)
 
     # Dummy inputs, test a forward

--- a/tests/test_pytorch_transformer_parity.py
+++ b/tests/test_pytorch_transformer_parity.py
@@ -22,72 +22,68 @@ ACTIVATION = "relu"
 
 
 _test_config_encoder = {
-    "block_config": {
-        "block_type": "encoder",
-        "dim_model": EMB,
-        "num_layers": LAYERS,
-        "layer_norm_style": "post",
-        "multi_head_config": {
-            "num_heads": HEADS,
-            "residual_dropout": DROP,
-            "bias": True,
-            "attention": {
-                "name": "scaled_dot_product",
-                "dropout": DROP,
-                "causal": False,
-                "seq_len": SEQ,
-            },
-            "dim_model": EMB,
-        },
-        "feedforward_config": {
-            "name": "MLP",
+    "block_type": "encoder",
+    "dim_model": EMB,
+    "num_layers": LAYERS,
+    "layer_norm_style": "post",
+    "multi_head_config": {
+        "num_heads": HEADS,
+        "residual_dropout": DROP,
+        "bias": True,
+        "attention": {
+            "name": "scaled_dot_product",
             "dropout": DROP,
-            "activation": ACTIVATION,
-            "hidden_layer_multiplier": 4,
-            "dim_model": EMB,
+            "causal": False,
+            "seq_len": SEQ,
         },
+        "dim_model": EMB,
+    },
+    "feedforward_config": {
+        "name": "MLP",
+        "dropout": DROP,
+        "activation": ACTIVATION,
+        "hidden_layer_multiplier": 4,
+        "dim_model": EMB,
     },
 }
 
 
 _test_config_decoder = {
-    "block_config": {
-        "block_type": "decoder",
+    "block_type": "decoder",
+    "dim_model": EMB,
+    "num_layers": LAYERS,
+    "layer_norm_style": "post",
+    "multi_head_config_masked": {
+        "num_heads": HEADS,
+        "residual_dropout": DROP,
         "dim_model": EMB,
-        "num_layers": LAYERS,
-        "layer_norm_style": "post",
-        "multi_head_config_masked": {
-            "num_heads": HEADS,
-            "residual_dropout": DROP,
-            "dim_model": EMB,
-            "bias": True,
-            "attention": {
-                "name": "scaled_dot_product",
-                "dropout": DROP,
-                "causal": False,
-                "seq_len": SEQ,
-            },
-        },
-        "multi_head_config_cross": {
-            "num_heads": HEADS,
-            "residual_dropout": DROP,
-            "dim_model": EMB,
-            "bias": True,
-            "attention": {
-                "name": "scaled_dot_product",
-                "dropout": DROP,
-                "causal": False,
-                "seq_len": SEQ,
-            },
-        },
-        "feedforward_config": {
-            "name": "MLP",
+        "bias": True,
+        "attention": {
+            "name": "scaled_dot_product",
             "dropout": DROP,
-            "activation": ACTIVATION,
-            "hidden_layer_multiplier": 4,
-            "dim_model": EMB,
+            "causal": False,
+            "seq_len": SEQ,
         },
-    }
+    },
+    "multi_head_config_cross": {
+        "num_heads": HEADS,
+        "residual_dropout": DROP,
+        "dim_model": EMB,
+        "bias": True,
+        "attention": {
+            "name": "scaled_dot_product",
+            "dropout": DROP,
+            "causal": False,
+            "seq_len": SEQ,
+        },
+    },
+    "feedforward_config": {
+        "name": "MLP",
+        "dropout": DROP,
+        "activation": ACTIVATION,
+        "hidden_layer_multiplier": 4,
+        "dim_model": EMB,
+    },
 }
 
 _test_config = [_test_config_encoder, _test_config_decoder]

--- a/tests/test_reversible.py
+++ b/tests/test_reversible.py
@@ -22,77 +22,73 @@ DEVICES = (
 
 _test_config_encoder = {
     "reversible": False,
-    "block_config": {
-        "block_type": "encoder",
+    "block_type": "encoder",
+    "dim_model": EMB,
+    "position_encoding_config": {
+        "name": "vocab",
+        "seq_len": SEQ,
+        "vocab_size": VOCAB,
         "dim_model": EMB,
-        "position_encoding_config": {
-            "name": "vocab",
-            "seq_len": SEQ,
-            "vocab_size": VOCAB,
-            "dim_model": EMB,
-        },
-        "num_layers": 3,
-        "multi_head_config": {
-            "num_heads": 4,
-            "residual_dropout": 0,
-            "attention": {
-                "name": "linformer",
-                "dropout": 0,
-                "causal": True,
-                "seq_len": SEQ,
-            },
-            "dim_model": EMB,
-        },
-        "feedforward_config": {
-            "name": "MLP",
+    },
+    "num_layers": 3,
+    "multi_head_config": {
+        "num_heads": 4,
+        "residual_dropout": 0,
+        "attention": {
+            "name": "linformer",
             "dropout": 0,
-            "activation": "relu",
-            "hidden_layer_multiplier": 4,
-            "dim_model": EMB,
+            "causal": True,
+            "seq_len": SEQ,
         },
+        "dim_model": EMB,
+    },
+    "feedforward_config": {
+        "name": "MLP",
+        "dropout": 0,
+        "activation": "relu",
+        "hidden_layer_multiplier": 4,
+        "dim_model": EMB,
     },
 }
 
 _test_config_decoder = {
-    "block_config": {
-        "block_type": "decoder",
+    "block_type": "decoder",
+    "dim_model": EMB,
+    "position_encoding_config": {
+        "name": "vocab",
+        "seq_len": SEQ,
+        "vocab_size": VOCAB,
         "dim_model": EMB,
-        "position_encoding_config": {
-            "name": "vocab",
-            "seq_len": SEQ,
-            "vocab_size": VOCAB,
-            "dim_model": EMB,
-        },
-        "num_layers": 2,
-        "multi_head_config_masked": {
-            "num_heads": 4,
-            "residual_dropout": 0,
-            "dim_model": EMB,
-            "attention": {
-                "name": "linformer",
-                "dropout": 0,
-                "causal": True,
-                "seq_len": SEQ,
-            },
-        },
-        "multi_head_config_cross": {
-            "num_heads": 4,
-            "residual_dropout": 0,
-            "dim_model": EMB,
-            "attention": {
-                "name": "linformer",
-                "dropout": 0,
-                "causal": True,
-                "seq_len": SEQ,
-            },
-        },
-        "feedforward_config": {
-            "name": "MLP",
+    },
+    "num_layers": 2,
+    "multi_head_config_masked": {
+        "num_heads": 4,
+        "residual_dropout": 0,
+        "dim_model": EMB,
+        "attention": {
+            "name": "linformer",
             "dropout": 0,
-            "activation": "relu",
-            "hidden_layer_multiplier": 4,
-            "dim_model": EMB,
+            "causal": True,
+            "seq_len": SEQ,
         },
+    },
+    "multi_head_config_cross": {
+        "num_heads": 4,
+        "residual_dropout": 0,
+        "dim_model": EMB,
+        "attention": {
+            "name": "linformer",
+            "dropout": 0,
+            "causal": True,
+            "seq_len": SEQ,
+        },
+    },
+    "feedforward_config": {
+        "name": "MLP",
+        "dropout": 0,
+        "activation": "relu",
+        "hidden_layer_multiplier": 4,
+        "dim_model": EMB,
     },
 }
 
@@ -105,7 +101,7 @@ _test_configs = [
 
 def _rev_config(config, flag: bool):
     for c in filter(
-        lambda x: x["block_config"]["block_type"] == "encoder",
+        lambda x: x["block_type"] == "encoder",
         config,
     ):
         c["reversible"] = flag

--- a/xformers/benchmarks/LRA/code/config.json
+++ b/xformers/benchmarks/LRA/code/config.json
@@ -30,25 +30,23 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 4,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 4
+                    "block_type": "encoder",
+                    "num_layers": 4,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 4
                     }
                 }
             ]
@@ -97,25 +95,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -164,25 +160,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -226,25 +220,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -293,25 +285,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],

--- a/xformers/benchmarks/LRA/code/config_nystrom.json
+++ b/xformers/benchmarks/LRA/code/config_nystrom.json
@@ -31,27 +31,26 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
+            
             ],
             "extra_settings": {
                 "attention": {
@@ -108,25 +107,23 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -183,27 +180,26 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "pre",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "pre",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
+            
             ],
             "extra_settings": {
                 "attention": {
@@ -253,25 +249,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -320,25 +314,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],

--- a/xformers/benchmarks/LRA/code/config_orig_lra.json
+++ b/xformers/benchmarks/LRA/code/config_orig_lra.json
@@ -31,25 +31,23 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 4,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 4
+                    "block_type": "encoder",
+                    "num_layers": 4,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 4
                     }
                 }
             ],
@@ -102,25 +100,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -169,25 +165,23 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 4,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 4
+                    "block_type": "encoder",
+                    "num_layers": 4,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 4
                     }
                 }
             ],
@@ -235,25 +229,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -302,25 +294,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],

--- a/xformers/benchmarks/LRA/code/config_orig_lra_paper.json
+++ b/xformers/benchmarks/LRA/code/config_orig_lra_paper.json
@@ -31,25 +31,23 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 6,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 4
+                    "block_type": "encoder",
+                    "num_layers": 6,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 4
                     }
                 }
             ]
@@ -98,25 +96,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -165,25 +161,23 @@
             "xformer": [
                 {
                     "reversible": false,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 4,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 4
+                    "block_type": "encoder",
+                    "num_layers": 4,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 4
                     }
                 }
             ],
@@ -227,25 +221,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],
@@ -294,25 +286,23 @@
             "xformer": [
                 {
                     "reversible": true,
-                    "block_config": {
-                        "block_type": "encoder",
-                        "num_layers": 2,
-                        "layer_norm_style": "post",
-                        "position_encoding_config": {
-                            "name": "vocab"
-                        },
-                        "multi_head_config": {
-                            "residual_dropout": 0.1,
-                            "attention": {
-                                "name": "generic",
-                                "causal": false
-                            }
-                        },
-                        "feedforward_config": {
-                            "name": "MLP",
-                            "activation": "gelu",
-                            "hidden_layer_multiplier": 2
+                    "block_type": "encoder",
+                    "num_layers": 2,
+                    "layer_norm_style": "post",
+                    "position_encoding_config": {
+                        "name": "vocab"
+                    },
+                    "multi_head_config": {
+                        "residual_dropout": 0.1,
+                        "attention": {
+                            "name": "generic",
+                            "causal": false
                         }
+                    },
+                    "feedforward_config": {
+                        "name": "MLP",
+                        "activation": "gelu",
+                        "hidden_layer_multiplier": 2
                     }
                 }
             ],

--- a/xformers/benchmarks/LRA/code/model_wrapper.py
+++ b/xformers/benchmarks/LRA/code/model_wrapper.py
@@ -52,8 +52,7 @@ def patch_model_config(config, attention_name):
     except KeyError:
         extra_attention_settings = None
 
-    for b in config["xformer"]:
-        bc = b["block_config"]
+    for bc in config["xformer"]:
         bc["dim_model"] = commons["dim_model"]
         bc["position_encoding_config"].update(commons)
         bc["feedforward_config"].update(commons)
@@ -129,7 +128,7 @@ class ModelTrunk(nn.Module):
         self.model = xFormer.from_config(xFormerConfig(config_model["xformer"]))
         self.norm = nn.LayerNorm(self.config_model["common"]["dim_model"])
 
-        ff_config = self.config_model["xformer"][0]["block_config"][
+        ff_config = self.config_model["xformer"][0][
             "feedforward_config"
         ]
         self.dim_mlp = (

--- a/xformers/benchmarks/LRA/code/model_wrapper.py
+++ b/xformers/benchmarks/LRA/code/model_wrapper.py
@@ -128,9 +128,7 @@ class ModelTrunk(nn.Module):
         self.model = xFormer.from_config(xFormerConfig(config_model["xformer"]))
         self.norm = nn.LayerNorm(self.config_model["common"]["dim_model"])
 
-        ff_config = self.config_model["xformer"][0][
-            "feedforward_config"
-        ]
+        ff_config = self.config_model["xformer"][0]["feedforward_config"]
         self.dim_mlp = (
             self.config_model["common"]["dim_model"]
             * ff_config["hidden_layer_multiplier"]

--- a/xformers/benchmarks/benchmark_pytorch_transformer.py
+++ b/xformers/benchmarks/benchmark_pytorch_transformer.py
@@ -138,7 +138,6 @@ def bench_pytorch_encoder(
                             "dim_model": emb,
                         },
                     },
-
                 ]
             )
         ).to(device)

--- a/xformers/benchmarks/benchmark_pytorch_transformer.py
+++ b/xformers/benchmarks/benchmark_pytorch_transformer.py
@@ -113,33 +113,32 @@ def bench_pytorch_encoder(
             xFormerConfig(
                 [
                     {
-                        "block_config": {
-                            "block_type": "encoder",
-                            "dim_model": emb,
-                            "num_layers": layers,
-                            "layer_norm_style": "post",
-                            "multi_head_config": {
-                                "num_heads": n_heads,
-                                "residual_dropout": dropout,
-                                "use_separate_proj_weight": True,
-                                "bias": True,
-                                "attention": {
-                                    "name": "scaled_dot_product",
-                                    "dropout": dropout,
-                                    "causal": False,
-                                    "seq_len": seq,
-                                },
-                                "dim_model": emb,
-                            },
-                            "feedforward_config": {
-                                "name": "FusedMLP",
+                        "block_type": "encoder",
+                        "dim_model": emb,
+                        "num_layers": layers,
+                        "layer_norm_style": "post",
+                        "multi_head_config": {
+                            "num_heads": n_heads,
+                            "residual_dropout": dropout,
+                            "use_separate_proj_weight": True,
+                            "bias": True,
+                            "attention": {
+                                "name": "scaled_dot_product",
                                 "dropout": dropout,
-                                "activation": activation,
-                                "hidden_layer_multiplier": 4,
-                                "dim_model": emb,
+                                "causal": False,
+                                "seq_len": seq,
                             },
+                            "dim_model": emb,
                         },
-                    }
+                        "feedforward_config": {
+                            "name": "FusedMLP",
+                            "dropout": dropout,
+                            "activation": activation,
+                            "hidden_layer_multiplier": 4,
+                            "dim_model": emb,
+                        },
+                    },
+
                 ]
             )
         ).to(device)

--- a/xformers/components/__init__.py
+++ b/xformers/components/__init__.py
@@ -46,7 +46,10 @@ def build_multi_head_attention(
                     "num_heads"
                 ]
 
-            if "dim_features" not in multi_head_config["attention"]:
+            if (
+                "dim_features" not in multi_head_config["attention"]
+                or multi_head_config["attention"]["dim_features"] is None
+            ):
                 multi_head_config["attention"]["dim_features"] = (
                     multi_head_config["dim_model"] // multi_head_config["num_heads"]
                 )

--- a/xformers/components/attention/local.py
+++ b/xformers/components/attention/local.py
@@ -26,9 +26,9 @@ from xformers.components.attention.core import scaled_dot_product_attention
 
 @dataclass
 class LocalAttentionConfig(AttentionConfig):
-    causal: Optional[bool]
-    window_size: Optional[int]
-    force_sparsity: Optional[bool]
+    causal: Optional[bool] = None
+    window_size: Optional[int] = None
+    force_sparsity: Optional[bool] = None
 
 
 @register_attention("local", LocalAttentionConfig)

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -151,7 +151,7 @@ class xFormerEncoderConfig(xFormerBlockConfig):
         position_encoding_config: Optional[Dict[str, Any]] = None,
         layer_norm_style: str = "post",
         use_triton: bool = True,
-        **_,
+        **kwargs,
     ):
         # Convenience, fill in duplicated field
         try:
@@ -170,13 +170,15 @@ class xFormerEncoderConfig(xFormerBlockConfig):
         except AttributeError:
             # A config instance was passed in, this is fine
             pass
-
+        if "block_type" in kwargs:
+            assert kwargs["block_type"] == "encoder"
+        kwargs["block_type"] = BlockType("encoder")
         super().__init__(
             dim_model=dim_model,
             feedforward_config=feedforward_config,
             position_encoding_config=position_encoding_config,
             layer_norm_style=LayerNormStyle(layer_norm_style),
-            block_type=BlockType("encoder"),
+            **kwargs,
         )
 
         self.multi_head_config = multi_head_config
@@ -197,7 +199,7 @@ class xFormerDecoderConfig(xFormerBlockConfig):
         position_encoding_config: Optional[Dict[str, Any]] = None,
         layer_norm_style: str = "post",
         use_triton: bool = True,
-        **_,
+        **kwargs,
     ):
 
         # Convenience, fill in duplicated field
@@ -219,13 +221,16 @@ class xFormerDecoderConfig(xFormerBlockConfig):
         except AttributeError:
             # A config instance was passed in, this is fine
             pass
+        if "block_type" in kwargs.keys():
+            assert kwargs["block_type"] == "decoder"
+        kwargs["block_type"] = BlockType("decoder")
 
         super().__init__(
             dim_model=dim_model,
             feedforward_config=feedforward_config,
             position_encoding_config=position_encoding_config,
             layer_norm_style=LayerNormStyle(layer_norm_style),
-            block_type=BlockType("decoder"),
+            **kwargs,
         )
 
         self.multi_head_config_masked = multi_head_config_masked

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -100,7 +100,7 @@ class xFormerBlockConfig:
     layer_norm_style: LayerNormStyle
     layer_position: LayerPosition
     use_triton: bool
-    reversible: bool 
+    reversible: bool
     num_layers: int
 
     def __init__(

--- a/xformers/factory/hydra_helper.py
+++ b/xformers/factory/hydra_helper.py
@@ -1,11 +1,15 @@
 # register components configs into Hydra ConfigStore
 # component config classes could be used to validate configs
+import logging
+
 from hydra.core.config_store import ConfigStore
 from omegaconf.errors import ValidationError
 
 from xformers.components.attention import ATTENTION_REGISTRY
 from xformers.components.feedforward import FEEDFORWARD_REGISTRY
 from xformers.components.positional_embedding import POSITION_EMBEDDING_REGISTRY
+
+log = logging.getLogger(__name__)
 
 
 def import_xformer_config_schema():
@@ -24,4 +28,4 @@ def import_xformer_config_schema():
             try:
                 cs.store(name=f"{kk}_schema", node=v[kk].config, group=f"xformers/{k}")
             except ValidationError as e:
-                print(f"Error registering {kk}_schema, error: {e}")
+                log.debug(f"Error registering {kk}_schema, error: {e}")

--- a/xformers/factory/hydra_helper.py
+++ b/xformers/factory/hydra_helper.py
@@ -1,0 +1,27 @@
+# register components configs into Hydra ConfigStore
+# component config classes could be used to validate configs
+from hydra.core.config_store import ConfigStore
+from omegaconf.errors import ValidationError
+
+from xformers.components.attention import ATTENTION_REGISTRY
+from xformers.components.feedforward import FEEDFORWARD_REGISTRY
+from xformers.components.positional_embedding import POSITION_EMBEDDING_REGISTRY
+
+
+def import_xformer_config_schema():
+    """
+    Best effort - OmegaConf supports limited typing, so we may fail to import
+    certain config classes. For example, pytorch typing are not supported.
+    """
+    cs = ConfigStore.instance()
+
+    for k, v in {
+        "ff": FEEDFORWARD_REGISTRY,
+        "pe": POSITION_EMBEDDING_REGISTRY,
+        "attention": ATTENTION_REGISTRY,
+    }.items():
+        for kk in v.keys():
+            try:
+                cs.store(name=f"{kk}_schema", node=v[kk].config, group=f"xformers/{k}")
+            except ValidationError as e:
+                print(f"Error registering {kk}_schema, error: {e}")

--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -29,7 +29,7 @@ class xFormerConfig:
         for config in stack_configs:
             if config["block_type"] == "encoder":
                 self.stack_configs.append(xFormerEncoderConfig(**config))
-            else: 
+            else:
                 self.stack_configs.append(xFormerDecoderConfig(**config))
         # Check that the reversible setting is not alternating, which
         # - makes little sense, since you loose all the reversible benefits

--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -127,6 +127,7 @@ class xFormer(torch.nn.Module):
     ):
         if isinstance(stack_configs, xFormerBlockConfig):
             stack_configs = [stack_configs]
+
         reversible = [
             c.reversible
             for c in filter(lambda x: x.block_type == "encoder", stack_configs)


### PR DESCRIPTION
address the feedback in https://github.com/facebookresearch/xformers/pull/59

from a higher level
1. move hydra dependency to be  optional
2. refactor the model factory, mainly removed the StackConfig to make the config a bit simplified.

### see the final config
```
python examples/build_model/my_model.py --cfg job
```

<details><summary>output</summary>

```
xformer:
  stack_configs:
    encoder_local:
      _target_: xformers.factory.block_factory.xFormerEncoderConfig
      reversible: false
      num_layers: 4
      user_triton: true
      dim_model: ${emb}
      layer_norm_style: pre
      position_encoding_config:
        name: vocab
        seq_len: 1024
        vocab_size: ${vocab}
        dropout: 0
      multi_head_config:
        num_heads: 4
        residual_dropout: 0
        attention:
          name: local
          dropout: 0.0
          causal: null
          window_size: null
          force_sparsity: null
      feedforward_config:
        name: MLP
        dropout: 0
        activation: relu
        hidden_layer_multiplier: 4
    encoder_random:
      _target_: xformers.factory.block_factory.xFormerEncoderConfig
      reversible: false
      num_layers: 4
      user_triton: true
      dim_model: ${emb}
      layer_norm_style: pre
      position_encoding_config:
        name: vocab
        seq_len: 1024
        vocab_size: ${vocab}
        dropout: 0
      multi_head_config:
        num_heads: 4
        residual_dropout: 0
        attention:
          name: random
          dropout: 0.0
          r: 0.01
          constant_masking: true
          force_sparsity: false
      feedforward_config:
        name: MLP
        dropout: 0
        activation: relu
        hidden_layer_multiplier: 4
    decoder_nystrom_favor:
      _target_: xformers.factory.block_factory.xFormerDecoderConfig
      reversible: false
      num_layers: 3
      block_type: decoder
      dim_model: ${emb}
      layer_norm_style: pre
      position_encoding_config:
        name: vocab
        seq_len: ${seq}
        vocab_size: ${vocab}
        dropout: 0
      multi_head_config_masked:
        num_heads: 4
        residual_dropout: 0
        attention:
          name: nystrom
          dropout: 0
          causal: true
          seq_len: ${seq}
      multi_head_config_cross:
        num_heads: 4
        residual_dropout: 0
        attention:
          name: favor
          dropout: 0.0
          dim_features: null
          dim_head: null
          iter_before_redraw: null
          feature_map: null
      feedforward_config:
        name: MLP
        dropout: 0
        activation: relu
        hidden_layer_multiplier: 4
  _target_: xformers.factory.model_factory.xFormer
emb: 384
seq: 1024
vocab: 64
```
</details>

### model built
```
python examples/build_model/my_model.py
```
<details><summary>output</summary>

```
xFormer(
  (encoders): ModuleList(
    (0): xFormerEncoderBlock(
      (pose_encoding): VocabEmbedding(
        (dropout): Dropout(p=0, inplace=False)
        (position_embeddings): Embedding(1024, 384)
        (word_embeddings): Embedding(64, 384)
      )
      (mha): MultiHeadDispatch(
        (attention): LocalAttention(
          (attn_drop): Dropout(p=0.0, inplace=False)
        )
        (in_proj_container): InProjContainer()
        (resid_drop): Dropout(p=0, inplace=False)
        (proj): Linear(in_features=384, out_features=384, bias=True)
      )
      (feedforward): MLP(
        (mlp): Sequential(
          (0): Linear(in_features=384, out_features=1536, bias=True)
          (1): ReLU()
          (2): Dropout(p=0, inplace=False)
          (3): Linear(in_features=1536, out_features=384, bias=True)
          (4): Dropout(p=0, inplace=False)
        )
      )
      (wrap_att): Residual(
        (layer): PreNorm(
          (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
          (sublayer): MultiHeadDispatch(
            (attention): LocalAttention(
              (attn_drop): Dropout(p=0.0, inplace=False)
            )
            (in_proj_container): InProjContainer()
            (resid_drop): Dropout(p=0, inplace=False)
            (proj): Linear(in_features=384, out_features=384, bias=True)
          )
        )
      )
      (wrap_ff): PostNorm(
        (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
        (sublayer): Residual(
          (layer): PreNorm(
            (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
            (sublayer): MLP(
              (mlp): Sequential(
                (0): Linear(in_features=384, out_features=1536, bias=True)
                (1): ReLU()
                (2): Dropout(p=0, inplace=False)
                (3): Linear(in_features=1536, out_features=384, bias=True)
                (4): Dropout(p=0, inplace=False)
              )
            )
          )
        )
      )
    )
    (1): xFormerEncoderBlock(
      (pose_encoding): VocabEmbedding(
        (dropout): Dropout(p=0, inplace=False)
        (position_embeddings): Embedding(1024, 384)
        (word_embeddings): Embedding(64, 384)
      )
      (mha): MultiHeadDispatch(
        (attention): RandomAttention(
          (attn_drop): Dropout(p=0.0, inplace=False)
        )
        (in_proj_container): InProjContainer()
        (resid_drop): Dropout(p=0, inplace=False)
        (proj): Linear(in_features=384, out_features=384, bias=True)
      )
      (feedforward): MLP(
        (mlp): Sequential(
          (0): Linear(in_features=384, out_features=1536, bias=True)
          (1): ReLU()
          (2): Dropout(p=0, inplace=False)
          (3): Linear(in_features=1536, out_features=384, bias=True)
          (4): Dropout(p=0, inplace=False)
        )
      )
      (wrap_att): Residual(
        (layer): PreNorm(
          (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
          (sublayer): MultiHeadDispatch(
            (attention): RandomAttention(
              (attn_drop): Dropout(p=0.0, inplace=False)
            )
            (in_proj_container): InProjContainer()
            (resid_drop): Dropout(p=0, inplace=False)
            (proj): Linear(in_features=384, out_features=384, bias=True)
          )
        )
      )
      (wrap_ff): PostNorm(
        (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
        (sublayer): Residual(
          (layer): PreNorm(
            (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
            (sublayer): MLP(
              (mlp): Sequential(
                (0): Linear(in_features=384, out_features=1536, bias=True)
                (1): ReLU()
                (2): Dropout(p=0, inplace=False)
                (3): Linear(in_features=1536, out_features=384, bias=True)
                (4): Dropout(p=0, inplace=False)
              )
            )
          )
        )
      )
    )
  )
  (decoders): ModuleList(
    (0): xFormerDecoderBlock(
      (pose_encoding): VocabEmbedding(
        (dropout): Dropout(p=0, inplace=False)
        (position_embeddings): Embedding(1024, 384)
        (word_embeddings): Embedding(64, 384)
      )
      (mha): MultiHeadDispatch(
        (attention): NystromAttention(
          (attn_drop): Dropout(p=0, inplace=False)
        )
        (in_proj_container): InProjContainer()
        (resid_drop): Dropout(p=0, inplace=False)
        (proj): Linear(in_features=384, out_features=384, bias=True)
      )
      (cross_mha): MultiHeadDispatch(
        (attention): FavorAttention(
          (attn_drop): Dropout(p=0.0, inplace=True)
          (feature_map_query): SMReg()
          (feature_map_key): SMReg()
        )
        (in_proj_container): InProjContainer()
        (resid_drop): Dropout(p=0, inplace=False)
        (proj): Linear(in_features=384, out_features=384, bias=True)
      )
      (feedforward): MLP(
        (mlp): Sequential(
          (0): Linear(in_features=384, out_features=1536, bias=True)
          (1): ReLU()
          (2): Dropout(p=0, inplace=False)
          (3): Linear(in_features=1536, out_features=384, bias=True)
          (4): Dropout(p=0, inplace=False)
        )
      )
      (wrap_att): Residual(
        (layer): PreNorm(
          (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
          (sublayer): MultiHeadDispatch(
            (attention): NystromAttention(
              (attn_drop): Dropout(p=0, inplace=False)
            )
            (in_proj_container): InProjContainer()
            (resid_drop): Dropout(p=0, inplace=False)
            (proj): Linear(in_features=384, out_features=384, bias=True)
          )
        )
      )
      (wrap_cross): Residual(
        (layer): PreNorm(
          (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
          (sublayer): MultiHeadDispatch(
            (attention): FavorAttention(
              (attn_drop): Dropout(p=0.0, inplace=True)
              (feature_map_query): SMReg()
              (feature_map_key): SMReg()
            )
            (in_proj_container): InProjContainer()
            (resid_drop): Dropout(p=0, inplace=False)
            (proj): Linear(in_features=384, out_features=384, bias=True)
          )
        )
      )
      (wrap_ff): PostNorm(
        (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
        (sublayer): Residual(
          (layer): PreNorm(
            (norm): LayerNorm((384,), eps=1e-05, elementwise_affine=True)
            (sublayer): MLP(
              (mlp): Sequential(
                (0): Linear(in_features=384, out_features=1536, bias=True)
                (1): ReLU()
                (2): Dropout(p=0, inplace=False)
                (3): Linear(in_features=1536, out_features=384, bias=True)
                (4): Dropout(p=0, inplace=False)
              )
            )
          )
        )
      )
    )
  )
)
```

</details>
