### PR TITLE
[fix] catch error importing blocksparse tensor when triton not installed

### DIFF
--- a/xformers/sparse/__init__.py
+++ b/xformers/sparse/__init__.py
@@ -3,6 +3,13 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
 
-from .blocksparse_tensor import BlockSparseTensor  # noqa: F401
+try:
+    from .blocksparse_tensor import BlockSparseTensor  # noqa: F401
+except ImportError as e:
+    logging.warning(
+        f"Triton is not available, some optimizations will not be enabled.\nError {e}"
+    )
+
 from .csr_tensor import SparseCSRTensor  # noqa: F401


### PR DESCRIPTION
## What does this PR do?
Tests fail if Triton is not available when using Blocksparse Tensor

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
