### PR TITLE
[minor] Label attention properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ run_unittests: &run_unittests
   - run:
       name: Run Unit Tests
       command: |
-        pytest --junitxml=test-results/junit.xml --verbose --timeout 600 tests
+        CUDA_LAUNCH_BLOCKING=1 pytest --junitxml=test-results/junit.xml --verbose --timeout 600 tests
 
 run_experimental_unittests: &run_experimental_unittests
   - run:

--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -111,9 +111,14 @@ def test_xformer_encoder_block(
     _ = block(inputs)
 
     # Check that we support attention masking, at least interface wise (do not check correctness yet)
+    att_mask = torch.ones(SEQ, SEQ, dtype=torch.bool, device=device)
     if block.mha.attention.supports_attention_mask:
-        att_mask = torch.ones(SEQ, SEQ, dtype=torch.bool, device=device)
         _ = block(inputs, att_mask=att_mask)
+    else:
+        with pytest.raises(AssertionError):
+            # Check that passing an attention mask to a mechanism which does not support it raises
+            # an exception
+            _ = block(inputs, att_mask=att_mask)
 
     # Check that we support input masking, at least interface wise (do not check correctness yet)
     input_mask = torch.randn(SEQ, dtype=torch.float, device=device)

--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -111,8 +111,9 @@ def test_xformer_encoder_block(
     _ = block(inputs)
 
     # Check that we support attention masking, at least interface wise (do not check correctness yet)
-    att_mask = torch.ones(SEQ, SEQ, dtype=torch.bool, device=device)
-    _ = block(inputs, att_mask=att_mask)
+    if block.mha.attention.supports_attention_mask:
+        att_mask = torch.ones(SEQ, SEQ, dtype=torch.bool, device=device)
+        _ = block(inputs, att_mask=att_mask)
 
     # Check that we support input masking, at least interface wise (do not check correctness yet)
     input_mask = torch.randn(SEQ, dtype=torch.float, device=device)
@@ -223,7 +224,10 @@ def test_xformer_decoder_block(
     input_mask[input_mask < 0.0] = -float("inf")
 
     encoded = encoder_block(inputs)
-    _ = decoder_block(inputs, encoded, encoder_att_mask=att_mask, input_mask=input_mask)
+    if decoder_block.mha.attention.supports_attention_mask:
+        _ = decoder_block(
+            inputs, encoded, encoder_att_mask=att_mask, input_mask=input_mask
+        )
 
     # Test different sequence lengths when encoding and decoding
     if not decoder_block.mha.attention.requires_same_k_q_dimensions:
@@ -303,8 +307,9 @@ def test_embedding_projection():
     _ = block(inputs)
 
     # Check that we support attention masking, at least interface wise (do not check correctness yet)
-    att_mask = torch.ones(SEQ, SEQ, dtype=torch.bool, device=device)
-    _ = block(inputs, att_mask=att_mask)
+    if block.mha.attention.supports_attention_mask:
+        att_mask = torch.ones(SEQ, SEQ, dtype=torch.bool, device=device)
+        _ = block(inputs, att_mask=att_mask)
 
     # Check that we support input masking, at least interface wise (do not check correctness yet)
     input_mask = torch.randn(SEQ, dtype=torch.float, device=device)

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -39,7 +39,7 @@ encoder_configs = {
         "num_heads": 4,
         "residual_dropout": 0,
         "attention": {
-            "name": "linformer",
+            "name": "scaled_dot_product",
             "dropout": 0,
             "causal": True,
             "seq_len": SEQ,
@@ -73,7 +73,7 @@ decoder_configs = {
         "residual_dropout": 0,
         "dim_model": EMB,
         "attention": {
-            "name": "linformer",
+            "name": "scaled_dot_product",
             "dropout": 0,
             "causal": True,
             "seq_len": SEQ,
@@ -84,7 +84,7 @@ decoder_configs = {
         "residual_dropout": 0,
         "dim_model": EMB,
         "attention": {
-            "name": "linformer",
+            "name": "scaled_dot_product",
             "dropout": 0,
             "causal": True,
             "seq_len": SEQ,

--- a/xformers/components/attention/base.py
+++ b/xformers/components/attention/base.py
@@ -55,7 +55,7 @@ class Attention(nn.Module, metaclass=ABCMeta):
 
         # Whether this attention mechanism supports attention masks
         self.supports_attention_mask = True
-        self.supports_key_padding_mask = True
+        self.supports_key_padding_mask = False
 
     @classmethod
     def from_config(cls: Type[Self], config: AttentionConfig) -> Self:

--- a/xformers/components/attention/base.py
+++ b/xformers/components/attention/base.py
@@ -53,6 +53,10 @@ class Attention(nn.Module, metaclass=ABCMeta):
         # so that the MHA wrapper should skip it
         self.requires_skip_multi_head = False
 
+        # Whether this attention mechanism supports attention masks
+        self.supports_attention_mask = True
+        self.supports_key_padding_mask = True
+
     @classmethod
     def from_config(cls: Type[Self], config: AttentionConfig) -> Self:
         # Generate the class inputs from the config

--- a/xformers/components/attention/blocksparse.py
+++ b/xformers/components/attention/blocksparse.py
@@ -114,8 +114,11 @@ if _is_triton_available:
 
             # key padding mask and attention mask must be passed in separately
             self.requires_separate_masks = True
-
             self.requires_same_k_q_dimensions = True
+
+            # Properties specific to this attention mechanism
+            self.supports_attention_mask = True
+            self.supports_key_padding_mask = True
 
         def update_mask_type(self, mask: torch.Tensor):
             global _mask_type_warning

--- a/xformers/components/attention/compositional.py
+++ b/xformers/components/attention/compositional.py
@@ -189,6 +189,10 @@ class CompositionalAttention(Attention):
 
         self.causal = causal
 
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = True
+        self.supports_key_padding_mask = False
+
         self._reset_parameters()
 
     def _reset_parameters(self):

--- a/xformers/components/attention/favor.py
+++ b/xformers/components/attention/favor.py
@@ -104,6 +104,9 @@ class FavorAttention(Attention):
 
         self.feature_map: FeatureMap = feature_map_constructor(**feature_settings)  # type: ignore
 
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = False
+
     @staticmethod
     def _maybe_promote(x: torch.Tensor) -> torch.Tensor:
         # Only promote fp16 buffers, bfloat16 would be fine for instance

--- a/xformers/components/attention/favor.py
+++ b/xformers/components/attention/favor.py
@@ -106,6 +106,7 @@ class FavorAttention(Attention):
 
         # Properties specific to this attention mechanism
         self.supports_attention_mask = False
+        self.supports_key_padding_mask = False
 
     @staticmethod
     def _maybe_promote(x: torch.Tensor) -> torch.Tensor:

--- a/xformers/components/attention/fourier_mix.py
+++ b/xformers/components/attention/fourier_mix.py
@@ -20,6 +20,9 @@ class FourierMix(Attention):
         """
         super().__init__()
         self.attn_drop = torch.nn.Dropout(dropout, inplace=False)
+
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = False
         self.requires_input_projection = False
 
     def forward(self, q: torch.Tensor, *_, **__):

--- a/xformers/components/attention/global_tokens.py
+++ b/xformers/components/attention/global_tokens.py
@@ -78,7 +78,10 @@ class GlobalAttention(Attention):
             else maybe_sparsify(self.attention_mask)
         )
 
+        # Properties specific to this attention mechanism
         self.requires_same_k_q_dimensions = True
+        self.supports_attention_mask = False
+        self.supports_key_padding_mask = False
 
     def forward(
         self,

--- a/xformers/components/attention/lambda_layer.py
+++ b/xformers/components/attention/lambda_layer.py
@@ -48,6 +48,7 @@ class LambdaLayer(Attention):
         # Properties specific to this attention mechanism
         self.requires_same_k_q_dimensions = True
         self.supports_attention_mask = False
+        self.supports_key_padding_mask = False
 
     def forward(
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, *args, **kwargs

--- a/xformers/components/attention/lambda_layer.py
+++ b/xformers/components/attention/lambda_layer.py
@@ -44,7 +44,10 @@ class LambdaLayer(Attention):
         )
         self.rel_pos = calc_rel_pos(seq_len)
         self.attn_drop = torch.nn.Dropout(dropout, inplace=True)
+
+        # Properties specific to this attention mechanism
         self.requires_same_k_q_dimensions = True
+        self.supports_attention_mask = False
 
     def forward(
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, *args, **kwargs

--- a/xformers/components/attention/linformer.py
+++ b/xformers/components/attention/linformer.py
@@ -47,7 +47,10 @@ class LinformerAttention(Attention):
         # kq need to have the same dimension
         self.requires_same_k_q_dimensions = True
 
-        # This attention does not support attention masks
+        # THis attention has a specific input projection mechanism
+        self.requires_input_projection = False
+
+        # Properties specific to this attention mechanism
         self.supports_attention_mask = False
 
     def forward(

--- a/xformers/components/attention/linformer.py
+++ b/xformers/components/attention/linformer.py
@@ -42,7 +42,13 @@ class LinformerAttention(Attention):
         self.F = nn.Linear(seq_len, k, bias=False)
         self.attn_drop = nn.Dropout(dropout, inplace=False)
         self.seq_len = seq_len
+
+        # MHA related flags:
+        # kq need to have the same dimension
         self.requires_same_k_q_dimensions = True
+
+        # This attention does not support attention masks
+        self.supports_attention_mask = False
 
     def forward(
         self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, *args, **kwargs

--- a/xformers/components/attention/local.py
+++ b/xformers/components/attention/local.py
@@ -77,6 +77,10 @@ class LocalAttention(Attention):
         self.attention_mask: Optional[torch.Tensor] = None
         self.requires_same_k_q_dimensions = True
 
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = True
+        self.supports_key_padding_mask = False
+
     def _get_local_mask(self, shape: torch.Size) -> torch.Tensor:
         window_size = self.window_size * 2 + 1 if self.causal else self.window_size
         mask = local_1d_pattern(shape[1], window_size)

--- a/xformers/components/attention/nystrom.py
+++ b/xformers/components/attention/nystrom.py
@@ -156,6 +156,7 @@ class NystromAttention(Attention):
 
         # This attention does not support attention masks
         self.supports_attention_mask = False
+        self.supports_key_padding_mask = True
 
     def forward(
         self,

--- a/xformers/components/attention/nystrom.py
+++ b/xformers/components/attention/nystrom.py
@@ -154,6 +154,9 @@ class NystromAttention(Attention):
         self.causal_mask_2: Optional[torch.Tensor] = None
         self.causal_mask_3: Optional[torch.Tensor] = None
 
+        # This attention does not support attention masks
+        self.supports_attention_mask = False
+
     def forward(
         self,
         q: torch.Tensor,

--- a/xformers/components/attention/ortho.py
+++ b/xformers/components/attention/ortho.py
@@ -72,6 +72,10 @@ class OrthoFormerAttention(Attention):
         self.subsample_fraction = subsample_fraction
         self.landmark_selection = landmark_selection
 
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = True
+        self.supports_key_padding_mask = False
+
     def forward(
         self,
         q: torch.Tensor,

--- a/xformers/components/attention/random.py
+++ b/xformers/components/attention/random.py
@@ -68,6 +68,11 @@ class RandomAttention(Attention):
         self.rand_attention_mask: Optional[torch.Tensor] = None
         self.constant_masking = constant_masking
         self.force_sparsity = force_sparsity
+
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = True
+        self.supports_key_padding_mask = False
+
         self.requires_same_k_q_dimensions = True
 
     def _get_rand_mask(self, shape: torch.Size) -> torch.Tensor:

--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -57,6 +57,10 @@ class ScaledDotProduct(Attention):
         else:
             self.mask = None
 
+        # Properties specific to this attention mechanism
+        self.supports_attention_mask = True
+        self.supports_key_padding_mask = False
+
     def forward(
         self,
         q: torch.Tensor,

--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -165,10 +165,21 @@ class MultiHeadDispatch(nn.Module):
                     + "In that case causality is ill-determined. Please pad your sequences accordingly"
                 )
 
+        kw_mask_args = {}
+        if att_mask is not None:
+            assert (
+                self.attention.supports_attention_mask
+            ), "This attention does not support attention masks"
+            kw_mask_args["att_mask"] = att_mask
+
+        if key_padding_mask is not None:
+            assert (
+                self.attention.supports_key_padding_mask
+            ), "This attention does not support attention masks"
+            kw_mask_args["key_padding_mask"] = key_padding_mask
+
         if self.attention.requires_skip_multi_head:
-            return self.attention(
-                query, key, value, att_mask=att_mask, key_padding_mask=key_padding_mask
-            )
+            return self.attention(query, key, value, **kw_mask_args)
 
         # Calculate query, key, values for all heads in batch
         if self.attention.requires_input_projection:
@@ -199,9 +210,7 @@ class MultiHeadDispatch(nn.Module):
             v = reshape_fn(v, B, S_K, self.num_heads, self.dim_k)
 
         # Self-attend
-        y = self.attention(
-            q=q, k=k, v=v, att_mask=att_mask, key_padding_mask=key_padding_mask
-        )
+        y = self.attention(q=q, k=k, v=v, **kw_mask_args)
 
         # Re-assemble all head outputs side by side
         y = (


### PR DESCRIPTION
## What does this PR do?
Removes changes from the triton2 incoming PR, adds a field to all the attentions to mark whether they support an attention mask. The attentions which project onto a smaller space do not support that, and the new blocksparse attention introduced with Triton2 do not support it either.

Up until now passing an attention mask to these attention mechanisms would be silently ignored, this makes sure that it's not the case (an assert is raised), and it provides an easy way to check whether this mechanism supports that

Related to #231 (via triton2, which will support bf16 over blocksparse operations)

## Before submitting
- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
