### PR TITLE
[fix] Input mask <> attention mask 

### DIFF
--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -288,9 +288,11 @@ class xFormer(torch.nn.Module):
                 # Reversible Encoder
                 x = torch.cat([memory, memory], dim=-1)
 
-                # TODO: pass in key and value independently.
-                kwargs = {"att_mask": encoder_input_mask}
-                x = encoders(x, **kwargs)
+                # Apply the optional input masking
+                if encoder_input_mask is not None:
+                    x += encoder_input_mask.unsqueeze(0).unsqueeze(-1)
+
+                x = encoders(x)
                 memory = torch.stack(x.chunk(2, dim=-1)).mean(dim=0)
 
             if not self.decoders:


### PR DESCRIPTION
## What does this PR do?
mislabelled input mask / attention mask  in the encoder factory, found out of luck while ironing out the triton 2 PR (given that the blocksparse attention does not accept an attention mask anymore)

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
