### PR TITLE
[bugfix] Favor + fp16

### DIFF
--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -28,7 +28,7 @@ class GPT(pl.LightningModule):
         vocab_size,
         weight_decay=0.1,
         betas=(0.9, 0.95),
-        learning_rate=6e-4,
+        learning_rate=1e-4,
         n_embd=512,
         block_size=128,
         n_layer=4,

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -298,7 +298,7 @@ if __name__ == "__main__":
     model = GPT(
         vocab_size=train_dataset.vocab_size,
         block_size=train_dataset.block_size,
-        attention="nystrom",
+        attention="favor",
         warmup_tokens=REF_BATCH * WARMUP,
         final_tokens=EPOCHS * len(train_dataset) * BLOCK,
     )
@@ -310,7 +310,7 @@ if __name__ == "__main__":
         precision=16,
         gradient_clip_val=1,
         log_every_n_steps=1,
-        terminate_on_nan=True,
+        detect_anomaly=True,
         accumulate_grad_batches=REF_BATCH // BATCH,
     )
 

--- a/xformers/components/attention/favor.py
+++ b/xformers/components/attention/favor.py
@@ -10,6 +10,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
+from torch.cuda.amp import autocast
 
 from xformers.components.attention import Attention, AttentionConfig, register_attention
 from xformers.components.attention.feature_maps import (
@@ -100,6 +101,11 @@ class FavorAttention(Attention):
         self.feature_map_key: FeatureMap = feature_map_constructor(**feature_settings)  # type: ignore
 
     @staticmethod
+    def _maybe_promote(x: torch.Tensor) -> torch.Tensor:
+        # Only promote fp16 buffers, bfloat16 would be fine for instance
+        return x.float() if x.dtype == torch.float16 else x
+
+    @staticmethod
     def _causal_attention(
         k_prime: torch.Tensor, q_prime: torch.Tensor, v: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -123,18 +129,6 @@ class FavorAttention(Attention):
 
         return torch.cat(att_raw, dim=1), torch.cat(att_norm, dim=1)
 
-    @staticmethod
-    def _maybe_ceil_fp16(x: torch.Tensor) -> torch.Tensor:
-        """Handle fp16 limited dynamic range.
-        In this particular case (when this method is called),
-        we assume that inf can safely be capped with fp16 real max value (65504)"""
-
-        if not x.dtype == torch.float16:
-            return x
-
-        cap_value = 65504.0  # float16 actual max value
-        return torch.where(torch.isinf(x), torch.ones_like(x) * cap_value, x)
-
     def forward(
         self,
         q: torch.Tensor,
@@ -148,24 +142,24 @@ class FavorAttention(Attention):
         k_prime = self.feature_map_key(k)
         q_prime = self.feature_map_query(q)
 
-        if not self.causal:
-            att_normalization = q_prime @ (
-                k_prime.transpose(-2, -1) @ torch.ones_like(v)
-            )
-            att_raw = q_prime @ (k_prime.transpose(-2, -1) @ v)
-        else:
-            # Actually compute attention
-            att_raw, att_normalization = self._causal_attention(k_prime, q_prime, v)
+        with autocast(enabled=False):
+            # The softmax kernel approximation for Favor will easily overflow
+            # Force the computations here to stay in fp32 for numerical stability
+            # Note that the dimensions are vastly reduced when compared to scaled_dot_product
+            k_prime = self._maybe_promote(k_prime)
+            q_prime = self._maybe_promote(q_prime)
 
-        # Catch overflow, this is technically fine
-        att_raw = self._maybe_ceil_fp16(att_raw)
-        att_normalization = self._maybe_ceil_fp16(att_normalization)
+            if not self.causal:
+                att_normalization = q_prime @ (
+                    k_prime.transpose(-2, -1) @ torch.ones_like(v)
+                )
+                att_raw = q_prime @ (k_prime.transpose(-2, -1) @ v)
+            else:
+                # Actually compute attention
+                att_raw, att_normalization = self._causal_attention(k_prime, q_prime, v)
 
-        # Normalize
-        att = att_raw / att_normalization
-
-        if torch.isnan(att).any() or torch.isinf(att).any():
-            exit(-1)
+            # Normalize
+            att = att_raw / att_normalization
 
         if self.attn_drop is not None:
             att = self.attn_drop(att)

--- a/xformers/components/attention/favor.py
+++ b/xformers/components/attention/favor.py
@@ -148,6 +148,7 @@ class FavorAttention(Attention):
             # Note that the dimensions are vastly reduced when compared to scaled_dot_product
             k_prime = self._maybe_promote(k_prime)
             q_prime = self._maybe_promote(q_prime)
+            v = self._maybe_promote(v)
 
             if not self.causal:
                 att_normalization = q_prime @ (

--- a/xformers/components/residual.py
+++ b/xformers/components/residual.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 # NOTE: The Triton layernorm can be activated/deactivated from here
-_is_triton_available = False and torch.cuda.is_available()
+_is_triton_available = torch.cuda.is_available()
 
 if _is_triton_available:
     try:

--- a/xformers/components/residual.py
+++ b/xformers/components/residual.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 # NOTE: The Triton layernorm can be activated/deactivated from here
-_is_triton_available = torch.cuda.is_available()
+_is_triton_available = False and torch.cuda.is_available()
 
 if _is_triton_available:
     try:


### PR DESCRIPTION
## What does this PR do?
Fixes #96
There was no bug per say, the Softmax approximation for Favor just requires a big dynamic range and the attention computation would overflow in fp16. I tested a couple of takes (limit the values a posteriori, catch inf etc..) but this would be ugly and break the backward graph, in the end keeping this nugget of computations in fp32 is the safest bet I think. Note that we only promote fp16 tensors, not bfloat16 for instance

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
