### PR TITLE
T112038261 reduce test runtime

### DIFF
--- a/tests/test_attention_patterns.py
+++ b/tests/test_attention_patterns.py
@@ -118,10 +118,11 @@ def test_swin_attention_pattern(H, W, window_size):
     w = W // window_size
     d = d.reshape(h, window_size, w, window_size, h, window_size, w, window_size)
 
-    for y, x in itertools.product(range(h), range(w)):
+    product = itertools.product(range(h), range(w))
+    for y, x in product:
         # every region should fully attend to itself
         assert torch.all(d[y, :, x, :, y, :, x, :])
-        for y2, x2 in itertools.product(range(h), range(w)):
+        for y2, x2 in product:
             if y == y2 or x == x2:
                 continue
             # different regions shouldn't attend between each other
@@ -155,12 +156,15 @@ def test_swin_attention_pattern(H, W, window_size):
 def test_dilated_2d_pattern(H, W, k):
     d = AP.dilated_2d_pattern(H, W, k)
     d = d.reshape(H, W, H, W)
-    for h, w in itertools.product(range(H), range(W)):
+
+    product_HW = itertools.product(range(H), range(W))
+    product_kk = itertools.product(range(k), range(k))
+    for h, w in product_HW:
         i = h % k
         j = w % k
         # every kth element is taken
         assert torch.all(d[h, w][i::k, j::k])
-        for ii, jj in itertools.product(range(k), range(k)):
+        for ii, jj in product_kk:
             if ii == i and jj == j:
                 continue
             # and the other elements are discarded

--- a/tests/test_attentions.py
+++ b/tests/test_attentions.py
@@ -103,7 +103,7 @@ def test_order_invariance(
     )
 
     # Check that a shuffled input produces the same results
