### PR TITLE
[fix][speed] Better projections - correctness + speed

### DIFF
--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -271,12 +271,12 @@ def sample(model, x, steps, temperature=1.0, sample=False, top_k=None):
 if __name__ == "__main__":
     seed_everything(42)
     REF_BATCH = 512
-    BATCH = 256  # adjust depending on the avaiable memory on your machine
+    BATCH = 512  # adjust depending on the avaiable memory on your machine
     WORKERS = 8
     EPOCHS = 1
     BLOCK = 128
     WARMUP = 20
-    LR = 5e-5
+    LR = 6e-4
 
     if not os.path.exists("input.txt"):
         os.system(
@@ -299,7 +299,7 @@ if __name__ == "__main__":
     model = GPT(
         vocab_size=train_dataset.vocab_size,
         block_size=train_dataset.block_size,
-        attention="nystrom",
+        attention="scaled_dot_product",
         warmup_tokens=REF_BATCH * WARMUP,
         learning_rate=LR,
         final_tokens=EPOCHS * len(train_dataset) * BLOCK,

--- a/xformers/components/attention/_sputnik_sparse.py
+++ b/xformers/components/attention/_sputnik_sparse.py
@@ -258,7 +258,7 @@ class SparseCS:
         column_indices = self.column_indices
         out = _sddmm.apply(
             a,
-            b.transpose(-2, -1),
+            b.transpose(-2, -1).contiguous(),
             row_indices,
             row_offsets,
             column_indices,

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -143,9 +143,9 @@ if _is_sparse_available:
 def bmm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     if _is_sparse_available:
         if isinstance(a, SparseCS):
-            return a.spmm(b)
+            return a.spmm(b.contiguous())
         if a.is_sparse:
-            return _sparse_bmm(a, b)
+            return _sparse_bmm(a, b.contiguous())
     return a @ b
 
 

--- a/xformers/components/residual.py
+++ b/xformers/components/residual.py
@@ -5,23 +5,14 @@
 
 
 from enum import Enum
-from typing import List, Union
+from typing import Union
 
-import torch
 import torch.nn as nn
 
 from xformers import _is_triton_available
 
 if _is_triton_available:
     from xformers.triton.layer_norm import FusedLayerNorm
-
-
-def _to_tensor_list(
-    inputs: Union[torch.Tensor, List[torch.Tensor]]
-) -> List[torch.Tensor]:
-    if not isinstance(inputs, list):
-        inputs = [inputs]
-    return inputs
 
 
 class LayerNormStyle(str, Enum):
@@ -36,16 +27,23 @@ class LayerNormStyle(str, Enum):
 
 # CREDITS: the following is inspired by FastAI's Transformer implementation
 class Residual(nn.Module):
-    """Object-oriented handling of the residual path"""
+    """Object-oriented handling of the residual path
+
+    .. warning: by convention, if multiple tensors are being passed in,
+        the first one is used for the residual path
+    """
 
     def __init__(self, layer: nn.Module):
         super().__init__()
         self.layer = layer
 
-    def forward(self, inputs: Union[torch.Tensor, List[torch.Tensor]], *args, **kwargs):
-        inputs = _to_tensor_list(inputs)
-
-        return inputs[0] + self.layer(*inputs, *args, **kwargs)
+    def forward(
+        self,
+        *args,
+        **kwargs,
+    ):
+        residual = args[0]
+        return residual + self.layer(*args, **kwargs)
 
 
 class PreNorm(nn.Module):
@@ -62,11 +60,16 @@ class PreNorm(nn.Module):
 
         self.sublayer = sublayer
 
-    def forward(self, inputs: Union[torch.Tensor, List[torch.Tensor]], *args, **kwargs):
-        inputs = _to_tensor_list(inputs)
-
-        x_norm = [self.norm(x_) for x_ in inputs]
-        return self.sublayer(*x_norm, *args, **kwargs)
+    def forward(self, *args, **kwargs):
+        # Could be that the same tensor has been passed multiple times
+        # in that case we'll just normalize once
+        list_ids = [id(inp) for inp in args]
+        if list_ids.count(list_ids[0]) == len(list_ids):
+            normalized_input = self.norm(args[0])
+            sublayer_inputs = [normalized_input for _ in args]
+        else:
+            sublayer_inputs = [self.norm(x_) for x_ in args]
+        return self.sublayer(*sublayer_inputs, **kwargs)
 
 
 class PostNorm(nn.Module):
@@ -81,8 +84,6 @@ class PostNorm(nn.Module):
 
         self.sublayer = sublayer
 
-    def forward(self, inputs: Union[torch.Tensor, List[torch.Tensor]], *args, **kwargs):
-        inputs = _to_tensor_list(inputs)
-
-        x = self.sublayer(*inputs, *args, **kwargs)
+    def forward(self, *args, **kwargs):
+        x = self.sublayer(*args, **kwargs)
         return self.norm(x)

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -364,8 +364,8 @@ class xFormerDecoderBlock(torch.nn.Module):
         else:
             target_q, target_k, target_v = target, target, target
 
-        x = self.wrap_att([target_q, target_k, target_v], att_mask=decoder_att_mask)
-        x = self.wrap_cross([x, memory, memory], att_mask=encoder_att_mask)
+        x = self.wrap_att(target_q, target_k, target_v, att_mask=decoder_att_mask)
+        x = self.wrap_cross(x, memory, memory, att_mask=encoder_att_mask)
         x = self.wrap_ff(x)
 
         return x


### PR DESCRIPTION
## What does this PR do?
- fixes the self attention optimization (project all in one go) not being triggered
- contiguous tensors are only needed for sparse, removing the contiguous cost when not needed
- fixing a simplifying a broken path in the factory / residual and normalization, related to the above: only normalize once if this is the same tensor, and propagate the same id down

With these changes/fixes, vanilla xformers is 5-10% faster than timm on a vanilla ViT (up from being 10% slower) as per the bench [from the other PR](https://github.com/facebookresearch/xformers/issues/108), and microGPT trains something decent in 20 minutes on a laptop (3080 / fp16)

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
