### PR TITLE
[Minor] Small triton layer norm refactor, align the different triton layers

### DIFF
--- a/xformers/triton/dropout.py
+++ b/xformers/triton/dropout.py
@@ -203,7 +203,7 @@ class FusedDropoutBias(torch.nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Convenience, catch a possible type or device mismatch
-        if self.bias is not None:  # type: ignore
+        if self.bias is not None:
             self.bias = self.bias.to(dtype=x.dtype, device=x.device)  # type: ignore
 
         # Train/inference

--- a/xformers/triton/fused_linear_layer.py
+++ b/xformers/triton/fused_linear_layer.py
@@ -51,7 +51,9 @@ class _fused_linear_triton(torch.autograd.Function):
 
     @staticmethod
     @custom_bwd
-    def backward(ctx: Any, grad_out: torch.Tensor) -> Any:  # type: ignore
+    def backward(
+        ctx: Any, grad_out: torch.Tensor
+    ) -> Any:  # pragma: no cover  # this is covered, but called directly from C++
         """
         Compute the derivative with respect to x, other tensors were not trainable inputs.
         """


### PR DESCRIPTION
## What does this PR do?
Remove non-kernel code from k_layer_norm basically, do the same as the other triton layers. No logic or perf change, just moving the code around

Initially spotted when looking into #219, but ended up not fixing anything
 
## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
