### PR TITLE
[LRA] Fix unexpected keyword layer_position in block factory

### DIFF
--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -8,3 +8,4 @@ tqdm == 4.59.0
 pandas == 1.2.4
 seaborn == 0.11.1
 triton == 1.1.1
+pytorch-lightning >= 1.3 

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -110,11 +110,11 @@ def test_presets(config, reversible, device):
     modelConfig = xFormerConfig(config)
     if isinstance(modelConfig.stack_configs, dict):
         for k, blockConfig in modelConfig.stack_configs.items():
-            assert(blockConfig.layer_position)
+            assert blockConfig.layer_position
     else:
         for blockConfig in modelConfig.stack_configs:
-            assert(blockConfig.layer_position)
-    
+            assert blockConfig.layer_position
+
     model = xFormer.from_config(modelConfig).to(device)
 
     # Dummy inputs, test a forward

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -107,7 +107,15 @@ def test_presets(config, reversible, device):
     else:
         config["encoder"]["reversible"] = reversible
 
-    model = xFormer.from_config(xFormerConfig(config)).to(device)
+    modelConfig = xFormerConfig(config)
+    if isinstance(modelConfig.stack_configs, dict):
+        for k, blockConfig in modelConfig.stack_configs.items():
+            assert(blockConfig.layer_position)
+    else:
+        for blockConfig in modelConfig.stack_configs:
+            assert(blockConfig.layer_position)
+    
+    model = xFormer.from_config(modelConfig).to(device)
 
     # Dummy inputs, test a forward
     inputs = (torch.rand((BATCH, SEQ), device=device) * 10).abs().to(torch.int)

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -112,7 +112,9 @@ class xFormerBlockConfig:
         layer_norm_style: LayerNormStyle = LayerNormStyle("post"),
         reversible: bool = False,
         num_layers: int = 1,
+        layer_position: Optional[LayerPosition] = None,
     ):
+
         self.dim_model = dim_model
         self.block_type = block_type
         self.layer_norm_style = layer_norm_style
@@ -135,7 +137,10 @@ class xFormerBlockConfig:
         )
 
         # Default is that this layer is the only one, so both first and last
-        self.layer_position = LayerPosition()
+        if layer_position:
+            self.layer_position = layer_position
+        else:
+            self.layer_position = LayerPosition()
 
 
 @dataclass(init=False)


### PR DESCRIPTION
## What does this PR do?
Fixes an issue I experienced running the LRA where the layer_position configuration was being passed into the xFormerBlockConfig initialization but the init function was not expecting it and was creating just a default assignment.

The original error was:

```
% python run_tasks.py --attention nystrom --task retrieval --world_size 1 --checkpoint_dir /checkpoint/jajsmith/xformers --config code/config_nystrom.json
WARNING:root:Blocksparse is not available: the current GPU does not expose Tensor cores
WARNING:root:Blocksparse is not available: the current GPU does not expose Tensor cores
INFO:root:Added key: store_based_barrier_key:1 to store for rank: 0
process shutting down
process exiting with exitcode 1
Traceback (most recent call last):
File "run_tasks.py", line 583, in <module>
torch.multiprocessing.spawn(
File "/private/home/jajsmith/.conda/envs/xformer_env/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 230, in spawn
return start_processes(fn, args, nprocs, join, daemon, start_method='spawn')
File "/private/home/jajsmith/.conda/envs/xformer_env/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 188, in start_processes
while not context.join():
File "/private/home/jajsmith/.conda/envs/xformer_env/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 150, in join
raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException:
-- Process 0 terminated with the following error:
Traceback (most recent call last):
File "/private/home/jajsmith/.conda/envs/xformer_env/lib/python3.8/site-packages/torch/multiprocessing/spawn.py", line 59, in _wrap
fn(i, *args)
File "/private/home/jajsmith/xformers/xformers/benchmarks/LRA/run_tasks.py", line 272, in benchmark
model = build_model(args, config)
File "/private/home/jajsmith/xformers/xformers/benchmarks/LRA/run_tasks.py", line 64, in build_model
model: nn.Module = ModelForSCDual(config[f"{task}"], attention_name)
File "/private/home/jajsmith/xformers/xformers/benchmarks/LRA/code/model_wrapper.py", line 175, in __init__
super().__init__(config, model_name)
File "/private/home/jajsmith/xformers/xformers/benchmarks/LRA/code/model_wrapper.py", line 127, in __init__
self.config_model = patch_model_config(config_model, model_name)
File "/private/home/jajsmith/xformers/xformers/benchmarks/LRA/code/model_wrapper.py", line 74, in patch_model_config
bc = generate_matching_config(bc, xFormerEncoderConfig)
File "/private/home/jajsmith/xformers/xformers/utils.py", line 81, in generate_matching_config
return config_class(**subset)
File "/private/home/jajsmith/xformers/xformers/factory/block_factory.py", line 176, in __init__
super().__init__(
TypeError: __init__() got an unexpected keyword argument ‘layer_position'
```

While this does not allow me to rerun LRA (still experiencing another issue), it does get past the config initialization section now.
And I also tested that there was not regression in the solution by rerunning some of the other benchmarks:

```
 python xformers/benchmarks/benchmark_encoder.py --activations relu -a nystrom linformer orthoformer scaled_dot_product fourier_mix --plot -emb 256 -bs 32 -heads 16
```

Which succeeded.

## Before submitting

- [ x ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ x ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ x ] N/A
- [ ] Did you make sure to update the docs?
  - [ x ] N/A
- [ ] Did you write any new necessary tests?
  - [ x ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ x ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
