### PR TITLE
Remove keyword arguments to attention call, pass as positional

### DIFF
--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -210,7 +210,7 @@ class MultiHeadDispatch(nn.Module):
             v = reshape_fn(v, B, S_K, self.num_heads, self.dim_k)
 
         # Self-attend
-        y = self.attention(q=q, k=k, v=v, **kw_mask_args)
+        y = self.attention(q, k, v, **kw_mask_args)
 
         # Re-assemble all head outputs side by side
         y = (


### PR DESCRIPTION
## What does this PR do?

As discussed with Ben offline, when using forward module hooks on the attention block arguments need to be passed in as positional args to access them within the hook (can be seen in the [docs](https://pytorch.org/docs/stable/generated/torch.nn.modules.module.register_module_forward_hook.html#torch.nn.modules.module.register_module_forward_hook)).

My use case for this is profiling using the [DeepSpeedProfiler](https://www.deepspeed.ai/tutorials/flops-profiler/). The profiler attaches hooks to modules to calculate how many FLOPs are done. When using xformers we need to declare a few more hooks in order to calculate them correctly, (as seen [here](https://github.com/SeanNaren/SmallScience/blob/feat/profiling/profiler.py#L26)).

An example!
```python
import torch

from xformers.components.attention import ScaledDotProduct

attention = ScaledDotProduct()


def hook(module, input, output):
    assert input


attention.register_forward_hook(hook)

inputs = torch.rand((8, 128, 128))

# this would fail the above assertion
# attention(q=inputs, k=inputs, v=inputs)

# this works!
attention(inputs, inputs, inputs)
```

@blefaudeux mentioned how it was mainly a case of being explicit (as it could be very wrong if args were swapped, the attention mechanism under the hood expected a different order of positional arguments). I'm up for alternatives, please let me know if there are any!

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
