### PR TITLE
[fix] fall back to torch.log_softmax properly

### DIFF
--- a/xformers/triton/softmax.py
+++ b/xformers/triton/softmax.py
@@ -202,4 +202,7 @@ def _softmax_dispatch(
     if mask is not None:
         x += mask
 
-    return torch.softmax(x, dim=-1)
+    if log:
+        return torch.log_softmax(x, dim=-1)
+    else:
+        return torch.softmax(x, dim=-1)


### PR DESCRIPTION
## What does this PR do? 

fallback to torch.log_softmax when tritron's sfotmax w/ log=True.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
