### PR TITLE
[CI][minor] Another very minor change, speed up the cpu runs

### DIFF
--- a/tests/test_reversible.py
+++ b/tests/test_reversible.py
@@ -10,8 +10,8 @@ import torch
 
 from xformers.factory.model_factory import xFormer, xFormerConfig
 
-BATCH = 20
-SEQ = 128
+BATCH = 2
+SEQ = 64
 EMB = 48
 VOCAB = 16
 DEVICES = (
@@ -213,5 +213,12 @@ def test_reversible_train(config, device):
     eval_stop_rev = evaluate(model_reversible)
     eval_stop_non_rev = evaluate(model_non_reversible)
     if len(config) < 2:  # only check the encoder case
-        assert eval_start_rev / eval_stop_rev > 3
-        assert eval_start_non_rev / eval_stop_non_rev > 3
+        train_ratio_rev = eval_start_rev / eval_stop_rev
+        train_ratio_non_rev = eval_start_non_rev / eval_stop_non_rev
+
+        # Assert that train ratio > 1 (we trained),
+        # and reversible is not much worse than non-reversible (it's actually better on this dummy test)
+
+        assert train_ratio_rev > 1
+        assert train_ratio_non_rev > 1
+        assert train_ratio_rev > train_ratio_non_rev


### PR DESCRIPTION
## What does this PR do?
CircleCI reported that the reversible unit test was taking north of a minute on CPU ([see](https://app.circleci.com/insights/github/facebookresearch/xformers/workflows/build/tests?branch=main)), simplifying it. Should also help with FB infra
cc @dianaml0 

Insta land, hoping that's ok (cc @fmassa  )

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
