### PR TITLE
Add init meta context

### DIFF
--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -297,7 +297,9 @@ if __name__ == "__main__":
         pin_memory=True,
     )
 
-    with init_meta_context():  # enable scaling to very large model without raising OOM.
+    # enable scaling to very large model without raising OOM.
+    #  the entire model will be create on meta device
+    with init_meta_context():
         model = GPT(
             vocab_size=train_dataset.vocab_size,
             block_size=train_dataset.block_size,


### PR DESCRIPTION
## What does this PR do?

This PR adds support for `init_meta_context` for the microGPT.py example. I noticed it is failing for the microVIT.py. I will investigate deeper. It seems related to TorchMetrics.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
