### PR TITLE
[partial refactor] Dedicated attention mask wrapper

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ copyright = "2021, Facebook AI Research"
 author = "Facebook AI Research"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.5"
+release = "0.0.6"
 
 
 # -- General configuration ---------------------------------------------------

--- a/tests/test_attention_mask.py
+++ b/tests/test_attention_mask.py
@@ -1,0 +1,61 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import pytest
+import torch
+
+from xformers.components.attention import AttentionMask
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="This test requires a CUDA device"
+)
+def test_mask_creation():
+    # Check that we can create from boolean
+    bool_mask = torch.rand((256, 256)) > 0.5
+    additive_mask = AttentionMask.from_bool(bool_mask)
+    assert (bool_mask == additive_mask.to_bool()).all()
+
+    bool_mask = torch.rand((2, 256, 256)) > 0.5
+    additive_mask = AttentionMask.from_bool(bool_mask)
+    assert (bool_mask == additive_mask.to_bool()).all()
+    assert additive_mask.ndim == bool_mask.ndim
+
+    # Check that we can create from multiplicative
+    ref_mask = torch.randint(0, 2, (256, 256))
+    mul_mask = ref_mask.float()
+    additive_mask = AttentionMask.from_multiplicative(mul_mask)
+    assert (ref_mask.bool() == additive_mask.to_bool()).all()
+
+    # Check the causal mask
+    causal_mask = AttentionMask.make_causal(256, 256)
+    assert (torch.tril(torch.ones(256, 256)).bool() == causal_mask.to_bool()).all()
+    assert causal_mask.is_causal
+
+    causal_mask = AttentionMask.make_causal(256)
+    assert (torch.tril(torch.ones(256, 256)).bool() == causal_mask.to_bool()).all()
+
+    causal_mask = AttentionMask.make_causal(256, 128)
+    assert (torch.tril(torch.ones(256, 128)).bool() == causal_mask.to_bool()).all()
+
+    # Check that we can add masks
+    bool_mask_1 = torch.rand((256, 256)) > 0.5
+    add_mask_1 = AttentionMask.from_bool(bool_mask_1)
+
+    bool_mask_2 = torch.rand((256, 256)) > 0.5
+    add_mask_2 = AttentionMask.from_bool(bool_mask_2)
+
+    assert ((add_mask_1 + add_mask_2).to_bool() == (bool_mask_1 & bool_mask_2)).all()
+
+    # Check type handling
+    additive_mask = AttentionMask.from_bool(torch.rand((256, 256)) > 0.5)
+    additive_mask = additive_mask.to(device=torch.device("cuda"))
+    assert "cuda" in str(additive_mask.values.device)
+
+    # Check that the causal flag is maintained
+    additive_mask = AttentionMask.make_causal(256, 256)
+    additive_mask = additive_mask.to(device=torch.device("cuda"))
+    assert additive_mask.is_causal

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -399,9 +399,10 @@ def test_csr_transpose():
 
 @pytest.mark.parametrize("contiguous", [True, False])
 @pytest.mark.parametrize("device", _devices)
-def test_sparse_bmm(device, contiguous):
-    B, M, N = 8, 64, 32
-    prob = 0.95
+@pytest.mark.parametrize("prob", [0.95, 0.996])  # cover > 0.995
+@pytest.mark.parametrize("N", [32, 64, 96])  # cover > 64
+def test_sparse_bmm(device, contiguous, prob, N):
+    B, M = 8, 64
     a = torch.rand(B, M, N, device=device)
     a[a < prob] = 0
     a = a.to_sparse()

--- a/tests/test_pytorch_transformer_parity.py
+++ b/tests/test_pytorch_transformer_parity.py
@@ -114,7 +114,6 @@ def test_pytorch_encoder_parity(device=torch.device("cuda")):
             dim_feedforward=4 * EMB,
             dropout=DROP,
             activation=ACTIVATION,
-            layer_norm_eps=1e-05,
             batch_first=True,  # (batch, seq, feature)
             device=device,
         ),

