### PR TITLE
Create BlockSparse Tensor

### DIFF
--- a/tests/test_sparse_tensors.py
+++ b/tests/test_sparse_tensors.py
@@ -8,7 +8,6 @@ import torch
 
 # needed to register custom ops
 import xformers  # noqa: F401
-import xformers.components.attention
 from xformers.sparse import BlockSparseTensor
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/tests/test_sparse_tensors.py
+++ b/tests/test_sparse_tensors.py
@@ -1,0 +1,101 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+# needed to register custom ops
+import xformers  # noqa: F401
+import xformers.components.attention
+from xformers.sparse import BlockSparseTensor
+
+cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+_devices = ["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"]
+_devices = ["cuda:0"]
+
+
+def _create_tensor(device):
+    BLOCK = 32
+    Z = 8
+    H = 2
+    shape = (512, 512)
+
+    layout = torch.randint(2, (H, shape[0] // BLOCK, shape[1] // BLOCK))
+    values = torch.randn(Z, layout.sum(), BLOCK, BLOCK, device=device)
+
+    mask = (
+        layout[None, :, :, None, :, None]
+        .repeat(Z, 1, 1, BLOCK, 1, BLOCK)
+        .reshape(Z, H, shape[0], shape[1])
+    )
+
+    return BlockSparseTensor(values, layout), mask.bool()
+
+
+@pytest.mark.parametrize("device", _devices)
+def test_sparse_softmax(device):
+    a_block, mask = _create_tensor(device)
+    a = a_block.to_dense()
+    a[~mask] = float("-inf")
+
+    res_gt = torch.softmax(a, dim=-1)
+    res_block = torch.softmax(a_block, dim=-1)
+
+    res = res_block.to_dense()
+
+    assert res.dtype == res_gt.dtype
+    assert torch.allclose(res, res_gt)
+
+
+@pytest.mark.parametrize("device", _devices)
+def test_sparse_softmax_backward(device):
+    a_block, mask = _create_tensor(device)
+    a = a_block.to_dense()
+    a_block.requires_grad_(True)
+
+    a[~mask] = float("-inf")
+    a.requires_grad_(True)
+
+    res_gt = torch.softmax(a, dim=-1)
+    res_block = torch.softmax(a_block, dim=-1)
+
+    res_block._blocksparse_values.sum().backward()
+    res_gt.sum().backward()
+
+    assert torch.allclose(a.grad, a_block.grad.to_dense(), atol=1e-7)
+
+
+@pytest.mark.parametrize("device", _devices)
+def test_deepcopy(device):
+    import copy
+
+    a_block, mask = _create_tensor(device)
+
+    b_block = copy.deepcopy(a_block)
+    assert torch.equal(a_block, b_block)
+
+
+@pytest.mark.parametrize("device", _devices)
+def test_module_buffer(device):
+    a_block, _ = _create_tensor(device)
+    b_block, _ = _create_tensor(device)
+
+    module = torch.nn.Module()
+    # test that register_buffer works
+    module.register_buffer("a_block", a_block)
+
+    assert module.a_block is a_block
+
+    module.to(device)
+    assert module.a_block.device == torch.device(device)
+
+    state_dict = module.state_dict()
+    assert "a_block" in state_dict
+    assert torch.equal(a_block.to(device), state_dict["a_block"])
+
+    module.load_state_dict(state_dict)
+
+    module.load_state_dict({"a_block": b_block})
+    assert torch.equal(module.a_block, b_block.to(device))

--- a/tests/test_sparse_tensors.py
+++ b/tests/test_sparse_tensors.py
@@ -12,7 +12,6 @@ from xformers.ops import masked_matmul
 from xformers.sparse import BlockSparseTensor
 
 cuda_only = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-_devices = ["cuda:0"] if torch.cuda.is_available() else []
 _devices = ["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"]
 
 

--- a/xformers/sparse/__init__.py
+++ b/xformers/sparse/__init__.py
@@ -5,3 +5,4 @@
 
 
 from .csr_tensor import SparseCSRTensor  # noqa: F401
+from .blocksparse_tensor import BlockSparseTensor  # noqa: F401

--- a/xformers/sparse/__init__.py
+++ b/xformers/sparse/__init__.py
@@ -4,5 +4,5 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from .csr_tensor import SparseCSRTensor  # noqa: F401
 from .blocksparse_tensor import BlockSparseTensor  # noqa: F401
+from .csr_tensor import SparseCSRTensor  # noqa: F401

--- a/xformers/sparse/blocksparse_tensor.py
+++ b/xformers/sparse/blocksparse_tensor.py
@@ -1,0 +1,140 @@
+import torch
+from xformers.ops import masked_matmul
+
+from triton.ops.blocksparse import matmul as blocksparse_matmul
+from triton.ops.blocksparse import softmax as blocksparse_softmax
+
+
+class BlockSparseTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, values, layout):
+        kwargs = {}
+        kwargs["device"] = values.device
+        kwargs["dtype"] = values.dtype
+        kwargs["layout"] = values.layout
+        kwargs["requires_grad"] = values.requires_grad
+        assert values.ndim == 4
+        B, C, H, W = values.shape
+        h, w = layout.shape[-2:]
+        shape = (B, C, H * h, W * w)
+        return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)
+
+    def __init__(self, values, layout):
+        assert values.shape[-2] == values.shape[-1]
+        block_size = values.shape[-1]
+        assert block_size >= 16, "Minimum block size is 16, for now at least"
+
+        # Pure blocksparse data
+        self.__values = values
+        self.__layout = layout
+
+        # blocksparse operators
+        self.__sparse_dot_sdd = blocksparse_matmul(
+            self.__layout,
+            block_size,
+            "sdd",
+            trans_a=False,
+            trans_b=True,
+        )
+        self.__sparse_dot_dsd = blocksparse_matmul(
+            self.__layout,
+            block_size,
+            "dsd",
+            trans_a=False,
+            trans_b=False,
+        )
+        self.__sparse_softmax = blocksparse_softmax(self.__layout, block_size)
+
+    def __repr__(self):
+        return f"block_sparse_tensor(shape={self.shape}, values={self.__values})"
+
+    @classmethod
+    def _wrap(cls, values, bmat):
+        matrix = cls.__new__(cls, values, bmat.__layout)
+        matrix.__values = values
+        matrix.__layout = layout
+        matrix.__sparse_dot_sdd = bmat.__sparse_dot_sdd
+        matrix.__sparse_dot_dsd = bmat.__sparse_dot_dsd
+        matrix.__sparse_softmax = bmat.__sparse_softmax
+        return matrix
+
+    @classmethod
+    def _bmm(cls, arg0, arg1):
+        if not (isinstance(arg0, cls) and type(arg1) == torch.Tensor):
+            return NotImplemented
+        res = arg0.__sparse_dot_dsd(arg0.__values, arg1)
+        return res
+
+
+    @classmethod
+    def _masked_matmul(cls, a, b, mask):
+        if not (type(a) == torch.Tensor and type(b) == torch.Tensor):
+            return NotImplemented
+        b = b.transpose(-2, -1)
+        assert b.is_contiguous()
+        res = mask.__sparse_dot_sdd(a, b)
+        return cls._wrap(res, mask)
+
+    @classmethod
+    def _softmax(cls, arg0, dim):
+        if not (dim == -1 or dim == 2):
+            return NotImplemented
+        res = arg0.__sparse_softmax(arg0.__values)
+        return cls._wrap(res, arg0)
+
+    @classmethod
+    def _to_dense(cls, arg0):
+        return NotImplemented
+
+    @classmethod
+    def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if func in [torch.Tensor.bmm, torch.bmm]:
+            assert len(args) == 2
+            return cls._bmm(args[0], args[1])
+
+        if func in [torch.Tensor.softmax, torch.nn.functional.softmax, torch.softmax]:
+            return cls._softmax(args[0], kwargs["dim"])
+
+        if func == masked_matmul:
+            assert len(args) == 3
+            return cls._masked_matmul(args[0], args[1], args[2])
+
+        if func in [torch.nn.functional.dropout, torch.dropout, torch.dropout_]:
+            x = args[0]
+            values = x.__values.clone()
+            values = func(values, *args[1:], **kwargs)
+            return cls._wrap(values, x)
+
+        if func == torch.Tensor.to_dense:
+            assert len(args) == 1
+            return cls._to_dense(args[0])
+
+        if func == torch.Tensor.detach:
+            x = args[0]
+            values = x.__values.clone()
+            values = func(values, *args[1:], **kwargs)
+            return cls._wrap(values, x)
+
+        if func in [torch.Tensor.grad.__get__, torch.Tensor._grad.__get__]:
+            assert len(args) == 1
+            assert len(kwargs) == 0
+            x = args[0]
+            return cls._wrap(x.__values.grad, x)
+
+        if func == torch.Tensor.requires_grad_:
+            func(args[0].__values)
+
+        with torch._C.DisableTorchFunction():
+            ret = func(*args, **kwargs)
+            # TODO: check this
+            if func in torch.overrides.get_default_nowrap_functions():
+                return ret
+            return torch._tensor._convert(ret, cls)
+
+        return NotImplemented
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args, kwargs):
+        return NotImplemented

