### PR TITLE
Improve installation instructions on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ There are two ways you can install it:
   cd xformers
   pip install -r requirements.txt
   pip install -e .
+  # or, for OSX
+  MACOSX_DEPLOYMENT_TARGET=10.9 CC=clang CXX=clang++ pip install -e .
   ```
 
 #### Sparse attention kernels


### PR DESCRIPTION
## What does this PR do?
Fixes (part of) #157.

We need to specify those flags for installation on OSX to work. This is the same of what we do for torchvision in https://github.com/pytorch/vision#installation

Maybe the `MACOSX_DEPLOYMENT_TARGET=10.9` part can be removed in latest OSes, but further investigation is needed to see if we indeed can remove it.