### PR TITLE
[hotfix][minor] Speed fix MHA / self attention

### DIFF
--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -144,10 +144,11 @@ class MultiHeadDispatch(nn.Module):
         self._check(value, "value")
         self._check(key, "key")
 
-        max_batch = max((query.shape[0], key.shape[0], value.shape[0]))
-        query, key, value = map(
-            lambda x: x.expand(max_batch, -1, -1), [query, key, value]
-        )
+        if query.shape[0] != key.shape[0] or query.shape[0] != value.shape[0]:
+            max_batch = max((query.shape[0], key.shape[0], value.shape[0]))
+            query, key, value = map(
+                lambda x: x.expand(max_batch, -1, -1), [query, key, value]
+            )
 
         B, S_Q, _ = query.size()  # Batch x Sequence x Embedding (latent)
         _, S_K, _ = key.size()  # K, Q's sequence length could differ


### PR DESCRIPTION
## What does this PR do?
Rewriting some of the projection operations in the MHA, I stumbled upon this, which nukes the self-attention optimization and is generally a small speed loss (happens all the time, even if not needed because all the tensors are the same).
Does not change any of the logic

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
