### PR TITLE
Fix typo in attention.random doc

### DIFF
--- a/xformers/components/attention/random.py
+++ b/xformers/components/attention/random.py
@@ -49,7 +49,7 @@ class RandomAttention(Attention):
         **kwargs,
     ):
         """
-        "Random" attention, as proposed for instance in _BigBird.
+        "Random" attention, as proposed for instance in BigBird_.
         Random means in that case that each query can attend to a random set of keys.
         This implementation is sparse-aware, meaning that the empty attention parts will not be represented in memory.
 
@@ -57,8 +57,8 @@ class RandomAttention(Attention):
             r (float): the ratio in [0,1] of keys that the query can attend to
             constant_masking (bool): if true, keep the same random set for all queries.
 
-        _BigBird: "Zaheer, M., Guruganesh, G., Dubey, A., Ainslie, J., Alberti, C., Ontanon, S., Pham, P., Ravula,
-         A., Wang, Q., Yang, L., & Ahmed, A. (2020). Big Bird: Transformers for Longer Sequences. ArXiv, NeurIPS."
+        .. _BigBird: https://arxiv.org/pdf/2007.14062.pdf
+
         """
         super().__init__()
 

--- a/xformers/components/attention/random.py
+++ b/xformers/components/attention/random.py
@@ -50,7 +50,7 @@ class RandomAttention(Attention):
     ):
         """
         "Random" attention, as proposed for instance in _BigBird.
-        Random means in that case means that each query can attend to a random set of keys.
+        Random means in that case that each query can attend to a random set of keys.
         This implementation is sparse-aware, meaning that the empty attention parts will not be represented in memory.
 
         Args:


### PR DESCRIPTION
## What does this PR do?

* Fix typo in attention.random doc. Remove extra "means".
* Unify style for the BigBird reference with what is done [here](https://github.com/facebookresearch/xformers/blob/a65c2432efac89e62257c7ef47aeae1c93ab8f27/xformers/components/attention/local.py#L60).

Thanks for the great repo.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