-    seqs = [SEQ, SEQ//2] if (attention_name != "blocksparse") else [SEQ]
+    seqs = [SEQ, SEQ // 2] if (attention_name != "blocksparse") else [SEQ]
 
     for seq in seqs:
         # Check that we can pass a smaller sequence
@@ -194,7 +194,7 @@ def test_inproj(
     if same_settings:
         in_proj = InProjContainer(in_params, None, None)
     else:
-        out_features = MODEL if same_sizes else MODEL//2
+        out_features = MODEL if same_sizes else MODEL // 2
         in_params_flip = InProjParams(MODEL, out_features, not proj_bias, small_init)
         in_proj = InProjContainer(in_params, in_params_flip, in_params_flip)
 
@@ -248,7 +248,7 @@ def test_different_kq_dimensions(
         # pyre-fixme[29]: The library function `pytest.skip` is not supported by Pyre.
         pytest.skip(f"{attention_name} does not support different k, q dimensions yet.")
 
-    seq_q = SEQ//2
+    seq_q = SEQ // 2
     q = torch.rand((BATCH, seq_q, MODEL), device=device)
     k = torch.rand((BATCH, SEQ, MODEL), device=device)
     v = torch.rand((BATCH, SEQ, MODEL), device=device)

--- a/tests/test_attentions.py
+++ b/tests/test_attentions.py
@@ -23,7 +23,7 @@ DEVICES = (
 
 BATCH = 2
 SEQ = 128 if torch.cuda.is_available() else 32
-MODEL = 128 if torch.cuda.is_available() else 64
+MODEL = 128 if torch.cuda.is_available() else 16
 GLOBAL_ATTENTION_RATIO = (
     _DENSITY_THRESHOLD * 0.9
 )  # Make sure that we test the sparse implementation, no matter the threshold
@@ -81,7 +81,7 @@ def _get_multihead(
     return multi_head
 
 
-@pytest.mark.parametrize("attn_dropout", [0.0, 0.3])
+@pytest.mark.parametrize("attn_dropout", [0.3])
 @pytest.mark.parametrize("residual_dropout", [0.0, 0.1])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("heads", [1, 4])
@@ -103,7 +103,7 @@ def test_order_invariance(
     )
 
     # Check that a shuffled input produces the same results
-    seqs = [SEQ, SEQ - 16] if (attention_name != "blocksparse") else [SEQ]
+    seqs = [SEQ, SEQ//2] if (attention_name != "blocksparse") else [SEQ]
 
     for seq in seqs:
         # Check that we can pass a smaller sequence
@@ -194,7 +194,7 @@ def test_inproj(
     if same_settings:
         in_proj = InProjContainer(in_params, None, None)
     else:
-        out_features = MODEL if same_sizes else MODEL - 16
+        out_features = MODEL if same_sizes else MODEL//2
         in_params_flip = InProjParams(MODEL, out_features, not proj_bias, small_init)
         in_proj = InProjContainer(in_params, in_params_flip, in_params_flip)
 
@@ -248,7 +248,7 @@ def test_different_kq_dimensions(
         # pyre-fixme[29]: The library function `pytest.skip` is not supported by Pyre.
         pytest.skip(f"{attention_name} does not support different k, q dimensions yet.")
 
-    seq_q = SEQ - 16
+    seq_q = SEQ//2
     q = torch.rand((BATCH, seq_q, MODEL), device=device)
     k = torch.rand((BATCH, SEQ, MODEL), device=device)
     v = torch.rand((BATCH, SEQ, MODEL), device=device)

--- a/tests/test_attentions.py
+++ b/tests/test_attentions.py
@@ -81,7 +81,7 @@ def _get_multihead(
     return multi_head
 
 
-@pytest.mark.parametrize("attn_dropout", [0.3])
+@pytest.mark.parametrize("attn_dropout", [0.0, 0.3])
 @pytest.mark.parametrize("residual_dropout", [0.0, 0.1])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("heads", [1, 4])

--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -27,9 +27,9 @@ DEVICES = [torch.device("cuda")]
 VOCAB_SIZE = 64
 
 
-@pytest.mark.parametrize("attn_dropout", [0.0, 0.1])
-@pytest.mark.parametrize("residual_dropout", [0.0, 0.1])
-@pytest.mark.parametrize("heads", [1, 2])
+@pytest.mark.parametrize("attn_dropout", [0.1])
+@pytest.mark.parametrize("residual_dropout", [0.1])
+@pytest.mark.parametrize("heads", [2])
 @pytest.mark.parametrize("activation", [a.value for a in Activation])
 @pytest.mark.parametrize("attention_name", ATTENTION_REGISTRY.keys())
 @pytest.mark.parametrize("feedforward_name", FEEDFORWARD_REGISTRY.keys())
@@ -120,10 +120,10 @@ def test_xformer_encoder_block(
     _ = block(inputs, input_mask=input_mask)
 
 
-@pytest.mark.parametrize("attn_dropout", [0.0, 0.1])
-@pytest.mark.parametrize("residual_dropout", [0.0, 0.1])
+@pytest.mark.parametrize("attn_dropout", [0.1])
+@pytest.mark.parametrize("residual_dropout", [0.1])
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.parametrize("heads", [1, 2])
+@pytest.mark.parametrize("heads", [2])
 @pytest.mark.parametrize("activation", [a.value for a in Activation])
 @pytest.mark.parametrize("rotary_embeddings", [False, True])
 @pytest.mark.parametrize("attention_name", ATTENTION_REGISTRY.keys())

--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -29,7 +29,7 @@ VOCAB_SIZE = 64
 
 @pytest.mark.parametrize("attn_dropout", [0.1])
 @pytest.mark.parametrize("residual_dropout", [0.1])
-@pytest.mark.parametrize("heads", [2])
+@pytest.mark.parametrize("heads", [1, 2])
 @pytest.mark.parametrize("activation", [a.value for a in Activation])
 @pytest.mark.parametrize("attention_name", ATTENTION_REGISTRY.keys())
 @pytest.mark.parametrize("feedforward_name", FEEDFORWARD_REGISTRY.keys())
@@ -123,7 +123,7 @@ def test_xformer_encoder_block(
 @pytest.mark.parametrize("attn_dropout", [0.1])
 @pytest.mark.parametrize("residual_dropout", [0.1])
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.parametrize("heads", [2])
+@pytest.mark.parametrize("heads", [1, 2])
 @pytest.mark.parametrize("activation", [a.value for a in Activation])
 @pytest.mark.parametrize("rotary_embeddings", [False, True])
 @pytest.mark.parametrize("attention_name", ATTENTION_REGISTRY.keys())

--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -27,8 +27,8 @@ DEVICES = [torch.device("cuda")]
 VOCAB_SIZE = 64
 
 
-@pytest.mark.parametrize("attn_dropout", [0.1])
-@pytest.mark.parametrize("residual_dropout", [0.1])
+@pytest.mark.parametrize("attn_dropout", [0.0, 0.1])
+@pytest.mark.parametrize("residual_dropout", [0.0, 0.1])
 @pytest.mark.parametrize("heads", [1, 2])
 @pytest.mark.parametrize("activation", [a.value for a in Activation])
 @pytest.mark.parametrize("attention_name", ATTENTION_REGISTRY.keys())
@@ -120,8 +120,8 @@ def test_xformer_encoder_block(
     _ = block(inputs, input_mask=input_mask)
 
 
-@pytest.mark.parametrize("attn_dropout", [0.1])
-@pytest.mark.parametrize("residual_dropout", [0.1])
+@pytest.mark.parametrize("attn_dropout", [0.0, 0.1])
+@pytest.mark.parametrize("residual_dropout", [0.0, 0.1])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("heads", [1, 2])
 @pytest.mark.parametrize("activation", [a.value for a in Activation])

--- a/tests/test_compositional_attention.py
+++ b/tests/test_compositional_attention.py
@@ -29,7 +29,7 @@ GLOBAL_ATTENTION_RATIO = (
 assert ATTENTION_REGISTRY.keys(), "Attention layers should have been registered"
 
 
-@pytest.mark.parametrize("attn_dropout", [0.3])
+@pytest.mark.parametrize("attn_dropout", [0.0, 0.3])
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("heads", [4])
 @pytest.mark.parametrize("rules", [4])

--- a/tests/test_compositional_attention.py
+++ b/tests/test_compositional_attention.py
@@ -29,10 +29,10 @@ GLOBAL_ATTENTION_RATIO = (
 assert ATTENTION_REGISTRY.keys(), "Attention layers should have been registered"
 
 
-@pytest.mark.parametrize("attn_dropout", [0.0, 0.3])
+@pytest.mark.parametrize("attn_dropout", [0.3])
 @pytest.mark.parametrize("causal", [True, False])
-@pytest.mark.parametrize("heads", [1, 4])
-@pytest.mark.parametrize("rules", [1, 4])
+@pytest.mark.parametrize("heads", [4])
+@pytest.mark.parametrize("rules", [4])
 @pytest.mark.parametrize("q_compose", [False, True])
 @pytest.mark.parametrize("dim_selection", [MODEL // 2, None])
 @pytest.mark.parametrize("bias", [True, False])

--- a/tests/test_core_attention.py
+++ b/tests/test_core_attention.py
@@ -13,7 +13,7 @@ _devices = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
 
 
 def test_core_attention():
-    b, s, d = 4, 90, 16
+    b, s, d = 2, 400, 8
     prob = 0.95
 
     a = torch.rand(b, s, d)

--- a/tests/test_core_attention.py
+++ b/tests/test_core_attention.py
@@ -13,7 +13,7 @@ _devices = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
 
 
 def test_core_attention():
-    b, s, d = 8, 900, 32
+    b, s, d = 4, 90, 16
     prob = 0.95
 
     a = torch.rand(b, s, d)
@@ -29,7 +29,7 @@ def test_core_attention():
 
 def test_core_attention_mask_types():
 
-    b, s, d = 8, 900, 32
+    b, s, d = 4, 90, 16
     prob = 0.8  # make sure that we trigger the sparse kernels
 
     a = torch.rand(b, s, d)

--- a/tests/test_global_attention.py
+++ b/tests/test_global_attention.py
@@ -9,7 +9,7 @@ from xformers.components.attention import GlobalAttention, ScaledDotProduct
 
 
 def test_global_attention():
-    b, s, d = 8, 900, 384
+    b, s, d = 2, 90, 40
 
     def test_ratio(global_attention_ratio: float):
         # Make sure that Global and Normal attention get the same results for the corresponding tokens
@@ -31,7 +31,7 @@ def test_global_attention():
         # Check that the tokens which have access to the full attention give the same
         # results as the monolithic dense scaled_dot_product
         mask = config["attention_query_mask"][:, 0]
-        torch.allclose(r_global[:, mask, :], r_dense[:, mask, :])
+        assert torch.allclose(r_global[:, mask, :], r_dense[:, mask, :])
 
     # Test with different levels of sparsity, to make sure that all the paths are covered
     test_ratio(0.02)

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -11,8 +11,9 @@ import torch
 from xformers.factory.model_factory import xFormer, xFormerConfig
 
 BATCH = 2
-SEQ = 64
-EMB = 64
+SEQ = 16
+EMB = 16
+VOC = 16
 
 DEVICES = (
     [torch.device("cpu")]
@@ -30,7 +31,7 @@ encoder_configs = {
     "position_encoding_config": {
         "name": "vocab",
         "seq_len": SEQ,
-        "vocab_size": 64,
+        "vocab_size": VOC,
         "dim_model": EMB,
     },
     "num_layers": 3,
@@ -63,7 +64,7 @@ decoder_configs = {
     "position_encoding_config": {
         "name": "vocab",
         "seq_len": SEQ,
-        "vocab_size": 64,
+        "vocab_size": VOC,
         "dim_model": EMB,
     },
     "num_layers": 2,

--- a/tests/test_nystrom_attention.py
+++ b/tests/test_nystrom_attention.py
@@ -42,24 +42,28 @@ def test_nystrom_attention_close_to_sdp(
 
     a = torch.rand(b, s, d)
 
-    # Make sure that Nystrom and Normal attention are not too far off.
-    nystrom_attention = NystromAttention(**nystrom_config)
-    sdp_attention = ScaledDotProduct(**sdp_config)
+    def test_close_to_sdp():
+        # Make sure that Nystrom and Normal attention are not too far off.
 
-    r_nystrom = nystrom_attention(a, a, a, att_mask=None)
-    r_sdp = sdp_attention(a, a, a, att_mask=None)
+        nystrom_attention = NystromAttention(**nystrom_config)
+        sdp_attention = ScaledDotProduct(**sdp_config)
 
-    assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
+        r_nystrom = nystrom_attention(a, a, a, att_mask=None)
+        r_sdp = sdp_attention(a, a, a, att_mask=None)
 
-    # Make sure that Nystrom and Normal attention are not too far off.
+        assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
 
-    nystrom_attention = NystromAttention(**nystrom_config)
-    sdp_attention = ScaledDotProduct(**sdp_config)
+        # Make sure that Nystrom and Normal attention are not too far off.
 
-    r_nystrom = nystrom_attention(a, a, a, att_mask=None)
-    r_sdp = sdp_attention(a, a, a, att_mask=None)
+        nystrom_attention = NystromAttention(**nystrom_config)
+        sdp_attention = ScaledDotProduct(**sdp_config)
 
-    assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
+        r_nystrom = nystrom_attention(a, a, a, att_mask=None)
+        r_sdp = sdp_attention(a, a, a, att_mask=None)
+
+        assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
+
+    test_close_to_sdp()
 
 
 @pytest.mark.parametrize("pinverse_original_init", [True])

--- a/tests/test_nystrom_attention.py
+++ b/tests/test_nystrom_attention.py
@@ -13,8 +13,8 @@ from xformers.components.attention.utils import maybe_merge_masks
 
 @pytest.mark.parametrize("pinverse_original_init", [True, False])
 @pytest.mark.parametrize("use_razavi_pinverse", [True, False])
-@pytest.mark.parametrize("num_landmarks", [33, 905])
-def test_nystrom_attention(
+@pytest.mark.parametrize("num_landmarks", [30, 33, 905])
+def test_nystrom_attention_close_to_sdp(
     pinverse_original_init: bool,
     use_razavi_pinverse: bool,
     num_landmarks: int,
@@ -42,26 +42,56 @@ def test_nystrom_attention(
 
     a = torch.rand(b, s, d)
 
-    def test_close_to_sdp():
-        # Make sure that Nystrom and Normal attention are not too far off.
+    # Make sure that Nystrom and Normal attention are not too far off.
+    nystrom_attention = NystromAttention(**nystrom_config)
+    sdp_attention = ScaledDotProduct(**sdp_config)
 
-        nystrom_attention = NystromAttention(**nystrom_config)
-        sdp_attention = ScaledDotProduct(**sdp_config)
+    r_nystrom = nystrom_attention(a, a, a, att_mask=None)
+    r_sdp = sdp_attention(a, a, a, att_mask=None)
 
-        r_nystrom = nystrom_attention(a, a, a, att_mask=None)
-        r_sdp = sdp_attention(a, a, a, att_mask=None)
+    assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
 
-        assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
+    # Make sure that Nystrom and Normal attention are not too far off.
 
-        # Make sure that Nystrom and Normal attention are not too far off.
+    nystrom_attention = NystromAttention(**nystrom_config)
+    sdp_attention = ScaledDotProduct(**sdp_config)
 
-        nystrom_attention = NystromAttention(**nystrom_config)
-        sdp_attention = ScaledDotProduct(**sdp_config)
+    r_nystrom = nystrom_attention(a, a, a, att_mask=None)
+    r_sdp = sdp_attention(a, a, a, att_mask=None)
 
-        r_nystrom = nystrom_attention(a, a, a, att_mask=None)
-        r_sdp = sdp_attention(a, a, a, att_mask=None)
+    assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
 
-        assert torch.allclose(r_nystrom, r_sdp, rtol=0.005, atol=1e-2)
+
+@pytest.mark.parametrize("pinverse_original_init", [True])
+@pytest.mark.parametrize("use_razavi_pinverse", [True])
+@pytest.mark.parametrize("num_landmarks", [30])
+def test_nystrom_attention(
+    pinverse_original_init: bool,
+    use_razavi_pinverse: bool,
+    num_landmarks: int,
+):
+    # TODO: conv_kernel_size parameter not set to None fails this test. Investigate.
+    b, s, d = 2, 900, 40
+    num_heads = 2
+    seed = 42
+    torch.random.manual_seed(seed)
+    random.seed(seed)
+
+    nystrom_config = {
+        "name": "nystrom",
+        "dropout": 0.0,
+        "num_landmarks": num_landmarks,
+        "num_heads": num_heads,
+        "pinverse_original_init": pinverse_original_init,
+        "use_razavi_pinverse": use_razavi_pinverse,
+    }
+
+    sdp_config = {
+        "name": "scaled_dot_product",
+        "dropout": 0.0,
+    }
+
+    a = torch.rand(b, s, d)
 
     def test_att_mask_ignored():
         # If an sxs attention mask is passed in, it should be ignored.
@@ -119,6 +149,5 @@ def test_nystrom_attention(
         with pytest.raises(AssertionError):
             nystrom_attention(a, a, a, key_padding_mask=key_padding_mask)
 
-    test_close_to_sdp()
     test_att_mask_ignored()
     test_masking()

--- a/tests/test_nystrom_attention.py
+++ b/tests/test_nystrom_attention.py
@@ -13,14 +13,14 @@ from xformers.components.attention.utils import maybe_merge_masks
 
 @pytest.mark.parametrize("pinverse_original_init", [True, False])
 @pytest.mark.parametrize("use_razavi_pinverse", [True, False])
-@pytest.mark.parametrize("num_landmarks", [30, 33, 905])
+@pytest.mark.parametrize("num_landmarks", [33, 905])
 def test_nystrom_attention(
     pinverse_original_init: bool,
     use_razavi_pinverse: bool,
     num_landmarks: int,
 ):
     # TODO: conv_kernel_size parameter not set to None fails this test. Investigate.
-    b, s, d = 8, 900, 384
+    b, s, d = 2, 900, 40
     num_heads = 2
     seed = 42
     torch.random.manual_seed(seed)


### PR DESCRIPTION
## What does this PR do?
Decreased CPU test suite runtime in Meta internal testing utility. This was requested via a Meta task filed by @dianaml0.

The changes include:

- decreasing the number of parameterized test cases in some of the highest cardinality test cases
- reducing tensor sizes in some of the slowest running tests (several minute runtime in Sandcastle -> few seconds)
- small number of changes to reduce inefficiencies in the code involving itertools.product()

## Before submitting

- [🙃 ] Did you have fun?
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [-] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  This was requested via a Meta task.
- [-] Did you make sure to update the docs?
  - [X] N/A
- [-] Did you write any new necessary tests?
  - [X] N/A
- [-] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [X] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
