### PR TITLE
[fix] Q/K/V needs to be divisible by heads, not more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix some torchscriptability [#246]
 - Fix FourierMix being compatible with AMP [#258]
+- Better asserts on QKV dimensions [#264]
 
 ### Added
 - Simplicial Embeddings [#259]
+- Mem efficient attention, FW pass [#267]
 
 ## [0.0.10] - 2022-03-14
 ### Fixed

--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -118,7 +118,7 @@ class MultiHeadDispatch(nn.Module):
 
     def _check(self, t, name):
         assert (
-            t.shape[2] % self.dim_k == 0
+            t.shape[2] % self.num_heads == 0
         ), f"the {name} embeddings need to be divisible by the number of heads"
 
     def forward(


### PR DESCRIPTION
## What does this PR do?
improvement for #264, but does not fix all the points. Divisibility by the number of heads is what we want to check here, really

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