--- a/tests/test_triton_fused_linear.py
+++ b/tests/test_triton_fused_linear.py
@@ -29,6 +29,10 @@ SHAPES = [(128, 256), (8, 384, 128), (8, 784, 512)]
 
 
 @pytest.mark.skipif(not _triton_available, reason="Triton is not available")
+@pytest.mark.skipif(
+    not _triton_available or gpu_capabilities_older_than_70(),
+    reason="Triton requires a SM70+ GPU",
+)
 @pytest.mark.parametrize("shape", SHAPES)
 @pytest.mark.parametrize(
     "dtype", [torch.float32]

--- a/xformers/__init__.py
+++ b/xformers/__init__.py
@@ -6,7 +6,7 @@
 import logging
 
 # Please update the doc version in docs/source/conf.py as well.
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 _is_sparse_available = True
 

--- a/xformers/components/__init__.py
+++ b/xformers/components/__init__.py
@@ -15,8 +15,6 @@ from .attention import Attention, build_attention  # noqa
 from .multi_head_dispatch import MultiHeadDispatch, MultiHeadDispatchConfig  # noqa
 from .residual import LayerNormStyle, PostNorm, PreNorm, Residual  # noqa
 
-__all__ = ["MultiHeadDispatch", "Activation"]
-
 # automatically import any Python files in the directory
 import_all_modules(str(Path(__file__).parent), "xformers.components")
 

--- a/xformers/components/attention/__init__.py
+++ b/xformers/components/attention/__init__.py
@@ -16,6 +16,7 @@ from xformers.utils import (
 )
 
 from ._sputnik_sparse import SparseCS
+from .attention_mask import AttentionMask
 from .base import Attention, AttentionConfig  # noqa
 
 # CREDITS: Classy Vision registry mechanism
@@ -77,10 +78,11 @@ register_attention: Callable[[str, Any], Callable[[Any], Any]] = get_registry_de
 )
 
 
-def maybe_sparsify(matrix):
+def maybe_sparsify(matrix) -> Any:
     # Sparsify if that makes sense
     if torch.count_nonzero(matrix).item() / matrix.numel() > _DENSITY_THRESHOLD:
-        return matrix
+        # If not sparse, then AttentionMask is the reference type
+        return AttentionMask.from_bool(matrix)
 
     return sparsify(matrix)
 
@@ -110,6 +112,7 @@ __all__ = [
     "GlobalAttention",
     "FavorAttention",
     "Attention",
+    "AttentionMask",
     "build_attention",
     "register_attention",
 ]

