### PR TITLE
Memory-efficient attention - forward pass

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+# needed to register custom ops
+import xformers  # noqa: F401
+
+_devices = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+
+
+def ref_attention(q, k, v):
+    return (q @ k.transpose(-2, -1)).softmax(-1) @ v
+
+
+@pytest.mark.parametrize("k_len", [5, 6, 32])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("kv_len", [3, 15, 32, 33])
+@pytest.mark.parametrize("q_len", [2, 3, 5])
+@pytest.mark.parametrize("device", _devices)
+def test_memory_efficient_attention(device, q_len, kv_len, batch_size, k_len):
+    scale = 3
+    query = torch.randn((batch_size, q_len, k_len), device=device) * scale
+    key = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+    value = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+
+    out = torch.ops.xformers.efficient_attention(query, key, value)
+    ref = ref_attention(query, key, value)
+
+    assert torch.allclose(out, ref, atol=2e-4)
+
+
+@pytest.mark.parametrize("k_len", [5, 6, 32])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("kv_len", [128, 512])
+@pytest.mark.parametrize("q_len", [128, 512])
+@pytest.mark.parametrize("device", _devices)
+def test_key_query_all_ones(device, q_len, kv_len, batch_size, k_len):
+    scale = 3
+    query = torch.ones((batch_size, q_len, k_len), device=device)
+    key = torch.ones((batch_size, kv_len, k_len), device=device)
+    value = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+
+    out = torch.ops.xformers.efficient_attention(query, key, value)
+    # this should be equivalent to the average over value
+    ref = value.mean(1, keepdim=True).expand_as(query)
+
+    assert torch.allclose(out, ref, atol=1e-5)

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -5,11 +5,11 @@ from typing import Dict
 import torch
 from torch.utils import benchmark
 
-# needed to register custom ops
-import xformers  # noqa: F401
+import xformers.ops
 
 
 def ref_attention(q, k, v):
+    q = q * (1.0 / q.shape[-1] ** 0.5)
     return (q @ k.transpose(-2, -1)).softmax(-1) @ v
 
 
@@ -33,7 +33,7 @@ for num_threads in NUM_THREADS:
         sub_label = f"B={B}, M={M}, K={K}"
 
         if True:
-            r = torch.ops.xformers.efficient_attention(q, q, q)
+            r = xformers.ops.memory_efficient_attention(q, q, q)
 
             rr = ref_attention(q, q, q)
             assert (r - rr).abs().max() < 1e-5

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -1,0 +1,89 @@
+import itertools
+import pprint
+from typing import Dict
+
+import torch
+from torch.utils import benchmark
+
+# needed to register custom ops
+import xformers  # noqa: F401
+
+
+def ref_attention(q, k, v):
+    return (q @ k.transpose(-2, -1)).softmax(-1) @ v
+
+
+min_run_time = 2
+device = torch.device("cuda")
+
+NUM_THREADS = [1] if device.type == "cuda" else [1, 40]
+SHAPES = list(
+    itertools.product([1, 8, 32, 256], [127, 128, 512, 513, 1023, 1024], [16, 32])
+)
+
+results = []
+mem_use: Dict[str, Dict[str, float]] = dict(optimized={}, vanilla={})
+
+print(f"Processing {len(SHAPES)} cases")
+for num_threads in NUM_THREADS:
+    for shape in SHAPES:
+        print(f"===== {shape} =====")
+        B, M, K = shape
+        q = torch.rand(shape, device=device)
+        sub_label = f"B={B}, M={M}, K={K}"
+
+        if True:
+            r = torch.ops.xformers.efficient_attention(q, q, q)
+
+            rr = ref_attention(q, q, q)
+            assert (r - rr).abs().max() < 1e-5
+
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.synchronize()
+        results.append(
+            benchmark.Timer(
+                stmt="fn(q, q, q)",
+                globals={
+                    "q": q,
+                    "fn": torch.ops.xformers.efficient_attention,
+                },
+                label="attention",
+                description="optimized",
+                sub_label=sub_label,
+                num_threads=num_threads,
+            ).blocked_autorange(min_run_time=min_run_time)
+        )
+        torch.cuda.synchronize()
+        memory = torch.cuda.max_memory_allocated() / 2 ** 20
+        mem_use["optimized"][sub_label] = memory
+        memory = f"Memory used: {memory} MB"
+
+        print("Optimized", memory)
+
+        torch.cuda.reset_peak_memory_stats()
+        torch.cuda.synchronize()
+        results.append(
+            benchmark.Timer(
+                stmt="fn(q, q, q)",
+                globals={
+                    "q": q,
+                    "fn": ref_attention,
+                },
+                label="attention",
+                description="vanilla",
+                sub_label=sub_label,
+                num_threads=num_threads,
+            ).blocked_autorange(min_run_time=min_run_time)
+        )
+
+        torch.cuda.synchronize()
+        memory = torch.cuda.max_memory_allocated() / 2 ** 20
+        mem_use["vanilla"][sub_label] = memory
+        memory = f"Memory used: {memory} MB"
+        print("Vanilla", memory)
+
+
+compare = benchmark.Compare(results)
+compare.print()
+
+pprint.pprint(mem_use)

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -56,9 +56,9 @@ for num_threads in NUM_THREADS:
         torch.cuda.synchronize()
         memory = torch.cuda.max_memory_allocated() / 2 ** 20
         mem_use["optimized"][sub_label] = memory
-        memory = f"Memory used: {memory} MB"
+        memory_str = f"Memory used: {memory} MB"
 
-        print("Optimized", memory)
+        print("Optimized", memory_str)
 
         torch.cuda.reset_peak_memory_stats()
         torch.cuda.synchronize()
@@ -79,8 +79,8 @@ for num_threads in NUM_THREADS:
         torch.cuda.synchronize()
         memory = torch.cuda.max_memory_allocated() / 2 ** 20
         mem_use["vanilla"][sub_label] = memory
-        memory = f"Memory used: {memory} MB"
-        print("Vanilla", memory)
+        memory_str = f"Memory used: {memory} MB"
+        print("Vanilla", memory_str)
 
 
 compare = benchmark.Compare(results)

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -1,3 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
 import itertools
 import pprint
 from typing import Dict

--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -1,0 +1,21 @@
+#include "matmul.h"
+#include <torch/types.h>
+#include <limits>
+
+/*
+at::Tensor matmul_with_mask(
+    const at::Tensor& a,
+    const at::Tensor& b,
+    const at::Tensor& mask) {
+  static auto op = c10::Dispatcher::singleton()
+                       .findSchemaOrThrow("xformers::matmul_with_mask", "")
+                       .typed<decltype(matmul_with_mask)>();
+  auto result = op.call(a, b, mask);
+  return result;
+}
+*/
+
+TORCH_LIBRARY_FRAGMENT(xformers, m) {
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "xformers::efficient_attention(Tensor query, Tensor key, Tensor value) -> Tensor"));
+}

--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -1,19 +1,4 @@
-#include "matmul.h"
 #include <torch/types.h>