--- a/xformers/sparse/blocksparse_tensor.py
+++ b/xformers/sparse/blocksparse_tensor.py
@@ -163,7 +163,13 @@ class BlockSparseTensor(torch.Tensor):
     def __torch_function__(cls, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
-        if func in [torch.Tensor.bmm, torch.bmm]:
+        if func in [
+            torch.Tensor.bmm,
+            torch.bmm,
+            torch.Tensor.__matmul__,
+            torch.matmul,
+            torch.Tensor.matmul,
+        ]:
             assert len(args) == 2
             return cls._bmm(args[0], args[1])
 

--- a/xformers/sparse/blocksparse_tensor.py
+++ b/xformers/sparse/blocksparse_tensor.py
@@ -1,8 +1,8 @@
 import torch
-from xformers.ops import masked_matmul
-
 from triton.ops.blocksparse import matmul as blocksparse_matmul
 from triton.ops.blocksparse import softmax as blocksparse_softmax
+
+from xformers.ops import masked_matmul
 
 
 class BlockSparseTensor(torch.Tensor):
@@ -14,9 +14,10 @@ class BlockSparseTensor(torch.Tensor):
         kwargs["layout"] = values.layout
         kwargs["requires_grad"] = values.requires_grad
         assert values.ndim == 4
-        B, C, H, W = values.shape
-        h, w = layout.shape[-2:]
-        shape = (B, C, H * h, W * w)
+        B, _, block_size, _ = values.shape
+        C, h, w = layout.shape
+        # TODO validate shape of layout vs values
+        shape = (B, C, block_size * h, block_size * w)
         return torch.Tensor._make_wrapper_subclass(cls, shape, **kwargs)
 
     def __init__(self, values, layout):
@@ -48,11 +49,25 @@ class BlockSparseTensor(torch.Tensor):
     def __repr__(self):
         return f"block_sparse_tensor(shape={self.shape}, values={self.__values})"
 
+    @property
+    def _blocksparse_values(self):
+        return self.__values
+
+    @classmethod
+    def _raw_wrap(cls, values, layout, sparse_dot_sdd, sparse_dot_dsd, sparse_softmax):
+        matrix = cls.__new__(cls, values, layout)
+        matrix.__values = values
+        matrix.__layout = layout
+        matrix.__sparse_dot_sdd = sparse_dot_sdd
+        matrix.__sparse_dot_dsd = sparse_dot_dsd
+        matrix.__sparse_softmax = sparse_softmax
+        return matrix
+
     @classmethod
     def _wrap(cls, values, bmat):
         matrix = cls.__new__(cls, values, bmat.__layout)
         matrix.__values = values
-        matrix.__layout = layout
+        matrix.__layout = bmat.__layout
         matrix.__sparse_dot_sdd = bmat.__sparse_dot_sdd
         matrix.__sparse_dot_dsd = bmat.__sparse_dot_dsd
         matrix.__sparse_softmax = bmat.__sparse_softmax
@@ -64,7 +79,6 @@ class BlockSparseTensor(torch.Tensor):
             return NotImplemented
         res = arg0.__sparse_dot_dsd(arg0.__values, arg1)
         return res
-
 
     @classmethod
     def _masked_matmul(cls, a, b, mask):
@@ -79,12 +93,66 @@ class BlockSparseTensor(torch.Tensor):
     def _softmax(cls, arg0, dim):
         if not (dim == -1 or dim == 2):
             return NotImplemented
-        res = arg0.__sparse_softmax(arg0.__values)
+        # TODO triton softmax performs an in-place operation
+        # res = arg0.__sparse_softmax(arg0.__values)
+        res = arg0.__sparse_softmax(arg0.__values.clone())
         return cls._wrap(res, arg0)
 
     @classmethod
+    def _to(cls, arg0, device):
+        if isinstance(device, str):
+            device = torch.device(device)
+        assert isinstance(device, torch.device)
+        return cls(
+            arg0.__values.to(device=device),
+            arg0.__layout,
+        )
+
+    @classmethod
+    def _copy(cls, arg0, arg1):
+        if not (isinstance(arg0, cls) and isinstance(arg1, cls)):
+            return NotImplemented
+        assert arg0.shape == arg1.shape
+        av0, av1 = arg0.__values, arg1.__values
+        av0.resize_as_(av1).copy_(av1)
+        av0, av1 = arg0.__layout, arg1.__layout
+        av0.resize_as_(av1).copy_(av1)
+        out = cls(arg0.__values, arg0.__layout)
+        arg0.__sparse_dot_sdd = out.__sparse_dot_sdd
+        arg0.__sparse_dot_dsd = out.__sparse_dot_dsd
+        arg0.__sparse_softmax = out.__sparse_softmax
+        return arg0
+
+    @classmethod
+    def _equal(cls, arg0, arg1):
+        if not (isinstance(arg0, cls) and isinstance(arg1, cls)):
+            return NotImplemented
+        if arg0.shape != arg1.shape:
+            return False
+        if not torch.equal(arg0.__values, arg1.__values):
+            return False
+        if not torch.equal(arg0.__layout, arg1.__layout):
+            return False
+        return True
+
+    @classmethod
     def _to_dense(cls, arg0):
-        return NotImplemented
+        # out = torch.zeros(arg0.shape, dtype=arg0.dtype, device=arg0.device, requires_grad=arg0.requires_grad)
+        out = torch.zeros(arg0.shape, dtype=arg0.dtype, device=arg0.device)
+        values = arg0.__values
+        layout = arg0.__layout
+        block_size = values.shape[-1]
+        blocks_i = layout.shape[-2]
+        blocks_j = layout.shape[-1]
+
+        out_r = out.reshape(
+            arg0.shape[0], arg0.shape[1], blocks_i, block_size, blocks_j, block_size
+        )
+
+        for idx, (h, i, j) in enumerate(zip(*layout.nonzero(as_tuple=True))):
+            out_r[:, h, i, :, j, :] = values[:, idx, :, :]
+
+        return out
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
@@ -107,6 +175,20 @@ class BlockSparseTensor(torch.Tensor):
             values = func(values, *args[1:], **kwargs)
             return cls._wrap(values, x)
 
+        if func == torch.Tensor.to:
+            # print(args, kwargs)
+            assert len(args) >= 2
+            return cls._to(args[0], args[1])
+            # return cls._to(args[0], kwargs["device"])
+
+        if func in [torch.Tensor.copy_]:
+            assert len(args) == 2
+            return cls._copy(args[0], args[1])
+
+        if func in [torch.Tensor.equal, torch.equal]:
+            assert len(args) == 2
+            return cls._equal(args[0], args[1])
+
         if func == torch.Tensor.to_dense:
             assert len(args) == 1
             return cls._to_dense(args[0])
@@ -116,6 +198,20 @@ class BlockSparseTensor(torch.Tensor):
             values = x.__values.clone()
             values = func(values, *args[1:], **kwargs)
             return cls._wrap(values, x)
+
+        if func == torch.Tensor.__deepcopy__:
+            x = args[0]
+            memo = args[1]
+            return cls._raw_wrap(
+                x.__values.__deepcopy__(memo),
+                x.__layout.__deepcopy__(memo),
+                # x.__sparse_dot_sdd.__deepcopy__(memo),
+                # x.__sparse_dot_dsd.__deepcopy__(memo),
+                # x.__sparse_softmax.__deepcopy__(memo),
+                x.__sparse_dot_sdd,
+                x.__sparse_dot_dsd,
+                x.__sparse_softmax,
+            )
 
         if func in [torch.Tensor.grad.__get__, torch.Tensor._grad.__get__]:
             assert len(args) == 1

--- a/xformers/sparse/blocksparse_tensor.py
+++ b/xformers/sparse/blocksparse_tensor.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
 import torch
 from triton.ops.blocksparse import matmul as blocksparse_matmul
 from triton.ops.blocksparse import softmax as blocksparse_softmax


### PR DESCRIPTION
## What does this PR do?

This PR creates a BlockSparse Tensor (similar to SparseCSRTensor). This will ultimately enable to use the same code-path in the `scaled_dot_product_attention`, so that users just need to pass a block-sparse matrix in the mask to get the expected results (as is the case now with `SparseCSRTensor`). This is not yet entirely plugged, but will be done in a follow-up PR.

I haven't made the `Blocksparse` `nn.Module` use our new Tensor for now as it relies on additional information for the softmax which I would rather not add in the `BlockSparseTensor` API (all the different types of masking).


Note that for now the backward of `masked_matmul` is not passing, which is very weird as it was pretty-much a copy-paste of what we had before. This needs to be further investigated.