--- a/xformers/components/attention/attention_mask.py
+++ b/xformers/components/attention/attention_mask.py
@@ -1,0 +1,144 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Optional, Type, TypeVar
+
+import torch
+
+Self = TypeVar("Self", bound="AttentionMask")
+
+
+class AttentionMask:
+    """
+    Holds an attention mask, along with a couple of helpers and attributes.
+
+    .. note: this is an additive mask, meaning that coefficients which should be computed hold the '0.' value,
+        and coefficients which should be skipped hold the '-inf' value. Any other value is possible if the purpose
+        is to bias the attention computation for instance
+
+    .. note: the attention mask dimensions are expected to be `[batch, to_sequence, from_sequence]`,
+        `[to_sequence, from_sequence]`, or anything broadcastable in between
+    """
+
+    def __init__(self, additive_mask: torch.Tensor, is_causal: bool = False):
+        assert additive_mask.is_floating_point()
+        assert not additive_mask.requires_grad
+
+        if additive_mask.ndim == 2:
+            additive_mask = additive_mask.unsqueeze(0)
+
+        self.values = additive_mask
+        self.is_causal = is_causal
+        self.seq_len = additive_mask.shape[1]
+        self.to_seq_len = additive_mask.shape[0]
+
+    def to_bool(self) -> torch.Tensor:
+        """
+        .. warning: we assume here that True implies that the value should be computed
+        """
+        return self.values != float("-inf")
+
+    @classmethod
+    def from_bool(cls: Type[Self], x: torch.Tensor) -> Self:
+        """
+        Create an AttentionMask given a boolean pattern.
+        .. warning: we assume here that True implies that the value should be computed
+        """
+        assert x.dtype == torch.bool
+
+        additive_mask = torch.empty_like(x, dtype=torch.float)
+        additive_mask.masked_fill_(x, 0.0)
+        additive_mask.masked_fill_(~x, float("-inf"))
+
+        return cls(additive_mask)
+
+    @classmethod
+    def from_multiplicative(cls: Type[Self], x: torch.Tensor) -> Self:
+        """
+        Create an AttentionMask given a multiplicative attention mask.
+        """
+        assert not x.dtype == torch.bool
+
+        additive_mask = torch.empty_like(x, dtype=torch.float)
+        x = x.bool()
+
+        additive_mask.masked_fill_(x, 0.0)
+        additive_mask.masked_fill_(~x, float("-inf"))
+
+        return cls(additive_mask)
+
+    @classmethod
+    def make_causal(
+        cls: Type[Self],
+        seq_len: int,
+        to_seq_len: Optional[int] = None,
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+    ) -> Self:
+        if not to_seq_len:
+            to_seq_len = seq_len
+
+        additive_mask = torch.triu(
+            torch.ones(seq_len, to_seq_len, device=device, dtype=dtype) * float("-inf"),
+            diagonal=1,
+        )
+        return cls(additive_mask=additive_mask, is_causal=True)
+
+    def make_crop(
+        self, seq_len: int, to_seq_len: Optional[int] = None
+    ) -> "AttentionMask":
+        """
+        Return a cropped attention mask, whose underlying tensor is a view of this one
+        """
+
+        if not to_seq_len:
+            to_seq_len = seq_len
+
+        return AttentionMask(
+            self.values[:, :seq_len, :to_seq_len], is_causal=self.is_causal
+        )
+
+    def __repr__(self):
+        return f"AttentionMask - causal {self.is_causal} - mask " + str(self.values)
+
+    @property
+    def device(self):
+        return self.values.device
+
+    @property
+    def is_sparse(self):
+        return False
+
+    @property
+    def ndim(self):
+        return len(self.values.shape)
+
+    @property
+    def dtype(self):
+        return self.values.dtype
+
+    @property
+    def shape(self):
+        return self.values.shape
+
+    def __add__(self, other):
+        assert isinstance(other, type(self))
+        return AttentionMask(self.values + other.values, is_causal=False)
+
+    def to(
+        self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None
+    ) -> "AttentionMask":
+        assert device is None or isinstance(device, torch.device)
+        assert dtype is None or isinstance(dtype, torch.dtype)
+        assert device is not None or dtype is not None
+
+        # Noop if we don't need to create another instance
+        if ((device and device == self.device) or not device) and (
+            (dtype and dtype == self.dtype) or not dtype
+        ):
+            return self
+
+        return AttentionMask(self.values.to(device=device, dtype=dtype), self.is_causal)

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import logging
 import math
 from contextlib import nullcontext
 from typing import Optional, Union

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -7,11 +7,12 @@
 import logging
 import math
 from contextlib import nullcontext
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 
 from xformers import _is_sparse_available
+from xformers.components.attention.attention_mask import AttentionMask
 
 if _is_sparse_available:
     from ._sputnik_sparse import SparseCS
@@ -69,12 +70,12 @@ def _broadcast_batch(mask, batch_size):
 
 
 def _matmul_with_mask(
-    a: torch.Tensor, b: torch.Tensor, mask: Optional[torch.Tensor]
+    a: torch.Tensor, b: torch.Tensor, mask: Optional[Union[torch.Tensor, "SparseCS"]]
 ) -> torch.Tensor:
     if mask is None:
         return a @ b
 
