### PR TITLE
[CI] Fix caching the env in between jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ setup_conda: &setup_conda
         source $BASH_ENV
 
         # check if we have restored venv cache (/home/circleci/venv) correctly, if so, just skip
-        if [ -f /home/circleci/venv/check_version.py ]; then python3 /home/circleci/venv/check_version.py torch gt 1.12 && exit 0; fi
+        if [ -f /home/circleci/venv/check_version.py ]; then $CONDA_PYTHON /home/circleci/venv/check_version.py torch gt 1.11 && exit 0; fi
 
         hash -r
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -81,7 +81,7 @@ install_dep: &install_dep
         source $BASH_ENV
 
         # check if we have restored venv cache (/home/circleci/venv) correctly, if so, just skip
-        if [ -f /home/circleci/venv/check_version.py ]; then $CONDA_PYTHON /home/circleci/venv/check_version.py torch gt 1.12 && exit 0; fi
+        if [ -f /home/circleci/venv/check_version.py ]; then $CONDA_PYTHON /home/circleci/venv/check_version.py torch gt 1.11 && exit 0; fi
 
         # start installing
         source activate /home/circleci/venv
@@ -98,7 +98,7 @@ install_dep_exp: &install_dep_exp
         source $BASH_ENV
 
         # check if we have restored venv cache (/home/circleci/venv) correctly, if so, just skip
-        if [ -f /home/circleci/venv/check_version.py ]; then $CONDA_PYTHON  /home/circleci/venv/check_version.py torch gt 1.12 && exit 0; fi
+        if [ -f /home/circleci/venv/check_version.py ]; then $CONDA_PYTHON  /home/circleci/venv/check_version.py torch gt 1.11 && exit 0; fi
 
         # start installing
         source activate /home/circleci/venv


### PR DESCRIPTION
## What does this PR do?
Minor, properly cache the env in between jobs, speeding up CI  a little.
I compared that with not using a cache at all, using a cache is actually faster:
- [with a warm cache](https://app.circleci.com/pipelines/github/facebookresearch/xformers/1460/workflows/1329534e-e14d-40b5-9775-daebde1adf4d) ~26 minutes
- [prior to this PR](https://app.circleci.com/pipelines/github/facebookresearch/xformers/1458/workflows/6ebb619b-296f-4c23-a705-30d748c0324c) ~35 minutes
- [no cache](https://app.circleci.com/pipelines/github/facebookresearch/xformers/1456/workflows/15e2decc-ade0-43a2-9f21-dce3a4cc5585) ~32 minutes 

(timings give or take a couple of minutes, but a proper cache is clearly better)

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
