### PR TITLE
[bug] Pre-norm wrapper only normalizing the first input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Expose bias flag for feedforwards, same default as Timm [#220]
 - Update eps value for layernormm, same default as torch [#221]
+- PreNorm bugfix, only one input was normalized [#233]
 
 ## [0.0.9] - 2022-02-09
 ### Added

--- a/tests/test_residual.py
+++ b/tests/test_residual.py
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch
+
+from xformers.components import PreNorm
+
+
+class Passthrough(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, *args):
+        return args
+
+
+def test_pre_norm():
+    # Check that passing the same tensor a bunch of times skips the extra normalizations
+    x = torch.rand((3, 3))
+
+    wrap = PreNorm(d_model=3, sublayer=Passthrough(), use_triton=False)
+    outputs = wrap(inputs=[x, x, x])
+
+    assert id(outputs[0]) == id(outputs[1])

--- a/xformers/components/__init__.py
+++ b/xformers/components/__init__.py
@@ -15,7 +15,11 @@ from .attention import Attention, build_attention  # noqa
 from .in_proj_container import InProjContainer, InProjParams  # noqa
 from .multi_head_dispatch import MultiHeadDispatch  # noqa
 from .multi_head_dispatch import MultiHeadDispatchConfig
-from .residual import LayerNormStyle, PostNorm, PreNorm, Residual  # noqa
+from .residual import LayerNormStyle  # noqa; noqa
+from .residual import PostNorm  # noqa
+from .residual import PreNorm  # noqa
+from .residual import RequiresWrappedInputs  # noqa
+from .residual import Residual  # noqa
 
 # automatically import any Python files in the directory
 import_all_modules(str(Path(__file__).parent), "xformers.components")

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -335,8 +335,8 @@ class xFormerEncoderBlock(torch.nn.Module):
             q, k, v = x, x, x
 
         # Pre/Post norms and residual paths are already handled
-        x = self.wrap_att(q, k, v, att_mask=att_mask)
-        x = self.wrap_ff(x)
+        x = self.wrap_att(inputs=[q, k, v], att_mask=att_mask)
+        x = self.wrap_ff(inputs=[x])
 
         return x
 
@@ -397,8 +397,10 @@ class xFormerDecoderBlock(torch.nn.Module):
         else:
             target_q, target_k, target_v = target, target, target
 
-        x = self.wrap_att([target_q, target_k, target_v], att_mask=decoder_att_mask)
-        x = self.wrap_cross([x, memory, memory], att_mask=encoder_att_mask)
-        x = self.wrap_ff(x)
+        x = self.wrap_att(
+            inputs=[target_q, target_k, target_v], att_mask=decoder_att_mask
+        )
+        x = self.wrap_cross(inputs=[x, memory, memory], att_mask=encoder_att_mask)
+        x = self.wrap_ff(inputs=[x])
 
         return x


### PR DESCRIPTION
## What does this PR do?
Could well explain #219 (cc @jramapuram), I stumbled upon this bug by luck while rewriting some of the input projection part and being more strict with self-attention (in that case the tensors need to be the exact same objects, with an incoming PR, makes it easier to catch a bug if the intent is self attention). 

This showed that the pre-norm wrapper was (a) only normalizing the first input (b) creating new objects because it would normalize the tensors one by one, even if it was the same tensor to begin with. This is a bug which already existed in the past and was fixed, not sure how it came back (long lived branch + botched merge maybe), hence the unit test and the change of interface to make sure that this does not happen anymore. Consequence was both correctness + speed (after the pre-norm, the tensors were not the same anymore, so the self attention speed up was off)

(a) I changed the interface to make it compulsory to pass the inputs as a list for all these wrappers, so that there's no more confusion
(b) is unit tested in this PR + the incoming PR will add another test

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
