### PR TITLE
[CI] Fix clang-format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,10 @@ install_dep_190: &install_dep_190
         python -m torch.utils.collect_env
         wget -O /home/circleci/venv/check_version.py https://raw.githubusercontent.com/min-xu-ai/check_verion/main/check_version.py
 
+        # install clang-format here, so that it gets cached
+        sudo apt-get update
+        sudo apt-get install clang-format
+
 install_repo: &install_repo
   - run:
       name: Install Repository
@@ -115,10 +119,7 @@ run_clang_format: &run_clang_format
   - run:
       name: Run Linter (clang-format)
       command: |
-        curl https://oss-clang-format.s3.us-east-2.amazonaws.com/linux64/clang-format-linux64 -o clang-format
-        chmod +x clang-format
-        sudo mv clang-format /opt/clang-format
-        ./.circleci/run-clang-format.py -r xformers/components/attention/csrc --clang-format-executable /opt/clang-format
+        ./.circleci/run-clang-format.py -r xformers/components/attention/csrc
 
 run_coverage: &run_coverage
   - run:


### PR DESCRIPTION
## What does this PR do?
Fixes CI, was dying on the clang-format binary pulled in, dynamically linked with libbtsomething5 which was not available anymore. Just pull it from ubuntu, and move this step to the dependency installation (which is cached) 

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
