### PR TITLE
[minor] Adding dev version numbering' 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,7 @@ copyright = "Copyright © 2021 Meta Platforms, Inc"
 author = "Facebook AI Research"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.10"
+release = "0.0.11.dev"
 
 # -- General configuration ---------------------------------------------------
 

--- a/xformers/__init__.py
+++ b/xformers/__init__.py
@@ -8,7 +8,7 @@ import logging
 import torch
 
 # Please update the doc version in docs/source/conf.py as well.
-__version__ = "0.0.10"
+__version__ = "0.0.11.dev"
 
 _is_sparse_available = True
 _is_triton_available = torch.cuda.is_available()


### PR DESCRIPTION
## What does this PR do?
Discussed on the Triton2 PR, move the python package numbering to 'next.dev' to make it easier to differentiate in between the current main package and the pip version

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