-    if _is_sparse_available:
+    if _is_sparse_available and mask.dtype == torch.bool:
         if isinstance(mask, SparseCS):
             return mask.matmul_with_mask(a, b)
         if mask.is_sparse:
@@ -87,6 +88,8 @@ def _matmul_with_mask(
         return torch.ops.xformers.matmul_with_mask(a, b, mask)
 
     # Non optimized codepath
+    assert not isinstance(mask, SparseCS)
+
     att = a @ b
     if mask.dtype == torch.bool:
         if mask.ndim == 2:
@@ -189,8 +192,7 @@ def _apply_dropout(att, dropout):
 def scaled_query_key_softmax(
     q: torch.Tensor,
     k: torch.Tensor,
-    att_mask: Optional[torch.Tensor],
-    causal: bool = False,
+    att_mask: Optional[Union[AttentionMask, "SparseCS", torch.Tensor]],
 ) -> torch.Tensor:
     # TODO assume we have (N, S, hs) instead of (B, nh, S, hs), with N = B x nh
     # this is needed due to limitations in sparse_bmm for now
@@ -199,15 +201,17 @@ def scaled_query_key_softmax(
     q = q / math.sqrt(k.size(-1))
 
     # Matmul with mask, if boolean
-    is_bool_mask = att_mask is not None and att_mask.dtype == torch.bool
-    att = _matmul_with_mask(q, k.transpose(-2, -1), att_mask if is_bool_mask else None)
+    if att_mask is not None and isinstance(att_mask, AttentionMask):
+        # Additive mask
+        mask: Optional[Union[SparseCS, torch.Tensor]] = att_mask.values
+    else:
+        mask = att_mask
 
-    # Could also be that the mask was additive
-    if att_mask is not None and att_mask.dtype != torch.bool:
-        att = att + att_mask
+    att = _matmul_with_mask(q, k.transpose(-2, -1), mask)
 
     # Softmax to get the attention probabilities
-    att = _softmax(att, causal=causal)
+    is_causal = att_mask.is_causal if isinstance(att_mask, AttentionMask) else False
+    att = _softmax(att, causal=is_causal)
     return att
 
 
@@ -215,9 +219,8 @@ def scaled_dot_product_attention(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    att_mask: Optional[torch.Tensor],
+    att_mask: Optional[Union[AttentionMask, "SparseCS", torch.Tensor]],
     dropout: Optional[torch.nn.Module] = None,
-    causal: bool = False,
 ) -> torch.Tensor:
     autocast_disabled = (
         _is_sparse_available
@@ -231,30 +234,23 @@ def scaled_dot_product_attention(
         and q.shape[-2] == k.shape[-2]
         and q.shape[-2] < att_mask.shape[1]
     ):
-        seq = q.shape[-2]
-        if att_mask.ndim == 2:
-
-            if not att_mask.is_sparse:
-                att_mask = att_mask[:seq, :seq]
-            else:
-                logging.warning(
-                    "Mismatching attention mask and sequence length. On the fly correction but this will be slow"
-                )
-                # Loosing sparsity on purpose,
-                # expectation is that moving back and forth dense/sparse will negate the speedup
-                att_mask = att_mask.to_dense().squeeze(0)[:seq, :seq]
+        if isinstance(att_mask, AttentionMask):
+            att_mask = att_mask.make_crop(seq_len=q.shape[-2])
         else:
-            assert (
-                not att_mask.is_sparse
-            ), "Sparse masks with a batch dimension are not supported for now"
-            att_mask = att_mask[:, :seq, :seq]
+            assert isinstance(att_mask, SparseCS) or att_mask.is_sparse, att_mask
+
+            logging.error(
+                "Mismatching sparse attention mask and sequence length."
+                + " Please pad the inputs or adjust the attention mask"
+            )
+            raise NotImplementedError
 
     # The actual attention
     with torch.cuda.amp.autocast(enabled=False) if autocast_disabled else nullcontext():
         if autocast_disabled:
             q, k, v = q.float(), k.float(), v.float()
 
-        att = scaled_query_key_softmax(q, k, att_mask=att_mask, causal=causal)
+        att = scaled_query_key_softmax(q, k, att_mask=att_mask)
 
         #  Optional dropout, could be part of the masking in the future
         att = _apply_dropout(att, dropout)

--- a/xformers/components/attention/global_tokens.py
+++ b/xformers/components/attention/global_tokens.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from xformers.components.attention import (
     Attention,
     AttentionConfig,
+    AttentionMask,
     maybe_sparsify,
     register_attention,
     sparsify,
@@ -91,10 +92,24 @@ class GlobalAttention(Attention):
             self.attention_mask = self.attention_mask.to(q.device)
 
         # Mask-aware attention
-        mask = (
-            self.attention_mask if att_mask is None else self.attention_mask & att_mask
+        if att_mask is not None:
+            if att_mask.dtype == torch.bool and isinstance(
+                self.attention_mask, AttentionMask
+            ):
+                mask = self.attention_mask + AttentionMask.from_bool(att_mask)
+            else:
+                mask = self.attention_mask & att_mask
+        else:
+            mask = self.attention_mask
+
+        # Handle q/k/v which would not fit the mask
+        seq_len = q.shape[-2]
+        q_, k_, v_ = map(lambda x: self._maybe_pad_sequence(x, mask), (q, k, v))
+
+        # Normal attention with the global tokens mask
+        att = scaled_dot_product_attention(
+            q=q_, k=k_, v=v_, att_mask=mask, dropout=self.attn_drop
         )
 
-        return scaled_dot_product_attention(
-            q=q, k=k, v=v, att_mask=mask, dropout=self.attn_drop
-        )
+        # Take into account an hypothetical padding
+        return att[:, :seq_len, :]

--- a/xformers/components/attention/random.py
+++ b/xformers/components/attention/random.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from xformers.components.attention import (
     Attention,
     AttentionConfig,
+    AttentionMask,
     maybe_sparsify,
     register_attention,
     sparsify,
@@ -93,12 +94,24 @@ class RandomAttention(Attention):
             self.rand_attention_mask = self._get_rand_mask(q.shape).to(q.device)
 
         # Mask-aware attention
-        mask = (
-            self.rand_attention_mask
-            if att_mask is None
-            else self.rand_attention_mask & att_mask
+        if att_mask is not None:
+            if att_mask.dtype == torch.bool and isinstance(
+                self.rand_attention_mask, AttentionMask
+            ):
+                mask = self.rand_attention_mask + AttentionMask.from_bool(att_mask)
+            else:
+                mask = self.rand_attention_mask & att_mask
+        else:
+            mask = self.rand_attention_mask
+
+        # Handle q/k/v which would not fit the mask
+        seq_len = q.shape[-2]
+        q_, k_, v_ = map(lambda x: self._maybe_pad_sequence(x, mask), (q, k, v))
+
+        # Normal attention with the random mask
+        att = scaled_dot_product_attention(
+            q=q_, k=k_, v=v_, att_mask=mask, dropout=self.attn_drop
         )
 
-        return scaled_dot_product_attention(
-            q=q, k=k, v=v, att_mask=mask, dropout=self.attn_drop
-        )
+        # Take into account an hypothetical padding
+        return att[:, :seq_len, :]


### PR DESCRIPTION
## What does this PR do?
- add a dedicated class to handle additive attention masks, and centralize some of the typical operations (change types, add to another mask, handle smaller sequences..)
- the sparse machinery is still the same and bools (cc @fmassa), I did not touch that. 
- I think that the above needs to be changed eventually, so that we converge towards additive masks all around, but it means that on the sparse side we need to completely handle a float additive mask, in that a value `a` would both mark the fact that this needs to be computed, and be added a posteriori to the computed attention value (not done right now)
- Fix https://github.com/facebookresearch/xformers/issues/90 (do not slice the attention mask)
- Fix https://github.com/facebookresearch/xformers/issues/91 (no causal flag in the core attention)

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
