### PR TITLE
[CI][Super minor] Align nightly pre-builts and agents' cuda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ cpu_py38: &cpu_py38
     - image: cimg/python:3.8
   resource_class: large
 
-gpu_cu112: &gpu_cu112
+gpu_cu111: &gpu_cu111
   environment:
-    CUDA_VERSION: "11.2"
-    CUDA_HOME: /usr/local/cuda-11.2
+    CUDA_VERSION: "11.1"
+    CUDA_HOME: /usr/local/cuda-11.1
   machine:
-    image: ubuntu-2004-cuda-11.2:202103-01
+    image: ubuntu-1604-cuda-11.1:202012-01
     resource_class: gpu.nvidia.medium
 
 
@@ -268,7 +268,7 @@ jobs:
 
 
   gpu_tests:
-    <<: *gpu_cu112
+    <<: *gpu_cu111
 
     working_directory: ~/xformers
 
@@ -285,7 +285,7 @@ jobs:
       # Cache the venv directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-key-gpu-112-394-{{ checksum "requirements-test.txt" }}-{{ checksum ".circleci/config.yml" }}
+            - cache-key-gpu-111-{{ checksum "requirements-test.txt" }}-{{ checksum ".circleci/config.yml" }}
 
       - <<: *install_dep
 
@@ -296,7 +296,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: cache-key-gpu-112-394-{{ checksum "requirements-test.txt"}}-{{ checksum ".circleci/config.yml"}}
+          key: cache-key-gpu-111-{{ checksum "requirements-test.txt"}}-{{ checksum ".circleci/config.yml"}}
 
       - <<: *install_repo
 
@@ -312,7 +312,7 @@ jobs:
           path: test-results
 
   gpu_experimental_tests:
-    <<: *gpu_cu112
+    <<: *gpu_cu111
 
     working_directory: ~/xformers
 
@@ -329,7 +329,7 @@ jobs:
       # Cache the venv directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-key-gpu-exp-112-394-{{ checksum "requirements-experimental.txt" }}-{{ checksum ".circleci/config.yml" }}
+            - cache-key-gpu-exp-111-{{ checksum "requirements-experimental.txt" }}-{{ checksum ".circleci/config.yml" }}
 
       - <<: *install_dep_exp
 
@@ -341,7 +341,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: cache-key-gpu-exp-112-394-{{ checksum "requirements-experimental.txt"}}-{{ checksum ".circleci/config.yml"}}
+          key: cache-key-gpu-exp-111-{{ checksum "requirements-experimental.txt"}}-{{ checksum ".circleci/config.yml"}}
 
       - <<: *install_experimental_repo
       - <<: *run_experimental_unittests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,6 +10,7 @@ isort == 5.7.0
 mypy == 0.812
 pyre-check == 0.9.8
 pyre-extensions == 0.0.23
+click == 8.0.4
 
 # Tools for unit tests & coverage.
 pytest == 5.4.1

--- a/xformers/benchmarks/benchmark_vit_timm.py
+++ b/xformers/benchmarks/benchmark_vit_timm.py
@@ -394,7 +394,7 @@ if __name__ == "__main__":
         max_epochs=MAX_EPOCHS,
         detect_anomaly=True,
         precision=16,
-        profiler=profiler,
+        profiler=profiler,  # type: ignore
     )
     trainer.fit(lm, dm)
 


### PR DESCRIPTION
## What does this PR do?
The CI agents that we use have cuda 11.2, but we were pulling in the 11.1 builds. Somehow it worked before, but stopped working recently (CI still works because this step is usually cached). Agents are available for cuda 11.1, aligning the two with this PR

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