-#include <limits>
-
-/*
-at::Tensor matmul_with_mask(
-    const at::Tensor& a,
-    const at::Tensor& b,
-    const at::Tensor& mask) {
-  static auto op = c10::Dispatcher::singleton()
-                       .findSchemaOrThrow("xformers::matmul_with_mask", "")
-                       .typed<decltype(matmul_with_mask)>();
-  auto result = op.call(a, b, mask);
-  return result;
-}
-*/
 
 TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -34,6 +34,10 @@ void attention_kernel(
     at::TensorAccessor<scalar_t, 3> buffer //,
     // at::TensorAccessor<int64_t, 2> mask
 ) {
+  // TODO: optimize the code by adding blocking
+  // over multiple dimensions. Doing this allows
+  // the compiler to group reads and operations
+  // for vectorization
   constexpr int64_t BLOCK = 1; // 8;
   int64_t K = query.size(2);
   int64_t B = query.size(0);

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -44,6 +44,7 @@ void attention_kernel(
   int64_t M = query.size(1);
   int64_t N = key.size(1);
   int64_t grain_size = 1;
+  scalar_t scale = 1.0 / std::sqrt(scalar_t(K));
   at::parallel_for(0, B, grain_size, [&](int64_t start, int64_t end) {
     auto buf = buffer[at::get_thread_num()][0].data();
     for (int64_t i = start; i < end; i++) {
@@ -56,7 +57,7 @@ void attention_kernel(
           auto bar = key[i][l].data();
           scalar_t si[BLOCK] = {0};
           for (int64_t k = 0; k < K; k++) {
-            auto aaar = aar[k];
+            auto aaar = aar[k] * scale;
             for (int64_t rr = 0; rr < BLOCK; rr++)
               si[rr] += aaar * bar[k + K * rr];
           }

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -38,15 +38,13 @@ void attention_kernel(
     //at::TensorAccessor<int64_t, 2> mask
     ) {
 
-  constexpr int64_t BLOCK = 8;
+  constexpr int64_t BLOCK = 1;//8;
   int64_t K = query.size(2);
   int64_t B = query.size(0);
   int64_t M = query.size(1);
   int64_t N = key.size(1);
-  int64_t grain_size = 1;//buffer.size(1);
+  int64_t grain_size = 1;
   at::parallel_for(0, B, grain_size, [&](int64_t start, int64_t end) {
-    using Vec = at::vec::Vectorized<scalar_t>;
-
     auto buf = buffer[at::get_thread_num()][0].data();
     for (int64_t i = start; i < end; i++) {
       for (int64_t j = 0; j < M; j++) {
@@ -96,30 +94,33 @@ void attention_kernel(
   });
 }
 
+
 at::Tensor attention(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value
     //const at::Tensor& mask
     ) {
+
   TORCH_CHECK(query.dim() == key.dim());
-  //TORCH_CHECK(query.dim() == mask.dim());
+  TORCH_CHECK(query.dim() == value.dim());
+  // TORCH_CHECK(query.dim() == mask.dim());
   TORCH_CHECK(query.dim() == 3);
   TORCH_CHECK(query.size(2) == key.size(2));
   TORCH_CHECK(query.size(0) == key.size(0));
-  //TORCH_CHECK(query.size(1) == mask.size(1));
-  //TORCH_CHECK(query.size(2) == mask.size(2));
-  //TORCH_CHECK(query.size(0) == mask.size(0));
 
-  /*
-  TORCH_CHECK(!a.is_cuda(), "a must be a CPU tensor");
-  TORCH_CHECK(!b.is_cuda(), "b must be a CPU tensor");
-  TORCH_CHECK(!mask.is_cuda(), "mask must be a CPU tensor");
+  TORCH_CHECK(query.size(0) == value.size(0));
+  TORCH_CHECK(key.size(1) == value.size(1));
+  TORCH_CHECK(query.size(2) == value.size(2)); // TODO: drop this limitation in the future
 
-  TORCH_CHECK(!a.is_sparse(), "a must be a dense tensor");
-  TORCH_CHECK(!b.is_sparse(), "b must be a dense tensor");
-  //TORCH_CHECK(mask.is_sparse(), "mask must be a sparse tensor");
-  */
+  TORCH_CHECK(!query.is_cuda(), "query must be a CPU tensor");
+  TORCH_CHECK(!key.is_cuda(), "key must be a CPU tensor");
+  TORCH_CHECK(!value.is_cuda(), "value must be a CPU tensor");
+
+  TORCH_CHECK(!query.is_sparse(), "query must be a dense tensor");
+  TORCH_CHECK(!key.is_sparse(), "key must be a dense tensor");
+  TORCH_CHECK(!value.is_sparse(), "value must be a dense tensor");
+
   TORCH_CHECK(query.is_contiguous());
   TORCH_CHECK(key.is_contiguous());
   TORCH_CHECK(value.is_contiguous());
@@ -129,11 +130,8 @@ at::Tensor attention(
   int64_t N = key.size(1);
   int64_t K = query.size(2);
 
-
   at::Tensor res = at::empty({B, M, K}, query.options());
 
-  int64_t grain_size = 32; // TODO: tune this
-  //at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
   at::Tensor buffer = at::empty({at::get_num_threads(), 1, K}, query.options());
 
   AT_DISPATCH_FLOATING_TYPES(
@@ -144,7 +142,6 @@ at::Tensor attention(
             key.accessor<scalar_t, 3>(),
             value.accessor<scalar_t, 3>(),
             buffer.accessor<scalar_t, 3>()
-            //idxs.accessor<int64_t, 2>()
             );
       });
 

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -1,0 +1,126 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+#include <cmath>
+#include <vector>
+
+namespace {
+
+template <typename scalar_t>
+void attention_kernel(
+    at::TensorAccessor<scalar_t, 3> output,
+    at::TensorAccessor<scalar_t, 3> q,
+    at::TensorAccessor<scalar_t, 3> k,
+    at::TensorAccessor<scalar_t, 3> v,
+    at::TensorAccessor<scalar_t, 3> buffer//,
+    //at::TensorAccessor<int64_t, 2> mask
+    ) {
+  int64_t K = q.size(2);
+  int64_t B = q.size(0);
+  int64_t M = q.size(1);
+  int64_t N = k.size(1);
+  int64_t grain_size = 1;//buffer.size(1);
+  at::parallel_for(0, B, grain_size, [&](int64_t start, int64_t end) {
+
+    auto buf = buffer[at::get_thread_num()][0];
+    for (int64_t i = start; i < end; i++) {
+    //for (int64_t ii = start; ii < end; ii++) {
+      //int64_t i = ii / M;
+      //int64_t j = ii % M;
+
+      //{
+      for (int64_t j = 0; j < M; j++) {
+        //auto buf = buffer[i][at::get_thread_num()];
+        for (int64_t k = 0; k < K; k++) {
+          buf[k] = 0;
+        }
+        auto aar = q[i][j];
+        scalar_t s_prime = 0;
+        scalar_t m_prime = -std::numeric_limits<scalar_t>::infinity();
+        for (int64_t l = 0; l < N; l++) {
+          auto bar = k[i][l];
+          scalar_t si = 0;
+          for (int64_t k = 0; k < K; k++) {
+            si += aar[k] * bar[k];
+          }
+          scalar_t m_i = si > m_prime ? si : m_prime;
+          auto vi = v[i][l];
+
+          scalar_t m_delta = std::exp(m_prime - m_i);
+          scalar_t s_delta = std::exp(si - m_i);
+
+          for (int64_t k = 0; k < K; k++) {
+            buf[k] = buf[k] * m_delta + vi[k] * s_delta;
+          }
+          s_prime = s_prime * m_delta + s_delta;
+
+          m_prime = m_i;
+        }
+        auto oo = output[i][j];
+        for (int64_t k = 0; k < K; k++) {
+          oo[k] = buf[k] / s_prime;
+        }
+      }
+    }
+  });
+}
+
+at::Tensor attention(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value
+    //const at::Tensor& mask
+    ) {
+  TORCH_CHECK(query.dim() == key.dim());
+  //TORCH_CHECK(query.dim() == mask.dim());
+  TORCH_CHECK(query.dim() == 3);
+  TORCH_CHECK(query.size(2) == key.size(2));
+  TORCH_CHECK(query.size(0) == key.size(0));
+  //TORCH_CHECK(query.size(1) == mask.size(1));
+  //TORCH_CHECK(query.size(2) == mask.size(2));
+  //TORCH_CHECK(query.size(0) == mask.size(0));
+
+  /*
+  TORCH_CHECK(!a.is_cuda(), "a must be a CPU tensor");
+  TORCH_CHECK(!b.is_cuda(), "b must be a CPU tensor");
+  TORCH_CHECK(!mask.is_cuda(), "mask must be a CPU tensor");
+
+  TORCH_CHECK(!a.is_sparse(), "a must be a dense tensor");
+  TORCH_CHECK(!b.is_sparse(), "b must be a dense tensor");
+  //TORCH_CHECK(mask.is_sparse(), "mask must be a sparse tensor");
+  */
+
+  int64_t B = query.size(0);
+  int64_t M = query.size(1);
+  int64_t N = key.size(1);
+  int64_t K = query.size(2);
+
+
+  at::Tensor res = at::empty({B, M, K}, query.options());
+
+  int64_t grain_size = 32; // TODO: tune this
+  //at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
+  at::Tensor buffer = at::empty({at::get_num_threads(), 1, K}, query.options());
+
+  AT_DISPATCH_FLOATING_TYPES(
+      query.scalar_type(), "attention_kernel", [&] {
+        attention_kernel<scalar_t>(
+            res.accessor<scalar_t, 3>(),
+            query.accessor<scalar_t, 3>(),
+            key.accessor<scalar_t, 3>(),
+            value.accessor<scalar_t, 3>(),
+            buffer.accessor<scalar_t, 3>()
+            //idxs.accessor<int64_t, 2>()
+            );
+      });
+
+  return res;
+}
+
+} // namespace
+
+TORCH_LIBRARY_IMPL(xformers, CPU, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("xformers::efficient_attention"),
+      TORCH_FN(attention));
+}

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -62,11 +62,10 @@ void attention_kernel(
             for (int64_t rr = 0; rr < BLOCK; rr++)
               si[rr] += aaar * bar[k + K * rr];
           }
-          scalar_t m_i_[BLOCK];
-          for (int64_t rr = 0; rr < BLOCK; rr++)
-            m_i_[rr] = si[rr] > m_prime ? si[rr] : m_prime;
-
-          scalar_t m_i = max<scalar_t, BLOCK>(m_i_);
+          scalar_t m_i = si[0] > m_prime ? si[0] : m_prime;
+          for (int64_t rr = 1; rr < BLOCK; rr++) {
+            m_i = si[rr] > m_i ? si[rr] : m_i;
+          }
 
           auto vi = value[i][l].data();
 

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -11,56 +11,46 @@
 namespace {
 
 template <typename scalar_t>
+void fill_zero(scalar_t* buf, int64_t K) {
+  for (int64_t k = 0; k < K; k++) {
+    buf[k] = 0;
+  }
+}
+
+
+template <typename scalar_t>
 void attention_kernel(
     at::TensorAccessor<scalar_t, 3> output,
-    at::TensorAccessor<scalar_t, 3> q,
-    at::TensorAccessor<scalar_t, 3> k,
-    at::TensorAccessor<scalar_t, 3> v,
+    at::TensorAccessor<scalar_t, 3> query,
+    at::TensorAccessor<scalar_t, 3> key,
+    at::TensorAccessor<scalar_t, 3> value,
     at::TensorAccessor<scalar_t, 3> buffer//,
     //at::TensorAccessor<int64_t, 2> mask
     ) {
 
-  int64_t K = q.size(2);
-  int64_t B = q.size(0);
-  int64_t M = q.size(1);
-  int64_t N = k.size(1);
+  int64_t K = query.size(2);
+  int64_t B = query.size(0);
+  int64_t M = query.size(1);
+  int64_t N = key.size(1);
   int64_t grain_size = 1;//buffer.size(1);
   at::parallel_for(0, B, grain_size, [&](int64_t start, int64_t end) {
     using Vec = at::vec::Vectorized<scalar_t>;
 
     auto buf = buffer[at::get_thread_num()][0].data();
     for (int64_t i = start; i < end; i++) {
-    //for (int64_t ii = start; ii < end; ii++) {
-      //int64_t i = ii / M;
-      //int64_t j = ii % M;
-
-      //{
       for (int64_t j = 0; j < M; j++) {
-        //auto buf = buffer[i][at::get_thread_num()];
-        for (int64_t k = 0; k < K; k++) {
-          buf[k] = 0;
-        }
-        //std::memset(buf.data(), 0, K * sizeof(scalar_t));
-        auto aar = q[i][j].data();
+        fill_zero<scalar_t>(buf, K);
+        auto aar = query[i][j].data();
         scalar_t s_prime = 0;
         scalar_t m_prime = -std::numeric_limits<scalar_t>::infinity();
         for (int64_t l = 0; l < N; l++) {
-          auto bar = k[i][l].data();
+          auto bar = key[i][l].data();
           scalar_t si = 0;
           for (int64_t k = 0; k < K; k++) {
             si += aar[k] * bar[k];
           }
-          /*
-          si = at::vec::map2_reduce_all<scalar_t>(
-            [](Vec a, Vec b) { return a * b; },
-            [](Vec x, Vec y) { return x + y; },
-            aar,
-            bar,
-            K
-          );
-          */
           scalar_t m_i = si > m_prime ? si : m_prime;
-          auto vi = v[i][l].data();
+          auto vi = value[i][l].data();
 
           scalar_t m_delta = std::exp(m_prime - m_i);
           scalar_t s_delta = std::exp(si - m_i);
@@ -68,13 +58,6 @@ void attention_kernel(
           for (int64_t k = 0; k < K; k++) {
             buf[k] = buf[k] * m_delta + vi[k] * s_delta;
           }
-          //at::vec::map2<scalar_t>(
-          //  [m_delta, s_delta](Vec a, Vec b) { return a * Vec(m_delta) + b * Vec(s_delta); },
-          //  buf,
-          //  buf,
-          //  vi,
-          //  K
-          //);
           s_prime = s_prime * m_delta + s_delta;
 
           m_prime = m_i;

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -11,10 +11,6 @@
 
 namespace {
 
-#define CUDA_1D_KERNEL_LOOP(i, n)                                \
-  for (int i = (blockIdx.x * blockDim.x) + threadIdx.x; i < (n); \
-       i += (blockDim.x * gridDim.x))
-
 template <typename integer>
 constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
   return (n + m - 1) / m;
@@ -64,38 +60,38 @@ __device__ __forceinline__ scalar_t warpMax(scalar_t val) {
   return val;
 }
 
-template <typename scalar_t, int BLOCK, int BLOCK2>
+template <typename scalar_t, typename vec_t, int BLOCK, int BLOCK2>
 __device__ void compute_dot(
-    float4* aar[BLOCK2],
-    float4* bar,
+    vec_t* aar[BLOCK2],
+    vec_t* bar,
     scalar_t si[BLOCK2][BLOCK],
     int64_t K) {
-  constexpr int kVecSize = sizeof(float4) / sizeof(float);
+  constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
   for (int64_t k = 0; k < K / kVecSize; k += 1) {
-    float4 aaar[BLOCK2];
+    vec_t aaar[BLOCK2];
 #pragma unroll
     for (int64_t rr = 0; rr < BLOCK2; rr++) {
       aaar[rr] = __ldg(aar[rr] + k);
     }
 #pragma unroll
     for (int64_t rr = 0; rr < BLOCK; rr++) {
-      float4 bbb = bar[k + K / kVecSize * rr];
+      vec_t bbb = bar[k + K / kVecSize * rr];
 #pragma unroll
       for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
-        sputnik::VectorCompute<float4>::Dot(aaar[rr2], bbb, &si[rr2][rr]);
+        sputnik::VectorCompute<vec_t>::Dot(aaar[rr2], bbb, &si[rr2][rr]);
       }
     }
   }
 }
 
-template <typename scalar_t, int BLOCK, int BLOCK2>
+template <typename scalar_t, typename vec_t, int BLOCK, int BLOCK2>
 __device__ void compute_final_mult(
-    float4* vi,
+    vec_t* vi,
     scalar_t s_delta[BLOCK2][BLOCK],
     scalar_t m_delta[BLOCK2],
-    float4 buffer[BLOCK2][8] /*TODO fix me*/,
+    vec_t buffer[BLOCK2][8] /*TODO fix me*/,
     int64_t K) {
-  constexpr int kVecSize = sizeof(float4) / sizeof(float);
+  constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
 
   for (int64_t k = 0; k < K / kVecSize; k += 1) {
 #pragma unroll
@@ -104,11 +100,11 @@ __device__ void compute_final_mult(
     }
 #pragma unroll
     for (int64_t rr = 0; rr < BLOCK; rr++) {
-      float4 tmp2 = vi[k + K / kVecSize * rr];
+      vec_t tmp2 = vi[k + K / kVecSize * rr];
 
 #pragma unroll
       for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
-        sputnik::VectorCompute<float4>::FMA(
+        sputnik::VectorCompute<vec_t>::FMA(
             s_delta[rr2][rr], tmp2, &buffer[rr2][k]);
       }
     }
@@ -165,13 +161,13 @@ __device__ __forceinline__ void update_scaling_coeffs(
   }
 }
 
-template <typename scalar_t, int BLOCK = 32, int BLOCK2 = 2>
+template <typename scalar_t, typename vec_t = float4, int BLOCK = 32, int BLOCK2 = 2, int WARP_SIZE = 4>
 __global__ void attention_kernel(
     at::PackedTensorAccessor<scalar_t, 3> output,
     at::PackedTensorAccessor<scalar_t, 3> query,
     at::PackedTensorAccessor<scalar_t, 3> key,
     at::PackedTensorAccessor<scalar_t, 3> value) {
-  constexpr int kVecSize = sizeof(float4) / sizeof(float);
+  constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
   int64_t K = query.size(2);
   int64_t B = query.size(0);
   int64_t M = query.size(1);
@@ -180,25 +176,25 @@ __global__ void attention_kernel(
   int64_t i = blockIdx.y;
   int64_t j = blockIdx.x * (blockDim.y * BLOCK2) + threadIdx.y * BLOCK2;
 
-  float4* aar[BLOCK2];
-  float4* oo[BLOCK2];
-  float4 buffer[BLOCK2][8] = {0}; // TODO == K / 4
+  vec_t* aar[BLOCK2];
+  vec_t* oo[BLOCK2];
+  vec_t buffer[BLOCK2][8] = {0}; // TODO == K / 4
   scalar_t s_prime[BLOCK2] = {0};
   scalar_t m_prime[BLOCK2] = {-std::numeric_limits<scalar_t>::infinity()};
   for (int64_t rr = 0; rr < BLOCK2; rr++) {
-    aar[rr] = reinterpret_cast<float4*>(query[i][j + rr].data());
-    oo[rr] = reinterpret_cast<float4*>(output[i][j + rr].data());
+    aar[rr] = reinterpret_cast<vec_t*>(query[i][j + rr].data());
+    oo[rr] = reinterpret_cast<vec_t*>(output[i][j + rr].data());
   }
 
   for (int64_t l = threadIdx.x * BLOCK; l < N; l += BLOCK * blockDim.x) {
-    auto bar = reinterpret_cast<float4*>(key[i][l].data());
+    auto bar = reinterpret_cast<vec_t*>(key[i][l].data());
     scalar_t si[BLOCK2][BLOCK] = {0};
-    compute_dot<scalar_t, BLOCK, BLOCK2>(aar, bar, si, K);
+    compute_dot<scalar_t, vec_t, BLOCK, BLOCK2>(aar, bar, si, K);
 
     scalar_t m_i[BLOCK2];
     compute_max<scalar_t, BLOCK, BLOCK2>(si, m_prime, m_i);
 
-    auto vi = reinterpret_cast<float4*>(value[i][l].data());
+    auto vi = reinterpret_cast<vec_t*>(value[i][l].data());
 
     scalar_t m_delta[BLOCK2];
     scalar_t s_delta[BLOCK2][BLOCK];
@@ -206,7 +202,7 @@ __global__ void attention_kernel(
     compute_scaling_coeffs<scalar_t, BLOCK, BLOCK2>(
         m_i, m_prime, si, m_delta, s_delta);
 
-    compute_final_mult<scalar_t, BLOCK, BLOCK2>(
+    compute_final_mult<scalar_t, vec_t, BLOCK, BLOCK2>(
         vi, s_delta, m_delta, buffer, K);
 
     update_scaling_coeffs<scalar_t, BLOCK, BLOCK2>(
@@ -216,21 +212,21 @@ __global__ void attention_kernel(
   for (int64_t rr = 0; rr < BLOCK2; rr++) {
     scalar_t m_i = m_prime[rr];
     scalar_t s_i = s_prime[rr];
-    m_prime[rr] = warpMax<scalar_t, 4>(m_prime[rr]);
+    m_prime[rr] = warpMax<scalar_t, WARP_SIZE>(m_prime[rr]);
     scalar_t m_delta = std::exp(m_i - m_prime[rr]);
     scalar_t s_delta = s_i * m_delta;
-    s_delta = warpSum<scalar_t, 4>(s_delta);
+    s_delta = warpSum<scalar_t, WARP_SIZE>(s_delta);
     s_prime[rr] = s_delta;
     for (int64_t k = 0; k < K / kVecSize; k += 1) {
-      float4 tmp = buffer[rr][k];
+      vec_t tmp = buffer[rr][k];
       iMul<scalar_t>(m_delta, &tmp);
-      tmp = warpSum<float4, 4>(tmp);
+      tmp = warpSum<vec_t, WARP_SIZE>(tmp);
       buffer[rr][k] = tmp;
     }
   }
 
   for (int64_t k = threadIdx.x; k < K / kVecSize; k += blockDim.x) {
-    float4 tmp;
+    vec_t tmp;
 
 #pragma unroll
     for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
@@ -279,26 +275,23 @@ at::Tensor attention(
 
   at::Tensor res = at::zeros({B, M, K}, query.options());
 
-  int64_t grain_size = 32; // TODO: tune this
-  // at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
-  // at::Tensor buffer = at::empty({at::get_num_threads(), 1, K},
-  // query.options());
 
-  // dim3 grid(std::min(
-  //    ceil_div(static_cast<int64_t>(B), static_cast<int64_t>(512)),
-  //    static_cast<int64_t>(4096)));
-  // dim3 block(512);
-  // dim3 grid(M / 32, B);
-  dim3 grid(M / 32, B);
-  // dim3 block(32, 32);
-  // dim3 block(4, 32);
-  dim3 block(4, 16);
+  constexpr int WARP_SIZE = 4;
+
+  constexpr int BLOCK = 32;
+  constexpr int BLOCK2 = 2;
+
+  constexpr int TILE_SIZE = 32;
+
+
+  dim3 grid(M / TILE_SIZE, B);
+  dim3 block(WARP_SIZE, TILE_SIZE / BLOCK2);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   using scalar_t = float;
   // AT_DISPATCH_FLOATING_TYPES(
   // query.scalar_type(), "attention_kernel", [&] {
-  attention_kernel<scalar_t><<<grid, block, 0, stream>>>(
+  attention_kernel<scalar_t, float4, BLOCK, BLOCK2, WARP_SIZE><<<grid, block, 0, stream>>>(
       res.packed_accessor<scalar_t, 3>(),
       query.packed_accessor<scalar_t, 3>(),
       key.packed_accessor<scalar_t, 3>(),

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -290,10 +290,12 @@ __global__ void attention_kernel(
   scalar_t s_prime[kBlockSizeQ] = {0};
   scalar_t m_prime[kBlockSizeQ] = {-std::numeric_limits<scalar_t>::infinity()};
   for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+    int64_t index = query_idx + q_item_idx;
+    index = index >= M ? M - 1 : index;
     query_block[q_item_idx] = reinterpret_cast<vec_t*>(
-        query[batch_idx][query_idx + q_item_idx].data());
+        query[batch_idx][index].data());
     output_block[q_item_idx] = reinterpret_cast<vec_t*>(
-        output[batch_idx][query_idx + q_item_idx].data());
+        output[batch_idx][index].data());
   }
 
   int64_t l = threadIdx.x * kBlockSizeK;

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -36,35 +36,50 @@ __global__ void attention_kernel(
   int64_t N = key.size(1);
 
   int64_t i = blockIdx.y;
-  int64_t j = blockIdx.x;
+  //int64_t j = blockIdx.x;
+  int64_t j = blockIdx.x * blockDim.y + threadIdx.y;
 
       {{
-        auto aar = query[i][j].data();
+        //auto aar = query[i][j].data();
+        auto aar = reinterpret_cast<float4 *>(query[i][j].data());
 
-        auto oo = output[i][j].data();
+        //auto oo = output[i][j].data();
+        auto oo = reinterpret_cast<float4 *>(output[i][j].data());
         scalar_t s_prime = 0;
         scalar_t m_prime = -std::numeric_limits<scalar_t>::infinity();
+        //for (int64_t l = threadIdx.x * BLOCK; l < N; l+=BLOCK * blockDim.x) {
         for (int64_t l = 0; l < N; l+=BLOCK) {
-          auto bar = key[i][l].data();
+          //auto bar = key[i][l].data();
+          auto bar = reinterpret_cast<float4 *>(key[i][l].data());
           scalar_t si[BLOCK] = {0};
-          for (int64_t k = threadIdx.x; k < K; k+=32) {
-            auto aaar = aar[k];
-            for (int64_t rr = 0; rr < BLOCK; rr++)
-              si[rr] += aaar * bar[k + K * rr];
-          }
+          //for (int64_t k = threadIdx.x; k < K; k+=32) {
+          for (int64_t k = 0; k < K / 4; k+=1) {
+            //auto aaar = aar[k];
+            //auto aaar = __ldg(aar + k);
+            float4 aaar = __ldg(aar + k);
+            for (int64_t rr = 0; rr < BLOCK; rr++) {
+              float4 bbb = bar[k + K / 4 * rr];
+              si[rr] += aaar.x * bbb.x + aaar.y * bbb.y + aaar.z * bbb.z + aaar.w * bbb.w;
 
-          for (int64_t rr = 0; rr < BLOCK; rr++) {
-            for (int stride = 16; stride > 0; stride >>= 1) {
-              si[rr] += __shfl_xor_sync(0xffffffff, si[rr], stride, 32);
+              //si[rr] += aaar * bar[k + K * rr];
+              //si[rr] += aaar * __ldg(bar + k + K * rr);
             }
           }
+
+          //for (int64_t rr = 0; rr < BLOCK; rr++) {
+          //  for (int stride = 16; stride > 0; stride >>= 1) {
+          //    si[rr] += __shfl_xor_sync(0xffffffff, si[rr], stride, 32);
+          //  }
+          //}
 
           scalar_t m_i = si[0] > m_prime ? si[0] : m_prime;
           for (int64_t rr = 1; rr < BLOCK; rr++) {
             m_i = si[rr] > m_i ? si[rr] : m_i;
           }
+          //s_prime = m_i;  // TODO: only for testing, remove!!!
 
-          auto vi = value[i][l].data();
+          //auto vi = value[i][l].data();
+          auto vi = reinterpret_cast<float4 *>(value[i][l].data());
 
           scalar_t m_delta;
           scalar_t s_delta[BLOCK];
@@ -73,10 +88,24 @@ __global__ void attention_kernel(
           for (int64_t rr = 0; rr < BLOCK; rr++)
             s_delta[rr] = std::exp(si[rr] - m_i);
 
-          for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
-            oo[k] = oo[k] * m_delta;
-            for (int64_t rr = 0; rr < BLOCK; rr++)
-              oo[k] += vi[k + K * rr] * s_delta[rr];
+          //for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
+          for (int64_t k = 0; k < K/4; k+=1) {
+            //oo[k] = oo[k] * m_delta;
+            float4 tmp = oo[k];
+            tmp.x = tmp.x * m_delta;
+            tmp.y = tmp.y * m_delta;
+            tmp.z = tmp.z * m_delta;
+            tmp.w = tmp.w * m_delta;
+            for (int64_t rr = 0; rr < BLOCK; rr++) {
+              //oo[k] += vi[k + K * rr] * s_delta[rr];
+              float4 tmp2 = vi[k + K / 4 * rr];
+              tmp.x += tmp2.x * s_delta[rr];
+              tmp.y += tmp2.y * s_delta[rr];
+              tmp.z += tmp2.z * s_delta[rr];
+              tmp.w += tmp2.w * s_delta[rr];
+              //oo[k] += __ldg(vi + k + K * rr) * s_delta[rr];
+            }
+            oo[k] = tmp;
           }
           s_prime = s_prime * m_delta;
           for (int64_t rr = 0; rr < BLOCK; rr++)
@@ -85,8 +114,15 @@ __global__ void attention_kernel(
           m_prime = m_i;
         }
 
-        for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
-          oo[k] /= s_prime;
+        //for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
+        for (int64_t k = 0; k < K / 4; k+=1) {
+          //oo[k] /= s_prime;
+          float4 tmp = oo[k];
+          tmp.x /= s_prime;
+          tmp.y /= s_prime;
+          tmp.z /= s_prime;
+          tmp.w /= s_prime;
+          oo[k] = tmp;
         }
       }
   }
@@ -139,8 +175,11 @@ at::Tensor attention(
   //    ceil_div(static_cast<int64_t>(B), static_cast<int64_t>(512)),
   //    static_cast<int64_t>(4096)));
   //dim3 block(512);
-  dim3 grid(M, B);
-  dim3 block(32, 1);
+  //dim3 grid(M / 32, B);
+  dim3 grid(M / 32, B);
+  //dim3 block(32, 32);
+  //dim3 block(4, 32);
+  dim3 block(1, 32);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES(

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -487,6 +487,7 @@ at::Tensor attention(
   using scalar_t = float;
 
   if ((K % 4) == 0) {
+    TORCH_CHECK(K / 4 <= BUFFER_SIZE, "For now only a certain number of K values are supported. Let us know if you hit this and we will fix it");
     attention_kernel<scalar_t, float4, kBlockSizeK, kBlockSizeQ, WARP_SIZE, BUFFER_SIZE>
         <<<grid, block, 0, stream>>>(
             res.packed_accessor<scalar_t, 3>(),
@@ -495,6 +496,7 @@ at::Tensor attention(
             value.packed_accessor<scalar_t, 3>()
         );
   } else if ((K % 2) == 0) {
+    TORCH_CHECK(K / 2 <= BUFFER_SIZE, "For now only a certain number of K values are supported. Let us know if you hit this and we will fix it");
     attention_kernel<scalar_t, float2, kBlockSizeK, kBlockSizeQ, WARP_SIZE, BUFFER_SIZE>
         <<<grid, block, 0, stream>>>(
             res.packed_accessor<scalar_t, 3>(),
@@ -504,6 +506,7 @@ at::Tensor attention(
         );
 
   } else {
+    TORCH_CHECK(K <= BUFFER_SIZE, "For now only a certain number of K values are supported. Let us know if you hit this and we will fix it");
     attention_kernel<scalar_t, float, kBlockSizeK, kBlockSizeQ, WARP_SIZE, BUFFER_SIZE>
         <<<grid, block, 0, stream>>>(
             res.packed_accessor<scalar_t, 3>(),

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -1,0 +1,158 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <torch/library.h>
+#include <cmath>
+#include <vector>
+
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+
+namespace {
+
+
+
+#define CUDA_1D_KERNEL_LOOP(i, n)                                \
+  for (int i = (blockIdx.x * blockDim.x) + threadIdx.x; i < (n); \
+       i += (blockDim.x * gridDim.x))
+
+template <typename integer>
+constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
+  return (n + m - 1) / m;
+}
+
+template <typename scalar_t>
+__global__ void attention_kernel(
+    at::PackedTensorAccessor<scalar_t, 3> output,
+    at::PackedTensorAccessor<scalar_t, 3> query,
+    at::PackedTensorAccessor<scalar_t, 3> key,
+    at::PackedTensorAccessor<scalar_t, 3> value
+    ) {
+  constexpr int64_t BLOCK = 8;
+  int64_t K = query.size(2);
+  int64_t B = query.size(0);
+  int64_t M = query.size(1);
+  int64_t N = key.size(1);
+
+  CUDA_1D_KERNEL_LOOP(i, B) {
+
+      for (int64_t j = 0; j < M; j++) {
+        //fill_zero<scalar_t>(buf, K);
+        auto aar = query[i][j].data();
+
+        auto oo = output[i][j].data();
+        scalar_t s_prime = 0;
+        scalar_t m_prime = -std::numeric_limits<scalar_t>::infinity();
+        for (int64_t l = 0; l < N; l+=BLOCK) {
+          auto bar = key[i][l].data();
+          scalar_t si[BLOCK] = {0};
+          for (int64_t k = 0; k < K; k++) {
+            auto aaar = aar[k];
+            for (int64_t rr = 0; rr < BLOCK; rr++)
+              si[rr] += aaar * bar[k + K * rr];
+          }
+          scalar_t m_i = si[0] > m_prime ? si[0] : m_prime;
+          for (int64_t rr = 1; rr < BLOCK; rr++) {
+            m_i = si[rr] > m_i ? si[rr] : m_i;
+          }
+
+          auto vi = value[i][l].data();
+
+          scalar_t m_delta;
+          scalar_t s_delta[BLOCK];
+          m_delta = std::exp(m_prime - m_i);
+
+          for (int64_t rr = 0; rr < BLOCK; rr++)
+            s_delta[rr] = std::exp(si[rr] - m_i);
+
+          for (int64_t k = 0; k < K; k++) {
+            oo[k] = oo[k] * m_delta;
+            for (int64_t rr = 0; rr < BLOCK; rr++)
+              oo[k] += vi[k + K * rr] * s_delta[rr];
+          }
+          s_prime = s_prime * m_delta;
+          for (int64_t rr = 0; rr < BLOCK; rr++)
+            s_prime += s_delta[rr];
+
+          m_prime = m_i;
+        }
+
+        for (int64_t k = 0; k < K; k++) {
+          oo[k] /= s_prime;
+        }
+      }
+  }
+}
+
+at::Tensor attention(
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value
+    //const at::Tensor& mask
+    ) {
+  TORCH_CHECK(query.dim() == key.dim());
+  //TORCH_CHECK(query.dim() == mask.dim());
+  TORCH_CHECK(query.dim() == 3);
+  TORCH_CHECK(query.size(2) == key.size(2));
+  TORCH_CHECK(query.size(0) == key.size(0));
+  //TORCH_CHECK(query.size(1) == mask.size(1));
+  //TORCH_CHECK(query.size(2) == mask.size(2));
+  //TORCH_CHECK(query.size(0) == mask.size(0));
+
+  /*
+  TORCH_CHECK(!a.is_cuda(), "a must be a CPU tensor");
+  TORCH_CHECK(!b.is_cuda(), "b must be a CPU tensor");
+  TORCH_CHECK(!mask.is_cuda(), "mask must be a CPU tensor");
+
+  TORCH_CHECK(!a.is_sparse(), "a must be a dense tensor");
+  TORCH_CHECK(!b.is_sparse(), "b must be a dense tensor");
+  //TORCH_CHECK(mask.is_sparse(), "mask must be a sparse tensor");
+  */
+  TORCH_CHECK(query.is_contiguous());
+  TORCH_CHECK(key.is_contiguous());
+  TORCH_CHECK(value.is_contiguous());
+
+  at::cuda::CUDAGuard device_guard(query.device());
+
+  int64_t B = query.size(0);
+  int64_t M = query.size(1);
+  int64_t N = key.size(1);
+  int64_t K = query.size(2);
+
+
+  at::Tensor res = at::zeros({B, M, K}, query.options());
+
+  int64_t grain_size = 32; // TODO: tune this
+  //at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
+  //at::Tensor buffer = at::empty({at::get_num_threads(), 1, K}, query.options());
+
+
+  dim3 grid(std::min(
+      ceil_div(static_cast<int64_t>(B), static_cast<int64_t>(512)),
+      static_cast<int64_t>(4096)));
+  dim3 block(512);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(
+      query.scalar_type(), "attention_kernel", [&] {
+        attention_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            res.packed_accessor<scalar_t, 3>(),
+            query.packed_accessor<scalar_t, 3>(),
+            key.packed_accessor<scalar_t, 3>(),
+            value.packed_accessor<scalar_t, 3>()
+            //buffer.accessor<scalar_t, 3>()
+            //idxs.accessor<int64_t, 2>()
+            );
+      });
+
+  return res;
+}
+
+} // namespace
+
+TORCH_LIBRARY_IMPL(xformers, CUDA, m) {
+  m.impl(
+      TORCH_SELECTIVE_NAME("xformers::efficient_attention"),
+      TORCH_FN(attention));
+}

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -30,6 +30,7 @@ __global__ void attention_kernel(
     at::PackedTensorAccessor<scalar_t, 3> value
     ) {
   constexpr int64_t BLOCK = 32;
+  constexpr int64_t BLOCK2 = 2;
   int64_t K = query.size(2);
   int64_t B = query.size(0);
   int64_t M = query.size(1);
@@ -37,38 +38,40 @@ __global__ void attention_kernel(
 
   int64_t i = blockIdx.y;
   //int64_t j = blockIdx.x;
-  int64_t j = blockIdx.x * (blockDim.y * 2) + threadIdx.y * 2;
+  int64_t j = blockIdx.x * (blockDim.y * BLOCK2) + threadIdx.y * BLOCK2;
 
       {{
         //auto aar = query[i][j].data();
-        auto aar = reinterpret_cast<float4 *>(query[i][j].data());
-        auto aar2 = reinterpret_cast<float4 *>(query[i][j+1].data());
+        float4* aar[BLOCK2];
+        float4* oo[BLOCK2];
+        scalar_t s_prime[BLOCK2] = {0};
+        scalar_t m_prime[BLOCK2] = {-std::numeric_limits<scalar_t>::infinity()};
+        for (int64_t rr = 0; rr < BLOCK2; rr++) {
+          aar[rr] = reinterpret_cast<float4 *>(query[i][j + rr].data());
+          oo[rr] = reinterpret_cast<float4 *>(output[i][j + rr].data());
+        }
 
-        //auto oo = output[i][j].data();
-        auto oo = reinterpret_cast<float4 *>(output[i][j].data());
-        auto oo2 = reinterpret_cast<float4 *>(output[i][j+1].data());
-        scalar_t s_prime = 0;
-        scalar_t m_prime = -std::numeric_limits<scalar_t>::infinity();
-
-        scalar_t s_prime2 = 0;
-        scalar_t m_prime2 = -std::numeric_limits<scalar_t>::infinity();
         //for (int64_t l = threadIdx.x * BLOCK; l < N; l+=BLOCK * blockDim.x) {
         for (int64_t l = 0; l < N; l+=BLOCK) {
           //auto bar = key[i][l].data();
           auto bar = reinterpret_cast<float4 *>(key[i][l].data());
-          scalar_t si[BLOCK] = {0};
-          scalar_t si2[BLOCK] = {0};
+          scalar_t si[BLOCK2][BLOCK] = {0};
           //for (int64_t k = threadIdx.x; k < K; k+=32) {
           for (int64_t k = 0; k < K / 4; k+=1) {
             //auto aaar = aar[k];
             //auto aaar = __ldg(aar + k);
-            float4 aaar = __ldg(aar + k);
-            float4 aaar2 = __ldg(aar2 + k);
+            float4 aaar[BLOCK2];
+#pragma unroll
+            for (int64_t rr = 0; rr < BLOCK2; rr++) {
+              aaar[rr] = __ldg(aar[rr] + k);
+            }
+#pragma unroll
             for (int64_t rr = 0; rr < BLOCK; rr++) {
               float4 bbb = bar[k + K / 4 * rr];
-              si[rr] += aaar.x * bbb.x + aaar.y * bbb.y + aaar.z * bbb.z + aaar.w * bbb.w;
-              si2[rr] += aaar2.x * bbb.x + aaar2.y * bbb.y + aaar2.z * bbb.z + aaar2.w * bbb.w;
-
+#pragma unroll
+              for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+                si[rr2][rr] += aaar[rr2].x * bbb.x + aaar[rr2].y * bbb.y + aaar[rr2].z * bbb.z + aaar[rr2].w * bbb.w;
+              }
               //si[rr] += aaar * bar[k + K * rr];
               //si[rr] += aaar * __ldg(bar + k + K * rr);
             }
@@ -80,96 +83,94 @@ __global__ void attention_kernel(
           //  }
           //}
 
-          scalar_t m_i = si[0] > m_prime ? si[0] : m_prime;
-          for (int64_t rr = 1; rr < BLOCK; rr++) {
-            m_i = si[rr] > m_i ? si[rr] : m_i;
-          }
+          scalar_t m_i[BLOCK2];
 
-          scalar_t m_i2 = si2[0] > m_prime2 ? si2[0] : m_prime2;
-          for (int64_t rr = 1; rr < BLOCK; rr++) {
-            m_i2 = si2[rr] > m_i2 ? si2[rr] : m_i2;
+#pragma unroll
+          for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+            m_i[rr2] = si[rr2][0] > m_prime[rr2] ? si[rr2][0] : m_prime[rr2];
+#pragma unroll
+            for (int64_t rr = 1; rr < BLOCK; rr++) {
+              m_i[rr2] = si[rr2][rr] > m_i[rr2] ? si[rr2][rr] : m_i[rr2];
+            }
           }
           //s_prime = m_i;  // TODO: only for testing, remove!!!
 
           //auto vi = value[i][l].data();
           auto vi = reinterpret_cast<float4 *>(value[i][l].data());
 
-          scalar_t m_delta;
-          scalar_t s_delta[BLOCK];
-          m_delta = std::exp(m_prime - m_i);
 
+          scalar_t m_delta[BLOCK2];
+          scalar_t s_delta[BLOCK2][BLOCK];
 
-          scalar_t m_delta2;
-          scalar_t s_delta2[BLOCK];
-          m_delta2 = std::exp(m_prime2 - m_i2);
+#pragma unroll
+          for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++)
+            m_delta[rr2] = std::exp(m_prime[rr2] - m_i[rr2]);
 
-          for (int64_t rr = 0; rr < BLOCK; rr++)
-            s_delta[rr] = std::exp(si[rr] - m_i);
-
-          for (int64_t rr = 0; rr < BLOCK; rr++)
-            s_delta2[rr] = std::exp(si2[rr] - m_i2);
+#pragma unroll
+          for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++)
+#pragma unroll
+            for (int64_t rr = 0; rr < BLOCK; rr++)
+              s_delta[rr2][rr] = std::exp(si[rr2][rr] - m_i[rr2]);
 
           //for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
+#pragma unroll
           for (int64_t k = 0; k < K/4; k+=1) {
             //oo[k] = oo[k] * m_delta;
-            float4 tmp = oo[k];
-            tmp.x = tmp.x * m_delta;
-            tmp.y = tmp.y * m_delta;
-            tmp.z = tmp.z * m_delta;
-            tmp.w = tmp.w * m_delta;
-
-            float4 tmp3 = oo2[k];
-            tmp3.x = tmp3.x * m_delta2;
-            tmp3.y = tmp3.y * m_delta2;
-            tmp3.z = tmp3.z * m_delta2;
-            tmp3.w = tmp3.w * m_delta2;
+            float4 tmp[BLOCK2];
+#pragma unroll
+            for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+              tmp[rr2] = oo[rr2][k];
+              tmp[rr2].x = tmp[rr2].x * m_delta[rr2];
+              tmp[rr2].y = tmp[rr2].y * m_delta[rr2];
+              tmp[rr2].z = tmp[rr2].z * m_delta[rr2];
+              tmp[rr2].w = tmp[rr2].w * m_delta[rr2];
+            }
+#pragma unroll
             for (int64_t rr = 0; rr < BLOCK; rr++) {
               //oo[k] += vi[k + K * rr] * s_delta[rr];
               float4 tmp2 = vi[k + K / 4 * rr];
-              tmp.x += tmp2.x * s_delta[rr];
-              tmp.y += tmp2.y * s_delta[rr];
-              tmp.z += tmp2.z * s_delta[rr];
-              tmp.w += tmp2.w * s_delta[rr];
 
-              tmp3.x += tmp2.x * s_delta2[rr];
-              tmp3.y += tmp2.y * s_delta2[rr];
-              tmp3.z += tmp2.z * s_delta2[rr];
-              tmp3.w += tmp2.w * s_delta2[rr];
+#pragma unroll
+              for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+                tmp[rr2].x += tmp2.x * s_delta[rr2][rr];
+                tmp[rr2].y += tmp2.y * s_delta[rr2][rr];
+                tmp[rr2].z += tmp2.z * s_delta[rr2][rr];
+                tmp[rr2].w += tmp2.w * s_delta[rr2][rr];
+              }
               //oo[k] += __ldg(vi + k + K * rr) * s_delta[rr];
             }
-            oo[k] = tmp;
-            oo2[k] = tmp3;
+#pragma unroll
+            for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+              oo[rr2][k] = tmp[rr2];
+            }
           }
-          s_prime = s_prime * m_delta;
-          for (int64_t rr = 0; rr < BLOCK; rr++)
-            s_prime += s_delta[rr];
+#pragma unroll
+          for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+            s_prime[rr2] = s_prime[rr2] * m_delta[rr2];
+#pragma unroll
+            for (int64_t rr = 0; rr < BLOCK; rr++)
+              s_prime[rr2] += s_delta[rr2][rr];
 
-          m_prime = m_i;
-
-
-          s_prime2 = s_prime2 * m_delta2;
-          for (int64_t rr = 0; rr < BLOCK; rr++)
-            s_prime2 += s_delta2[rr];
-
-          m_prime2 = m_i2;
+            m_prime[rr2] = m_i[rr2];
+          }
         }
 
         //for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
         for (int64_t k = 0; k < K / 4; k+=1) {
           //oo[k] /= s_prime;
-          float4 tmp = oo[k];
-          float4 tmp2 = oo2[k];
-          tmp.x /= s_prime;
-          tmp.y /= s_prime;
-          tmp.z /= s_prime;
-          tmp.w /= s_prime;
+          float4 tmp;
 
-          tmp2.x /= s_prime2;
-          tmp2.y /= s_prime2;
-          tmp2.z /= s_prime2;
-          tmp2.w /= s_prime2;
-          oo[k] = tmp;
-          oo2[k] = tmp2;
+#pragma unroll
+          for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+            tmp = oo[rr2][k];
+
+            tmp.x /= s_prime[rr2];
+            tmp.y /= s_prime[rr2];
+            tmp.z /= s_prime[rr2];
+            tmp.w /= s_prime[rr2];
+
+            oo[rr2][k] = tmp;
+          }
         }
       }
   }

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -29,7 +29,7 @@ __global__ void attention_kernel(
     at::PackedTensorAccessor<scalar_t, 3> key,
     at::PackedTensorAccessor<scalar_t, 3> value
     ) {
-  constexpr int64_t BLOCK = 16;
+  constexpr int64_t BLOCK = 32;
   int64_t K = query.size(2);
   int64_t B = query.size(0);
   int64_t M = query.size(1);
@@ -37,29 +37,37 @@ __global__ void attention_kernel(
 
   int64_t i = blockIdx.y;
   //int64_t j = blockIdx.x;
-  int64_t j = blockIdx.x * blockDim.y + threadIdx.y;
+  int64_t j = blockIdx.x * (blockDim.y * 2) + threadIdx.y * 2;
 
       {{
         //auto aar = query[i][j].data();
         auto aar = reinterpret_cast<float4 *>(query[i][j].data());
+        auto aar2 = reinterpret_cast<float4 *>(query[i][j+1].data());
 
         //auto oo = output[i][j].data();
         auto oo = reinterpret_cast<float4 *>(output[i][j].data());
+        auto oo2 = reinterpret_cast<float4 *>(output[i][j+1].data());
         scalar_t s_prime = 0;
         scalar_t m_prime = -std::numeric_limits<scalar_t>::infinity();
+
+        scalar_t s_prime2 = 0;
+        scalar_t m_prime2 = -std::numeric_limits<scalar_t>::infinity();
         //for (int64_t l = threadIdx.x * BLOCK; l < N; l+=BLOCK * blockDim.x) {
         for (int64_t l = 0; l < N; l+=BLOCK) {
           //auto bar = key[i][l].data();
           auto bar = reinterpret_cast<float4 *>(key[i][l].data());
           scalar_t si[BLOCK] = {0};
+          scalar_t si2[BLOCK] = {0};
           //for (int64_t k = threadIdx.x; k < K; k+=32) {
           for (int64_t k = 0; k < K / 4; k+=1) {
             //auto aaar = aar[k];
             //auto aaar = __ldg(aar + k);
             float4 aaar = __ldg(aar + k);
+            float4 aaar2 = __ldg(aar2 + k);
             for (int64_t rr = 0; rr < BLOCK; rr++) {
               float4 bbb = bar[k + K / 4 * rr];
               si[rr] += aaar.x * bbb.x + aaar.y * bbb.y + aaar.z * bbb.z + aaar.w * bbb.w;
+              si2[rr] += aaar2.x * bbb.x + aaar2.y * bbb.y + aaar2.z * bbb.z + aaar2.w * bbb.w;
 
               //si[rr] += aaar * bar[k + K * rr];
               //si[rr] += aaar * __ldg(bar + k + K * rr);
@@ -76,6 +84,11 @@ __global__ void attention_kernel(
           for (int64_t rr = 1; rr < BLOCK; rr++) {
             m_i = si[rr] > m_i ? si[rr] : m_i;
           }
+
+          scalar_t m_i2 = si2[0] > m_prime2 ? si2[0] : m_prime2;
+          for (int64_t rr = 1; rr < BLOCK; rr++) {
+            m_i2 = si2[rr] > m_i2 ? si2[rr] : m_i2;
+          }
           //s_prime = m_i;  // TODO: only for testing, remove!!!
 
           //auto vi = value[i][l].data();
@@ -85,8 +98,16 @@ __global__ void attention_kernel(
           scalar_t s_delta[BLOCK];
           m_delta = std::exp(m_prime - m_i);
 
+
+          scalar_t m_delta2;
+          scalar_t s_delta2[BLOCK];
+          m_delta2 = std::exp(m_prime2 - m_i2);
+
           for (int64_t rr = 0; rr < BLOCK; rr++)
             s_delta[rr] = std::exp(si[rr] - m_i);
+
+          for (int64_t rr = 0; rr < BLOCK; rr++)
+            s_delta2[rr] = std::exp(si2[rr] - m_i2);
 
           //for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
           for (int64_t k = 0; k < K/4; k+=1) {
@@ -96,6 +117,12 @@ __global__ void attention_kernel(
             tmp.y = tmp.y * m_delta;
             tmp.z = tmp.z * m_delta;
             tmp.w = tmp.w * m_delta;
+
+            float4 tmp3 = oo2[k];
+            tmp3.x = tmp3.x * m_delta2;
+            tmp3.y = tmp3.y * m_delta2;
+            tmp3.z = tmp3.z * m_delta2;
+            tmp3.w = tmp3.w * m_delta2;
             for (int64_t rr = 0; rr < BLOCK; rr++) {
               //oo[k] += vi[k + K * rr] * s_delta[rr];
               float4 tmp2 = vi[k + K / 4 * rr];
@@ -103,26 +130,46 @@ __global__ void attention_kernel(
               tmp.y += tmp2.y * s_delta[rr];
               tmp.z += tmp2.z * s_delta[rr];
               tmp.w += tmp2.w * s_delta[rr];
+
+              tmp3.x += tmp2.x * s_delta2[rr];
+              tmp3.y += tmp2.y * s_delta2[rr];
+              tmp3.z += tmp2.z * s_delta2[rr];
+              tmp3.w += tmp2.w * s_delta2[rr];
               //oo[k] += __ldg(vi + k + K * rr) * s_delta[rr];
             }
             oo[k] = tmp;
+            oo2[k] = tmp3;
           }
           s_prime = s_prime * m_delta;
           for (int64_t rr = 0; rr < BLOCK; rr++)
             s_prime += s_delta[rr];
 
           m_prime = m_i;
+
+
+          s_prime2 = s_prime2 * m_delta2;
+          for (int64_t rr = 0; rr < BLOCK; rr++)
+            s_prime2 += s_delta2[rr];
+
+          m_prime2 = m_i2;
         }
 
         //for (int64_t k = threadIdx.x; k < K; k+=blockDim.x) {
         for (int64_t k = 0; k < K / 4; k+=1) {
           //oo[k] /= s_prime;
           float4 tmp = oo[k];
+          float4 tmp2 = oo2[k];
           tmp.x /= s_prime;
           tmp.y /= s_prime;
           tmp.z /= s_prime;
           tmp.w /= s_prime;
+
+          tmp2.x /= s_prime2;
+          tmp2.y /= s_prime2;
+          tmp2.z /= s_prime2;
+          tmp2.w /= s_prime2;
           oo[k] = tmp;
+          oo2[k] = tmp2;
         }
       }
   }
@@ -179,7 +226,7 @@ at::Tensor attention(
   dim3 grid(M / 32, B);
   //dim3 block(32, 32);
   //dim3 block(4, 32);
-  dim3 block(1, 32);
+  dim3 block(1, 16);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES(

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -35,10 +35,10 @@ __global__ void attention_kernel(
   int64_t M = query.size(1);
   int64_t N = key.size(1);
 
-  CUDA_1D_KERNEL_LOOP(i, B) {
+  int64_t i = blockIdx.y;
+  int64_t j = blockIdx.x;
 
-      for (int64_t j = 0; j < M; j++) {
-        //fill_zero<scalar_t>(buf, K);
+      {{
         auto aar = query[i][j].data();
 
         auto oo = output[i][j].data();
@@ -128,10 +128,12 @@ at::Tensor attention(
   //at::Tensor buffer = at::empty({at::get_num_threads(), 1, K}, query.options());
 
 
-  dim3 grid(std::min(
-      ceil_div(static_cast<int64_t>(B), static_cast<int64_t>(512)),
-      static_cast<int64_t>(4096)));
-  dim3 block(512);
+  //dim3 grid(std::min(
+  //    ceil_div(static_cast<int64_t>(B), static_cast<int64_t>(512)),
+  //    static_cast<int64_t>(4096)));
+  //dim3 block(512);
+  dim3 grid(M, B);
+  dim3 block(32, 1);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES(

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -193,15 +193,18 @@ __global__ void attention_kernel(
   scalar_t s_prime[kBlockSizeQ] = {0};
   scalar_t m_prime[kBlockSizeQ] = {-std::numeric_limits<scalar_t>::infinity()};
   for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
-    query_block[q_item_idx] = reinterpret_cast<vec_t*>(query[batch_idx][query_idx + q_item_idx].data());
-    output_block[q_item_idx] = reinterpret_cast<vec_t*>(output[batch_idx][query_idx + q_item_idx].data());
+    query_block[q_item_idx] = reinterpret_cast<vec_t*>(
+        query[batch_idx][query_idx + q_item_idx].data());
+    output_block[q_item_idx] = reinterpret_cast<vec_t*>(
+        output[batch_idx][query_idx + q_item_idx].data());
   }
 
   for (int64_t l = threadIdx.x * kBlockSizeK; l < N;
        l += kBlockSizeK * blockDim.x) {
     auto key_i = reinterpret_cast<vec_t*>(key[batch_idx][l].data());
     scalar_t si[kBlockSizeQ][kBlockSizeK] = {0};
-    compute_dot<scalar_t, vec_t, kBlockSizeK, kBlockSizeQ>(query_block, key_i, si, K);
+    compute_dot<scalar_t, vec_t, kBlockSizeK, kBlockSizeQ>(
+        query_block, key_i, si, K);
 
     scalar_t m_i[kBlockSizeQ];
     compute_max<scalar_t, kBlockSizeK, kBlockSizeQ>(si, m_prime, m_i);

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -4,16 +4,12 @@
 #include <cmath>
 #include <vector>
 
-
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 
 #include "sputnik/vector_utils.h"
 
-
 namespace {
-
-
 
 #define CUDA_1D_KERNEL_LOOP(i, n)                                \
   for (int i = (blockIdx.x * blockDim.x) + threadIdx.x; i < (n); \
@@ -25,7 +21,7 @@ constexpr __host__ __device__ inline integer ceil_div(integer n, integer m) {
 }
 
 template <typename scalar_t>
-__device__ __forceinline__ void iMul(scalar_t x1, float4 * out) {
+__device__ __forceinline__ void iMul(scalar_t x1, float4* out) {
   out[0].x *= x1;
   out[0].y *= x1;
   out[0].z *= x1;
@@ -33,13 +29,12 @@ __device__ __forceinline__ void iMul(scalar_t x1, float4 * out) {
 }
 
 template <typename scalar_t>
-__device__ __forceinline__ void iDiv(scalar_t x1, float4 * out) {
+__device__ __forceinline__ void iDiv(scalar_t x1, float4* out) {
   out[0].x /= x1;
   out[0].y /= x1;
   out[0].z /= x1;
   out[0].w /= x1;
 }
-
 
 template <typename scalar_t, int WARP_SIZE>
 __device__ __forceinline__ scalar_t warpSum(scalar_t val) {
@@ -60,7 +55,6 @@ __device__ __forceinline__ float4 warpSum(float4 val) {
   return val;
 }
 
-
 template <typename scalar_t, int WARP_SIZE>
 __device__ __forceinline__ scalar_t warpMax(scalar_t val) {
   for (int stride = WARP_SIZE / 2; stride > 0; stride >>= 1) {
@@ -70,11 +64,14 @@ __device__ __forceinline__ scalar_t warpMax(scalar_t val) {
   return val;
 }
 
-
 template <typename scalar_t, int BLOCK, int BLOCK2>
-__device__ void compute_dot(float4* aar[BLOCK2], float4* bar, scalar_t si[BLOCK2][BLOCK], int64_t K) {
+__device__ void compute_dot(
+    float4* aar[BLOCK2],
+    float4* bar,
+    scalar_t si[BLOCK2][BLOCK],
+    int64_t K) {
   constexpr int kVecSize = sizeof(float4) / sizeof(float);
-  for (int64_t k = 0; k < K / kVecSize; k+=1) {
+  for (int64_t k = 0; k < K / kVecSize; k += 1) {
     float4 aaar[BLOCK2];
 #pragma unroll
     for (int64_t rr = 0; rr < BLOCK2; rr++) {
@@ -92,10 +89,15 @@ __device__ void compute_dot(float4* aar[BLOCK2], float4* bar, scalar_t si[BLOCK2
 }
 
 template <typename scalar_t, int BLOCK, int BLOCK2>
-__device__ void compute_final_mult(float4* vi, scalar_t s_delta[BLOCK2][BLOCK], scalar_t m_delta[BLOCK2], float4 buffer[BLOCK2][8] /*TODO fix me*/, int64_t K) {
+__device__ void compute_final_mult(
+    float4* vi,
+    scalar_t s_delta[BLOCK2][BLOCK],
+    scalar_t m_delta[BLOCK2],
+    float4 buffer[BLOCK2][8] /*TODO fix me*/,
+    int64_t K) {
   constexpr int kVecSize = sizeof(float4) / sizeof(float);
 
-  for (int64_t k = 0; k < K/kVecSize; k+=1) {
+  for (int64_t k = 0; k < K / kVecSize; k += 1) {
 #pragma unroll
     for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
       iMul<scalar_t>(m_delta[rr2], &buffer[rr2][k]);
@@ -106,14 +108,18 @@ __device__ void compute_final_mult(float4* vi, scalar_t s_delta[BLOCK2][BLOCK], 
 
 #pragma unroll
       for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
-        sputnik::VectorCompute<float4>::FMA(s_delta[rr2][rr], tmp2, &buffer[rr2][k]);
+        sputnik::VectorCompute<float4>::FMA(
+            s_delta[rr2][rr], tmp2, &buffer[rr2][k]);
       }
     }
   }
 }
 
 template <typename scalar_t, int BLOCK, int BLOCK2>
-__device__ __forceinline__ void compute_max(scalar_t si[BLOCK2][BLOCK], scalar_t m_prime[BLOCK2], scalar_t m_i[BLOCK2]) {
+__device__ __forceinline__ void compute_max(
+    scalar_t si[BLOCK2][BLOCK],
+    scalar_t m_prime[BLOCK2],
+    scalar_t m_i[BLOCK2]) {
 #pragma unroll
   for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
     m_i[rr2] = si[rr2][0] > m_prime[rr2] ? si[rr2][0] : m_prime[rr2];
@@ -124,9 +130,13 @@ __device__ __forceinline__ void compute_max(scalar_t si[BLOCK2][BLOCK], scalar_t
   }
 }
 
-
 template <typename scalar_t, int BLOCK, int BLOCK2>
-__device__ __forceinline__ void compute_scaling_coeffs(scalar_t m_i[BLOCK2], scalar_t m_prime[BLOCK2], scalar_t si[BLOCK2][BLOCK], scalar_t m_delta[BLOCK2], scalar_t s_delta[BLOCK2][BLOCK]) {
+__device__ __forceinline__ void compute_scaling_coeffs(
+    scalar_t m_i[BLOCK2],
+    scalar_t m_prime[BLOCK2],
+    scalar_t si[BLOCK2][BLOCK],
+    scalar_t m_delta[BLOCK2],
+    scalar_t s_delta[BLOCK2][BLOCK]) {
 #pragma unroll
   for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++)
     m_delta[rr2] = std::exp(m_prime[rr2] - m_i[rr2]);
@@ -137,9 +147,13 @@ __device__ __forceinline__ void compute_scaling_coeffs(scalar_t m_i[BLOCK2], sca
       s_delta[rr2][rr] = std::exp(si[rr2][rr] - m_i[rr2]);
 }
 
-
 template <typename scalar_t, int BLOCK, int BLOCK2>
-__device__ __forceinline__ void update_scaling_coeffs(scalar_t m_delta[BLOCK2], scalar_t m_i[BLOCK2], scalar_t s_delta[BLOCK2][BLOCK], scalar_t m_prime[BLOCK2], scalar_t s_prime[BLOCK2]) {
+__device__ __forceinline__ void update_scaling_coeffs(
+    scalar_t m_delta[BLOCK2],
+    scalar_t m_i[BLOCK2],
+    scalar_t s_delta[BLOCK2][BLOCK],
+    scalar_t m_prime[BLOCK2],
+    scalar_t s_prime[BLOCK2]) {
 #pragma unroll
   for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
     s_prime[rr2] = s_prime[rr2] * m_delta[rr2];
@@ -151,13 +165,12 @@ __device__ __forceinline__ void update_scaling_coeffs(scalar_t m_delta[BLOCK2], 
   }
 }
 
-template <typename scalar_t, int BLOCK=32, int BLOCK2=2>
+template <typename scalar_t, int BLOCK = 32, int BLOCK2 = 2>
 __global__ void attention_kernel(
     at::PackedTensorAccessor<scalar_t, 3> output,
     at::PackedTensorAccessor<scalar_t, 3> query,
     at::PackedTensorAccessor<scalar_t, 3> key,
-    at::PackedTensorAccessor<scalar_t, 3> value
-    ) {
+    at::PackedTensorAccessor<scalar_t, 3> value) {
   constexpr int kVecSize = sizeof(float4) / sizeof(float);
   int64_t K = query.size(2);
   int64_t B = query.size(0);
@@ -167,66 +180,65 @@ __global__ void attention_kernel(
   int64_t i = blockIdx.y;
   int64_t j = blockIdx.x * (blockDim.y * BLOCK2) + threadIdx.y * BLOCK2;
 
-      {{
-        float4* aar[BLOCK2];
-        float4* oo[BLOCK2];
-        float4 buffer[BLOCK2][8] = {0}; // TODO == K / 4
-        scalar_t s_prime[BLOCK2] = {0};
-        scalar_t m_prime[BLOCK2] = {-std::numeric_limits<scalar_t>::infinity()};
-        for (int64_t rr = 0; rr < BLOCK2; rr++) {
-          aar[rr] = reinterpret_cast<float4 *>(query[i][j + rr].data());
-          oo[rr] = reinterpret_cast<float4 *>(output[i][j + rr].data());
-        }
+  float4* aar[BLOCK2];
+  float4* oo[BLOCK2];
+  float4 buffer[BLOCK2][8] = {0}; // TODO == K / 4
+  scalar_t s_prime[BLOCK2] = {0};
+  scalar_t m_prime[BLOCK2] = {-std::numeric_limits<scalar_t>::infinity()};
+  for (int64_t rr = 0; rr < BLOCK2; rr++) {
+    aar[rr] = reinterpret_cast<float4*>(query[i][j + rr].data());
+    oo[rr] = reinterpret_cast<float4*>(output[i][j + rr].data());
+  }
 
-        for (int64_t l = threadIdx.x * BLOCK; l < N; l+=BLOCK * blockDim.x) {
-          auto bar = reinterpret_cast<float4 *>(key[i][l].data());
-          scalar_t si[BLOCK2][BLOCK] = {0};
-          compute_dot<scalar_t, BLOCK, BLOCK2>(aar, bar, si, K);
+  for (int64_t l = threadIdx.x * BLOCK; l < N; l += BLOCK * blockDim.x) {
+    auto bar = reinterpret_cast<float4*>(key[i][l].data());
+    scalar_t si[BLOCK2][BLOCK] = {0};
+    compute_dot<scalar_t, BLOCK, BLOCK2>(aar, bar, si, K);
 
-          scalar_t m_i[BLOCK2];
-          compute_max<scalar_t, BLOCK, BLOCK2>(si, m_prime, m_i);
+    scalar_t m_i[BLOCK2];
+    compute_max<scalar_t, BLOCK, BLOCK2>(si, m_prime, m_i);
 
-          auto vi = reinterpret_cast<float4 *>(value[i][l].data());
+    auto vi = reinterpret_cast<float4*>(value[i][l].data());
 
-          scalar_t m_delta[BLOCK2];
-          scalar_t s_delta[BLOCK2][BLOCK];
+    scalar_t m_delta[BLOCK2];
+    scalar_t s_delta[BLOCK2][BLOCK];
 
-          compute_scaling_coeffs<scalar_t, BLOCK, BLOCK2>(m_i, m_prime, si, m_delta, s_delta);
+    compute_scaling_coeffs<scalar_t, BLOCK, BLOCK2>(
+        m_i, m_prime, si, m_delta, s_delta);
 
-          compute_final_mult<scalar_t, BLOCK, BLOCK2>(vi, s_delta, m_delta, buffer, K);
+    compute_final_mult<scalar_t, BLOCK, BLOCK2>(
+        vi, s_delta, m_delta, buffer, K);
 
-          update_scaling_coeffs<scalar_t, BLOCK, BLOCK2>(m_delta, m_i, s_delta, m_prime, s_prime);
-        }
+    update_scaling_coeffs<scalar_t, BLOCK, BLOCK2>(
+        m_delta, m_i, s_delta, m_prime, s_prime);
+  }
 
-        for (int64_t rr = 0; rr < BLOCK2; rr++) {
-          scalar_t m_i = m_prime[rr];
-          scalar_t s_i = s_prime[rr];
-          m_prime[rr] = warpMax<scalar_t, 4>(m_prime[rr]);
-          scalar_t m_delta = std::exp(m_i - m_prime[rr]);
-          scalar_t s_delta = s_i * m_delta;
-          s_delta = warpSum<scalar_t, 4>(s_delta);
-          s_prime[rr] = s_delta;
-          for (int64_t k = 0; k < K / kVecSize; k+=1) {
-            float4 tmp = buffer[rr][k];
-            iMul<scalar_t>(m_delta, &tmp);
-            tmp = warpSum<float4, 4>(tmp);
-            buffer[rr][k] = tmp;
+  for (int64_t rr = 0; rr < BLOCK2; rr++) {
+    scalar_t m_i = m_prime[rr];
+    scalar_t s_i = s_prime[rr];
+    m_prime[rr] = warpMax<scalar_t, 4>(m_prime[rr]);
+    scalar_t m_delta = std::exp(m_i - m_prime[rr]);
+    scalar_t s_delta = s_i * m_delta;
+    s_delta = warpSum<scalar_t, 4>(s_delta);
+    s_prime[rr] = s_delta;
+    for (int64_t k = 0; k < K / kVecSize; k += 1) {
+      float4 tmp = buffer[rr][k];
+      iMul<scalar_t>(m_delta, &tmp);
+      tmp = warpSum<float4, 4>(tmp);
+      buffer[rr][k] = tmp;
+    }
+  }
 
-          }
-        }
-
-        for (int64_t k = threadIdx.x; k < K / kVecSize; k+=blockDim.x) {
-          float4 tmp;
+  for (int64_t k = threadIdx.x; k < K / kVecSize; k += blockDim.x) {
+    float4 tmp;
 
 #pragma unroll
-          for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
-            tmp = buffer[rr2][k];
-            iDiv<scalar_t>(s_prime[rr2], &tmp);
+    for (int64_t rr2 = 0; rr2 < BLOCK2; rr2++) {
+      tmp = buffer[rr2][k];
+      iDiv<scalar_t>(s_prime[rr2], &tmp);
 
-            oo[rr2][k] = tmp;
-          }
-        }
-      }
+      oo[rr2][k] = tmp;
+    }
   }
 }
 
@@ -234,16 +246,16 @@ at::Tensor attention(
     const at::Tensor& query,
     const at::Tensor& key,
     const at::Tensor& value
-    //const at::Tensor& mask
-    ) {
+    // const at::Tensor& mask
+) {
   TORCH_CHECK(query.dim() == key.dim());
-  //TORCH_CHECK(query.dim() == mask.dim());
+  // TORCH_CHECK(query.dim() == mask.dim());
   TORCH_CHECK(query.dim() == 3);
   TORCH_CHECK(query.size(2) == key.size(2));
   TORCH_CHECK(query.size(0) == key.size(0));
-  //TORCH_CHECK(query.size(1) == mask.size(1));
-  //TORCH_CHECK(query.size(2) == mask.size(2));
-  //TORCH_CHECK(query.size(0) == mask.size(0));
+  // TORCH_CHECK(query.size(1) == mask.size(1));
+  // TORCH_CHECK(query.size(2) == mask.size(2));
+  // TORCH_CHECK(query.size(0) == mask.size(0));
 
   /*
   TORCH_CHECK(!a.is_cuda(), "a must be a CPU tensor");
@@ -265,37 +277,36 @@ at::Tensor attention(
   int64_t N = key.size(1);
   int64_t K = query.size(2);
 
-
   at::Tensor res = at::zeros({B, M, K}, query.options());
 
   int64_t grain_size = 32; // TODO: tune this
-  //at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
-  //at::Tensor buffer = at::empty({at::get_num_threads(), 1, K}, query.options());
+  // at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
+  // at::Tensor buffer = at::empty({at::get_num_threads(), 1, K},
+  // query.options());
 
-
-  //dim3 grid(std::min(
+  // dim3 grid(std::min(
   //    ceil_div(static_cast<int64_t>(B), static_cast<int64_t>(512)),
   //    static_cast<int64_t>(4096)));
-  //dim3 block(512);
-  //dim3 grid(M / 32, B);
+  // dim3 block(512);
+  // dim3 grid(M / 32, B);
   dim3 grid(M / 32, B);
-  //dim3 block(32, 32);
-  //dim3 block(4, 32);
+  // dim3 block(32, 32);
+  // dim3 block(4, 32);
   dim3 block(4, 16);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
   using scalar_t = float;
-  //AT_DISPATCH_FLOATING_TYPES(
-      //query.scalar_type(), "attention_kernel", [&] {
-        attention_kernel<scalar_t><<<grid, block, 0, stream>>>(
-            res.packed_accessor<scalar_t, 3>(),
-            query.packed_accessor<scalar_t, 3>(),
-            key.packed_accessor<scalar_t, 3>(),
-            value.packed_accessor<scalar_t, 3>()
-            //buffer.accessor<scalar_t, 3>()
-            //idxs.accessor<int64_t, 2>()
-            );
-      //});
+  // AT_DISPATCH_FLOATING_TYPES(
+  // query.scalar_type(), "attention_kernel", [&] {
+  attention_kernel<scalar_t><<<grid, block, 0, stream>>>(
+      res.packed_accessor<scalar_t, 3>(),
+      query.packed_accessor<scalar_t, 3>(),
+      key.packed_accessor<scalar_t, 3>(),
+      value.packed_accessor<scalar_t, 3>()
+      // buffer.accessor<scalar_t, 3>()
+      // idxs.accessor<int64_t, 2>()
+  );
+  //});
 
   return res;
 }

--- a/xformers/ops.py
+++ b/xformers/ops.py
@@ -27,3 +27,20 @@ def masked_matmul(a, b, mask=None):
         # mask is presumed additive
         att += mask
     return att
+
+
+def memory_efficient_attention(
+    query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+):
+    """
+    Implements the memory-efficient attention mechanism following
+    `"Self-Attention Does Not Need O(n^2) Memory" <http://arxiv.org/abs/2112.05682>`_.
+
+    For now, only forward in inference-mode is supported.
+    """
+    # don't support backwards for now
+    assert query.requires_grad is False
+    assert key.requires_grad is False
+    assert value.requires_grad is False
+
+    return torch.ops.xformers.efficient_attention(query, key, value)


### PR DESCRIPTION
## What does this PR do?

This PR implements the memory-efficient attention mechanism from https://arxiv.org/pdf/2112.05682v2.pdf, with both CPU and CUDA kernels. For now, only fp32 is supported.

The CPU implementation is fairly naive and I haven't focused on optimizing it (yet). So you should expect it to be quite a bit slower than a baseline CPU implementation in PyTorch. But it is generic and should support all cases

For the CUDA implementation, the performance is quite competitive with a baseline pytorch implementation for fp32 in terms of runtime (within 10% for most cases), while the memory savings are quite significant (10x+).

Here are some numbers (run on a P100 GPU):
<details>

<summary>
Speed / memory improvements on the CUDA case
</summary>

```
Optimized Memory used: 0.0634765625 MB
Vanilla Memory used: 0.171875 MB
===== (1, 128, 16) =====
Optimized Memory used: 0.0322265625 MB
Vanilla Memory used: 0.1494140625 MB
===== (1, 128, 32) =====
Optimized Memory used: 0.0634765625 MB
Vanilla Memory used: 0.1728515625 MB
===== (1, 512, 16) =====
Optimized Memory used: 0.1259765625 MB
Vanilla Memory used: 2.0947265625 MB
===== (1, 512, 32) =====
Optimized Memory used: 0.2509765625 MB
Vanilla Memory used: 2.1884765625 MB
===== (1, 513, 16) =====
Optimized Memory used: 0.1279296875 MB
Vanilla Memory used: 2.10498046875 MB
===== (1, 513, 32) =====
Optimized Memory used: 0.2529296875 MB
Vanilla Memory used: 2.19873046875 MB
===== (1, 1023, 16) =====
Optimized Memory used: 0.2509765625 MB
Vanilla Memory used: 8.173828125 MB
===== (1, 1023, 32) =====
Optimized Memory used: 0.5009765625 MB
Vanilla Memory used: 8.361328125 MB
===== (1, 1024, 16) =====
Optimized Memory used: 0.2509765625 MB
Vanilla Memory used: 8.1884765625 MB
===== (1, 1024, 32) =====
Optimized Memory used: 0.5009765625 MB
Vanilla Memory used: 8.3759765625 MB
===== (8, 127, 16) =====
Optimized Memory used: 0.2490234375 MB
Vanilla Memory used: 1.17236328125 MB
===== (8, 127, 32) =====
Optimized Memory used: 0.4970703125 MB
Vanilla Memory used: 1.3583984375 MB
===== (8, 128, 16) =====
Optimized Memory used: 0.2509765625 MB
Vanilla Memory used: 1.1884765625 MB
===== (8, 128, 32) =====
Optimized Memory used: 0.5009765625 MB
Vanilla Memory used: 1.3759765625 MB
===== (8, 512, 16) =====
Optimized Memory used: 1.0009765625 MB
Vanilla Memory used: 16.7509765625 MB
===== (8, 512, 32) =====
Optimized Memory used: 2.0009765625 MB
Vanilla Memory used: 17.5009765625 MB
===== (8, 513, 16) =====
Optimized Memory used: 1.0029296875 MB
Vanilla Memory used: 16.81591796875 MB
===== (8, 513, 32) =====
Optimized Memory used: 2.0048828125 MB
Vanilla Memory used: 17.5673828125 MB
===== (8, 1023, 16) =====
Optimized Memory used: 1.9990234375 MB
Vanilla Memory used: 65.49951171875 MB
===== (8, 1023, 32) =====
Optimized Memory used: 3.9970703125 MB
Vanilla Memory used: 66.998046875 MB
===== (8, 1024, 16) =====
Optimized Memory used: 2.0009765625 MB
Vanilla Memory used: 65.5009765625 MB
===== (8, 1024, 32) =====
Optimized Memory used: 4.0009765625 MB
Vanilla Memory used: 67.0009765625 MB
===== (32, 127, 16) =====
Optimized Memory used: 0.9931640625 MB
Vanilla Memory used: 4.68359375 MB
===== (32, 127, 32) =====
Optimized Memory used: 1.9853515625 MB
Vanilla Memory used: 5.427734375 MB
===== (32, 128, 16) =====
Optimized Memory used: 1.0009765625 MB
Vanilla Memory used: 4.7509765625 MB
===== (32, 128, 32) =====
Optimized Memory used: 2.0009765625 MB
Vanilla Memory used: 5.5009765625 MB
===== (32, 512, 16) =====
Optimized Memory used: 4.0009765625 MB
Vanilla Memory used: 67.0009765625 MB
===== (32, 512, 32) =====
Optimized Memory used: 8.0009765625 MB
Vanilla Memory used: 70.0009765625 MB
===== (32, 513, 16) =====
Optimized Memory used: 5.87939453125 MB
Vanilla Memory used: 69.12841796875 MB
===== (32, 513, 32) =====
Optimized Memory used: 8.0166015625 MB
Vanilla Memory used: 70.263671875 MB
===== (32, 1023, 16) =====
Optimized Memory used: 8.0068359375 MB
Vanilla Memory used: 262.0087890625 MB
===== (32, 1023, 32) =====
Optimized Memory used: 15.9931640625 MB
Vanilla Memory used: 267.9970703125 MB
===== (32, 1024, 16) =====
Optimized Memory used: 8.0048828125 MB
Vanilla Memory used: 262.0048828125 MB
===== (32, 1024, 32) =====
Optimized Memory used: 16.0087890625 MB
Vanilla Memory used: 268.0087890625 MB
===== (256, 127, 16) =====
Optimized Memory used: 7.9892578125 MB
Vanilla Memory used: 38.0048828125 MB
===== (256, 127, 32) =====
Optimized Memory used: 15.9462890625 MB
Vanilla Memory used: 43.9423828125 MB
===== (256, 128, 16) =====
Optimized Memory used: 8.0556640625 MB
Vanilla Memory used: 38.0556640625 MB
===== (256, 128, 32) =====
Optimized Memory used: 16.0009765625 MB
Vanilla Memory used: 44.0009765625 MB
===== (256, 512, 16) =====
Optimized Memory used: 32.0009765625 MB
Vanilla Memory used: 536.0009765625 MB
===== (256, 512, 32) =====
Optimized Memory used: 64.0009765625 MB
Vanilla Memory used: 560.0009765625 MB
===== (256, 513, 16) =====
Optimized Memory used: 32.0634765625 MB
Vanilla Memory used: 540.0478515625 MB
===== (256, 513, 32) =====
Optimized Memory used: 64.1259765625 MB
Vanilla Memory used: 564.0947265625 MB
===== (256, 1023, 16) =====
Optimized Memory used: 63.9384765625 MB
Vanilla Memory used: 2091.9560546875 MB
===== (256, 1023, 32) =====
Optimized Memory used: 127.9384765625 MB
Vanilla Memory used: 2139.9716796875 MB
===== (256, 1024, 16) =====
Optimized Memory used: 64.0009765625 MB
Vanilla Memory used: 2096.0009765625 MB
===== (256, 1024, 32) =====
Optimized Memory used: 128.0009765625 MB
Vanilla Memory used: 2144.0009765625 MB
[------------------- attention -------------------]
                           |  optimized  |  vanilla
1 threads: ----------------------------------------
      B=1, M=127, K=16     |      24.8   |     43.1
      B=1, M=127, K=32     |      38.3   |     42.8
      B=1, M=128, K=16     |      22.3   |     42.7
      B=1, M=128, K=32     |      40.6   |     42.6
      B=1, M=512, K=16     |      68.0   |     43.3
      B=1, M=512, K=32     |     124.9   |     43.0
      B=1, M=513, K=16     |      69.3   |     43.4
      B=1, M=513, K=32     |     127.7   |     44.2
      B=1, M=1023, K=16    |     129.5   |     65.6
      B=1, M=1023, K=32    |     237.6   |     77.6
      B=1, M=1024, K=16    |     127.0   |     60.7
      B=1, M=1024, K=32    |     236.3   |     67.6
      B=8, M=127, K=16     |      24.6   |     44.6
      B=8, M=127, K=32     |      38.4   |     44.6
      B=8, M=128, K=16     |      22.0   |     44.9
      B=8, M=128, K=32     |      40.4   |     44.4
      B=8, M=512, K=16     |     104.9   |    161.9
      B=8, M=512, K=32     |     191.1   |    167.8
      B=8, M=513, K=16     |     107.7   |    176.2
      B=8, M=513, K=32     |     195.2   |    184.1
      B=8, M=1023, K=16    |     269.7   |    504.8
      B=8, M=1023, K=32    |     570.8   |    526.6
      B=8, M=1024, K=16    |     262.0   |    490.4
      B=8, M=1024, K=32    |     555.5   |    517.5
      B=32, M=127, K=16    |      32.8   |     67.9
      B=32, M=127, K=32    |      58.3   |     68.8
      B=32, M=128, K=16    |      31.7   |     67.7
      B=32, M=128, K=32    |      55.5   |     68.5
      B=32, M=512, K=16    |     343.2   |    495.0
      B=32, M=512, K=32    |     829.6   |    523.0
      B=32, M=513, K=16    |     396.6   |    565.0
      B=32, M=513, K=32    |     791.6   |    606.9
      B=32, M=1023, K=16   |    1216.4   |   1883.1
      B=32, M=1023, K=32   |    2761.4   |   1978.6
      B=32, M=1024, K=16   |    1173.2   |   1826.1
      B=32, M=1024, K=32   |    2471.5   |   1936.5
      B=256, M=127, K=16   |     266.8   |    259.7
      B=256, M=127, K=32   |     708.9   |    275.0
      B=256, M=128, K=16   |     207.5   |    250.3
      B=256, M=128, K=32   |     442.1   |    267.8
      B=256, M=512, K=16   |    2039.8   |   3428.5
      B=256, M=512, K=32   |    4461.3   |   3673.7
      B=256, M=513, K=16   |    2056.5   |   3921.6
      B=256, M=513, K=32   |    4236.2   |   4294.6
      B=256, M=1023, K=16  |    7886.6   |  13886.5
      B=256, M=1023, K=32  |   16808.8   |  14857.4
      B=256, M=1024, K=16  |    7540.8   |  13333.9
      B=256, M=1024, K=32  |   15666.1   |  14408.2

Times are in microseconds (us).

```

</details>


You can see up to 20x memory savings for larger configurations, while the runtime is in the order of 10% slower than the baseline (which leverages CUBLAS internally).

## Next steps

This PR has some assumptions on the dimensionality of `K` (the feature map after splitting in heads). For now, it should be:
- if a multiple of 4, `K / 4 <= 8`
- else if a multiple of 2, `K / 2 <= 8`
- if none of the above, `K <= 8`

This can be fixed in the future if needed.

Fixes https://github.com/facebookresearch/xformers/issues/161.

