### PR TITLE
[minor] softfail if the triton installation is broken

### DIFF
--- a/xformers/triton/layer_norm.py
+++ b/xformers/triton/layer_norm.py
@@ -6,12 +6,16 @@
 # CREDITS: the underlying kernel comes straight from the Triton tutorials
 # see https://github.com/openai/triton/blob/master/python/tutorials/05-layer-norm.py
 
+import logging
 from typing import Optional
 
 import torch
 import torch.nn as nn
+import triton
 
 from xformers.triton.k_layer_norm import _LayerNorm
+
+_triton_registered_warnings = False
 
 
 class FusedLayerNorm(nn.Module):
@@ -38,7 +42,7 @@ class FusedLayerNorm(nn.Module):
         self.epsilon = eps
 
     def forward(self, x):
-        return _LayerNorm.apply(x, self.weight, self.bias, self.epsilon)
+        return layer_norm(x, self.weight, self.bias, self.epsilon)
 
 
 def layer_norm(
@@ -48,15 +52,29 @@ def layer_norm(
     bias: Optional[torch.Tensor] = None,
     eps: float = 1e-05,
 ) -> torch.Tensor:
+
+    global _triton_registered_warnings
+
     r"""Applies normalization over a mini batch of inputs"""
 
-    if (
-        torch.cuda.is_available()
-        and x.is_cuda
-        and weight is not None
-        and bias is not None
-    ):
-        return _LayerNorm.apply(x, normalized_shape, weight, bias, eps)
+    try:
+        if (
+            not _triton_registered_warnings
+            and torch.cuda.is_available()
+            and x.is_cuda
+            and weight is not None
+            and bias is not None
+        ):
+            return _LayerNorm.apply(x, normalized_shape, weight, bias, eps)
+    except (triton.code_gen.OutOfResources, RuntimeError) as e:
+        # Catch cases where the current GPU does not have enough registers to hold a full tensor line
+        # fallback to PyTorch's implementation, which streams the tensor in and out
+        _triton_registered_warnings = True
+        logging.warning(
+            "Triton layernorm kernel register spillover or invalid image caught. "
+            "Deactivating this kernel, please file an issue int the xFormers repository"
+        )
+        logging.warning(e)
 
     return torch.nn.functional.layer_norm(
         x, normalized_shape, weight=weight, bias=bias, eps=eps


### PR DESCRIPTION
## What does this PR do?
Catch a case where the Triton install is broken (because the cuda install is broken), fallback to pytorch
Been told from @SeanNaren that this was useful (we already do this for the fused softmax)

## Before submitting
- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
