### PR TITLE
[hotfix] Init typo 

### DIFF
--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -184,21 +184,9 @@ class xFormer(torch.nn.Module):
         )
         self.decoders = torch.nn.ModuleList(decoders)
 
-        if len(self.decoders) > 0:
-            # Use Xavier init for encoding/decoding tasks
-            self._reset_parameters()
-
     @classmethod
     def from_config(cls, config: xFormerConfig):
         return cls(config.stack_configs, config.tie_embedding_weights)
-
-    def _reset_parameters(self):
-        r"""Initiate parameters in the transformer model
-        following the Xavier distribution."""
-
-        for p in self.parameters():
-            if p.dim() > 1:
-                torch.nn.init.xavier_uniform_(p)
 
     def _verify_reversible(self, stack_configs: List[xFormerBlockConfig]):
         reversible = [


### PR DESCRIPTION
## What does this PR do?
I don't think that fixes #219, but related (init not properly done). Caught when implementing #227, I think that we would need to add a proper explicit/programable init to the  model factory to rule out any issue there. 

In the meantime this must have been a typo, I'm not sure when it slipped in but does not make a lot of sense (biases are typically zero-init but linear weights are one-init for instance, this line would nuke that). This PR makes sure that by default the init values defined by the components are preserved

cc @jramapuram

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
