### PR TITLE
[fix] Disable shape types in sine.py

### DIFF
--- a/xformers/components/positional_embedding/sine.py
+++ b/xformers/components/positional_embedding/sine.py
@@ -7,14 +7,9 @@
 # Silence Mypy errors in this file.
 # type: ignore
 
-from __future__ import annotations
-
 import math
-from typing import TypeVar
 
 import torch
-from pyre_extensions import Generic
-from typing_extensions import Literal as L
 
 from xformers.components.positional_embedding import (
     PositionEmbedding,
@@ -22,19 +17,14 @@ from xformers.components.positional_embedding import (
     register_positional_embedding,
 )
 
-N = TypeVar("N", bound=int)
-DimModel = TypeVar("DimModel", bound=int)
-
 
 @register_positional_embedding("sine", PositionEmbeddingConfig)
-class SinePositionalEmbedding(PositionEmbedding, Generic[DimModel]):
-    def __init__(self, dim_model: DimModel, *args, **kwargs):
+class SinePositionalEmbedding(PositionEmbedding):
+    def __init__(self, dim_model: int, *args, **kwargs):
         super().__init__()
-        self.dim_model: DimModel = dim_model
+        self.dim_model = dim_model
 
-    def forward(
-        self, x: torch.Tensor[torch.float, N, N]
-    ) -> torch.Tensor[torch.float, N, N, DimModel]:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         seq_len = x.shape[1]
         pos = (
             torch.arange(0, seq_len, device=x.device, dtype=torch.float32)
@@ -51,10 +41,6 @@ class SinePositionalEmbedding(PositionEmbedding, Generic[DimModel]):
         pos[:, 0::2] = torch.sin(pos[:, 0::2])
         pos[:, 1::2] = torch.cos(pos[:, 1::2])
 
-        # pyre-ignore[9]: x was declared as N x N but is expected as N * N * 1.
-        # Handle a non-existing embedding dimension
-        output: torch.Tensor[torch.float32, N, N, L[1]] = (
-            x.unsqueeze(-1) if x.ndim == 2 else x
-        )
+        output = x.unsqueeze(-1) if x.ndim == 2 else x
 
         return output + pos.unsqueeze(0)


### PR DESCRIPTION
The downstream library has an older version of `pyre_extensions` and it
will take some time to release a new version. So, remove the use of
`pyre_extensions.Generic` in sine.py for now.

This unblocks moving the other commits downstream.



## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A

cc @dianaml0 
