### PR TITLE
merge masks should return shape of attn mask

### DIFF
--- a/tests/test_attention_utils.py
+++ b/tests/test_attention_utils.py
@@ -31,7 +31,7 @@ def test_reshape_key_padding_mask():
         src_len=seq_len,
         num_heads=num_heads,
     )
-    assert torch.equal(merged_mask, reshaped_mask)
+    assert torch.equal(merged_mask, reshaped_mask.expand(-1, seq_len, -1))
 
     key_padding_mask = torch.randint(0, 2, (batched_dim, seq_len)).to(dtype=torch.bool)
     reshaped_mask = reshape_key_padding_mask(

--- a/xformers/components/attention/utils.py
+++ b/xformers/components/attention/utils.py
@@ -40,14 +40,18 @@ def maybe_merge_masks(
     batch_size: int,
     src_len: int,
     num_heads: int,
+    tgt_len: Optional[int] = None,
 ) -> Optional[torch.Tensor]:
+    if tgt_len is None:
+        tgt_len = src_len
     if key_padding_mask is not None:
         assert key_padding_mask.shape == (batch_size, src_len)
         key_padding_mask = _reshape_key_padding_mask(
             key_padding_mask, batch_size, src_len, num_heads
         )
         if att_mask is None:
-            att_mask = key_padding_mask
+            # make sure dimensions of key padding mask are the same as those expected for att_mask
+            att_mask = key_padding_mask.expand(-1, tgt_len, -1)
         # Assumption is that False means to mask.
         elif att_mask.dtype == torch.bool:
             att_mask = att_mask.logical_and(key_padding_mask)


### PR DESCRIPTION
## What does this PR do?
Merge masks should return shape that is expected for attn mask.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
