### PR TITLE
Memory efficient attention - backward pass

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -49,3 +49,58 @@ def test_key_query_all_ones(device, q_len, kv_len, batch_size, k_len):
     ref = value.mean(1, keepdim=True).expand_as(query)
 
     assert torch.allclose(out, ref, atol=1e-5)
+
+
+@pytest.mark.parametrize("k_len", [5, 6, 32])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("kv_len", [3, 15, 32, 33])
+@pytest.mark.parametrize("q_len", [2, 3, 5])
+@pytest.mark.parametrize("device", _devices)
+def test_logsumexp(device, q_len, kv_len, batch_size, k_len):
+    scale = 3
+    query = torch.randn((batch_size, q_len, k_len), device=device) * scale
+    key = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+    value = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+
+    _, lse = torch.ops.xformers.efficient_attention(query, key, value, True)
+    ref_lse = ((query / k_len ** 0.5) @ key.transpose(-2, -1)).logsumexp(-1)
+
+    assert torch.allclose(lse, ref_lse, atol=2e-4)
+
+
+@pytest.mark.parametrize("k_len", [5, 6, 32])
+@pytest.mark.parametrize("batch_size", [1, 4])
+@pytest.mark.parametrize("kv_len", [3, 15, 32, 33])
+@pytest.mark.parametrize("q_len", [2, 3, 5])
+@pytest.mark.parametrize("device", _devices)
+def test_memory_efficient_attention_backward(device, q_len, kv_len, batch_size, k_len):
+    scale = 3
+    query = torch.randn((batch_size, q_len, k_len), device=device) * scale
+    key = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+    value = torch.randn((batch_size, kv_len, k_len), device=device) * scale
+
+    query.requires_grad_(True)
+    key.requires_grad_(True)
+    value.requires_grad_(True)
+
+    out = xformers.ops.memory_efficient_attention(query, key, value)
+    out.backward(torch.ones_like(query))
+
+    grad_q = query.grad
+    grad_k = key.grad
+    grad_v = value.grad
+
+    query.grad = None
+    key.grad = None
+    value.grad = None
+
+    ref = ref_attention(query, key, value)
+    ref.backward(torch.ones_like(query))
+
+    # there is some extra precision loss in the CPU implementation due to an
+    # extra accumulation step in grad_q, which is not present in the CUDA
+    # implementation
+    atol = 3e-4 if device == "cuda" else 4e-4
+    assert torch.allclose(grad_q, query.grad, atol=atol), "grad_q doesn't match"
+    assert torch.allclose(grad_k, key.grad, atol=atol), "grad_k doesn't match"
+    assert torch.allclose(grad_v, value.grad, atol=atol), "grad_v doesn't match"

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -26,6 +26,7 @@ NUM_THREADS = [1] if device.type == "cuda" else [1, 40]
 SHAPES = list(
     itertools.product([1, 8, 32, 256], [127, 128, 512, 513, 1023, 1024], [16, 32])
 )
+SHAPES = [(256, 1024, 32)]
 
 results = []
 mem_use: Dict[str, Dict[str, float]] = dict(optimized={}, vanilla={})
@@ -38,7 +39,7 @@ for num_threads in NUM_THREADS:
         q = torch.rand(shape, device=device)
         sub_label = f"B={B}, M={M}, K={K}"
 
-        if True:
+        if False:
             r = xformers.ops.memory_efficient_attention(q, q, q)
 
             rr = ref_attention(q, q, q)
@@ -51,7 +52,7 @@ for num_threads in NUM_THREADS:
                 stmt="fn(q, q, q)",
                 globals={
                     "q": q,
-                    "fn": torch.ops.xformers.efficient_attention,
+                    "fn": xformers.ops.memory_efficient_attention,
                 },
                 label="attention",
                 description="optimized",

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -26,71 +26,151 @@ NUM_THREADS = [1] if device.type == "cuda" else [1, 40]
 SHAPES = list(
     itertools.product([1, 8, 32, 256], [127, 128, 512, 513, 1023, 1024], [16, 32])
 )
-SHAPES = [(256, 1024, 32)]
 
 results = []
 mem_use: Dict[str, Dict[str, float]] = dict(optimized={}, vanilla={})
 
-print(f"Processing {len(SHAPES)} cases")
-for num_threads in NUM_THREADS:
-    for shape in SHAPES:
-        print(f"===== {shape} =====")
-        B, M, K = shape
-        q = torch.rand(shape, device=device)
-        sub_label = f"B={B}, M={M}, K={K}"
 
-        if False:
-            r = xformers.ops.memory_efficient_attention(q, q, q)
+def benchmark_forward():
+    print(f"Processing {len(SHAPES)} cases")
+    print("Forward")
+    for num_threads in NUM_THREADS:
+        for shape in SHAPES:
+            print(f"===== {shape} =====")
+            B, M, K = shape
+            q = torch.rand(shape, device=device)
+            sub_label = f"B={B}, M={M}, K={K}"
 
-            rr = ref_attention(q, q, q)
-            assert (r - rr).abs().max() < 1e-5
+            if True:
+                r = xformers.ops.memory_efficient_attention(q, q, q)
 
-        torch.cuda.reset_peak_memory_stats()
-        torch.cuda.synchronize()
-        results.append(
-            benchmark.Timer(
-                stmt="fn(q, q, q)",
-                globals={
-                    "q": q,
-                    "fn": xformers.ops.memory_efficient_attention,
-                },
-                label="attention",
-                description="optimized",
-                sub_label=sub_label,
-                num_threads=num_threads,
-            ).blocked_autorange(min_run_time=min_run_time)
-        )
-        torch.cuda.synchronize()
-        memory = torch.cuda.max_memory_allocated() / 2 ** 20
-        mem_use["optimized"][sub_label] = memory
-        memory_str = f"Memory used: {memory} MB"
+                rr = ref_attention(q, q, q)
+                assert (r - rr).abs().max() < 1e-5
 
-        print("Optimized", memory_str)
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            results.append(
+                benchmark.Timer(
+                    stmt="fn(q, q, q)",
+                    globals={
+                        "q": q,
+                        "fn": xformers.ops.memory_efficient_attention,
+                    },
+                    label="attention",
+                    description="optimized",
+                    sub_label=sub_label,
+                    num_threads=num_threads,
+                ).blocked_autorange(min_run_time=min_run_time)
+            )
+            torch.cuda.synchronize()
+            memory = torch.cuda.max_memory_allocated() / 2 ** 20
+            mem_use["optimized"][sub_label] = memory
+            memory_str = f"Memory used: {memory} MB"
 
-        torch.cuda.reset_peak_memory_stats()
-        torch.cuda.synchronize()
-        results.append(
-            benchmark.Timer(
-                stmt="fn(q, q, q)",
-                globals={
-                    "q": q,
-                    "fn": ref_attention,
-                },
-                label="attention",
-                description="vanilla",
-                sub_label=sub_label,
-                num_threads=num_threads,
-            ).blocked_autorange(min_run_time=min_run_time)
-        )
+            print("Optimized", memory_str)
 
-        torch.cuda.synchronize()
-        memory = torch.cuda.max_memory_allocated() / 2 ** 20
-        mem_use["vanilla"][sub_label] = memory
-        memory_str = f"Memory used: {memory} MB"
-        print("Vanilla", memory_str)
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            results.append(
+                benchmark.Timer(
+                    stmt="fn(q, q, q)",
+                    globals={
+                        "q": q,
+                        "fn": ref_attention,
+                    },
+                    label="attention",
+                    description="vanilla",
+                    sub_label=sub_label,
+                    num_threads=num_threads,
+                ).blocked_autorange(min_run_time=min_run_time)
+            )
+
+            torch.cuda.synchronize()
+            memory = torch.cuda.max_memory_allocated() / 2 ** 20
+            mem_use["vanilla"][sub_label] = memory
+            memory_str = f"Memory used: {memory} MB"
+            print("Vanilla", memory_str)
+
+    compare = benchmark.Compare(results)
+    compare.print()
+
+    pprint.pprint(mem_use)
 
 
-compare = benchmark.Compare(results)
-compare.print()
+def benchmark_backward():
+    print(f"Processing {len(SHAPES)} cases")
+    print("Backward")
+    for num_threads in NUM_THREADS:
+        for shape in SHAPES:
+            print(f"===== {shape} =====")
+            B, M, K = shape
+            q = torch.rand(shape, device=device, requires_grad=True)
+            sub_label = f"B={B}, M={M}, K={K}"
 
-pprint.pprint(mem_use)
+            if True:
+                r = xformers.ops.memory_efficient_attention(q, q, q)
+                r.backward(torch.ones_like(q))
+
+                grad = q.grad
+                q.grad = None
+
+                rr = ref_attention(q, q, q)
+                rr.backward(torch.ones_like(q))
+                assert (grad - q.grad).abs().max() < 1e-5
+
+            out = xformers.ops.memory_efficient_attention(q, q, q)
+            grad = torch.ones_like(q)
+
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            results.append(
+                benchmark.Timer(
+                    stmt="out.backward(grad, retain_graph=True)",
+                    globals={
+                        "out": out,
+                        "grad": grad,
+                    },
+                    label="attention",
+                    description="optimized",
+                    sub_label=sub_label,
+                    num_threads=num_threads,
+                ).blocked_autorange(min_run_time=min_run_time)
+            )
+            torch.cuda.synchronize()
+            memory = torch.cuda.max_memory_allocated() / 2 ** 20
+            mem_use["optimized"][sub_label] = memory
+            memory_str = f"Memory used: {memory} MB"
+
+            print("Optimized", memory_str)
+
+            out = ref_attention(q, q, q)
+            torch.cuda.reset_peak_memory_stats()
+            torch.cuda.synchronize()
+            results.append(
+                benchmark.Timer(
+                    stmt="out.backward(grad, retain_graph=True)",
+                    globals={
+                        "out": out,
+                        "grad": grad,
+                    },
+                    label="attention",
+                    description="vanilla",
+                    sub_label=sub_label,
+                    num_threads=num_threads,
+                ).blocked_autorange(min_run_time=min_run_time)
+            )
+
+            torch.cuda.synchronize()
+            memory = torch.cuda.max_memory_allocated() / 2 ** 20
+            mem_use["vanilla"][sub_label] = memory
+            memory_str = f"Memory used: {memory} MB"
+            print("Vanilla", memory_str)
+
+    compare = benchmark.Compare(results)
+    compare.print()
+
+    pprint.pprint(mem_use)
+
+
+benchmark_forward()
+benchmark_backward()

--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -2,7 +2,7 @@
 
 TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention(Tensor query, Tensor key, Tensor value) -> Tensor"));
+      "xformers::efficient_attention(Tensor query, Tensor key, Tensor value, bool compute_logsumexp) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp) -> (Tensor, Tensor, Tensor)"));
 }

--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -4,5 +4,5 @@ TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention(Tensor query, Tensor key, Tensor value) -> Tensor"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value) -> (Tensor, Tensor, Tensor)"));
+      "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp) -> (Tensor, Tensor, Tensor)"));
 }

--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -3,4 +3,6 @@
 TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention(Tensor query, Tensor key, Tensor value) -> Tensor"));
+  m.def(TORCH_SELECTIVE_SCHEMA(
+      "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value) -> (Tensor, Tensor, Tensor)"));
 }

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -147,10 +147,189 @@ at::Tensor attention(
   return res;
 }
 
+template <typename scalar_t>
+void attention_backward_kernel(
+    at::TensorAccessor<scalar_t, 3> grad_q,
+    at::TensorAccessor<scalar_t, 3> grad_k,
+    at::TensorAccessor<scalar_t, 3> grad_v,
+    at::TensorAccessor<scalar_t, 3> grad_out,
+    at::TensorAccessor<scalar_t, 3> q,
+    at::TensorAccessor<scalar_t, 3> k,
+    at::TensorAccessor<scalar_t, 3> v,
+    at::TensorAccessor<scalar_t, 2> logsumexp_normalizer,
+    at::TensorAccessor<scalar_t, 3> buffer,
+    at::TensorAccessor<scalar_t, 3> buffer2,
+    at::TensorAccessor<scalar_t, 3> buffer3 //,
+    // at::TensorAccessor<int64_t, 2> mask
+) {
+  int64_t K = q.size(2);
+  int64_t B = q.size(0);
+  int64_t M = q.size(1);
+  int64_t N = k.size(1);
+  int64_t grain_size = 1; // buffer.size(1);
+  at::parallel_for(0, B, grain_size, [&](int64_t start, int64_t end) {
+    auto buf = buffer[at::get_thread_num()][0];
+    auto buf2 = buffer2[at::get_thread_num()];
+    auto buf3 = buffer3[at::get_thread_num()][0];
+    for (int64_t i = start; i < end; i++) {
+      for (int64_t l = 0; l < N; l++) {
+        for (int64_t k = 0; k < K; k++) {
+          buf2[l][k] = 0;
+        }
+      }
+
+      for (int64_t j = 0; j < M; j++) {
+        for (int64_t k = 0; k < K; k++) {
+          buf[k] = 0;
+        }
+        auto aar = q[i][j];
+        auto normalizer = logsumexp_normalizer[i][j];
+        scalar_t tmp_sum = 0;
+        for (int64_t l = 0; l < N; l++) {
+          auto bar = k[i][l];
+          scalar_t si = 0;
+          for (int64_t k = 0; k < K; k++) {
+            si += aar[k] * bar[k];
+          }
+          scalar_t attn_v = std::exp(si - normalizer);
+
+          for (int64_t k = 0; k < K; k++) {
+            grad_v[i][l][k] += attn_v * grad_out[i][j][k];
+          }
+
+          // now compute grad_q and grad_k
+          scalar_t g_attn = 0;
+          for (int64_t k = 0; k < K; k++) {
+            g_attn += grad_out[i][j][k] * v[i][l][k];
+            // g_attn[i][j][l] += grad_out[i][j][k] * v[i][l][k];
+          }
+          scalar_t tmp = attn_v * g_attn;
+          tmp_sum += tmp;
+
+          // grad_q is easy
+          for (int64_t k = 0; k < K; k++) {
+            grad_q[i][j][k] += tmp * bar[k]; // bar == key
+            buf[k] += attn_v * bar[k];
+          }
+
+          // scalar_t factor = tmp_sum / (tmp_sum - tmp);
+          // if (tmp_sum == tmp)
+          //  factor = 1;
+
+          //  but grad_k is trickier
+          for (int64_t k = 0; k < K; k++) {
+            grad_k[i][l][k] += tmp * aar[k];
+            // buf2[l][k] = buf2[l][k] * factor + attn_v * aar[k] * tmp_sum;
+          }
+        }
+        buf3[j] = tmp_sum;
+        for (int64_t k = 0; k < K; k++) {
+          grad_q[i][j][k] -= buf[k] * tmp_sum;
+        }
+      }
+
+      // TODO: try to make this folded in the previous loop
+      for (int64_t j = 0; j < M; j++) {
+        auto aar = q[i][j];
+        auto normalizer = logsumexp_normalizer[i][j];
+        scalar_t tmp = buf3[j];
+        for (int64_t l = 0; l < N; l++) {
+          auto bar = k[i][l];
+          scalar_t si = 0;
+          for (int64_t k = 0; k < K; k++) {
+            si += aar[k] * bar[k];
+          }
+          scalar_t attn_v = std::exp(si - normalizer);
+
+          for (int64_t k = 0; k < K; k++) {
+            buf2[l][k] += attn_v * aar[k] * tmp;
+          }
+        }
+      }
+
+      for (int64_t l = 0; l < N; l++) {
+        for (int64_t k = 0; k < K; k++) {
+          grad_k[i][l][k] -= buf2[l][k];
+        }
+      }
+    }
+  });
+}
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
+    const at::Tensor& grad_out,
+    const at::Tensor& query,
+    const at::Tensor& key,
+    const at::Tensor& value
+    // const at::Tensor& mask
+) {
+  TORCH_CHECK(query.dim() == key.dim());
+  // TORCH_CHECK(query.dim() == mask.dim());
+  TORCH_CHECK(query.dim() == 3);
+  TORCH_CHECK(query.size(2) == key.size(2));
+  TORCH_CHECK(query.size(0) == key.size(0));
+  // TORCH_CHECK(query.size(1) == mask.size(1));
+  // TORCH_CHECK(query.size(2) == mask.size(2));
+  // TORCH_CHECK(query.size(0) == mask.size(0));
+
+  /*
+  TORCH_CHECK(!a.is_cuda(), "a must be a CPU tensor");
+  TORCH_CHECK(!b.is_cuda(), "b must be a CPU tensor");
+  TORCH_CHECK(!mask.is_cuda(), "mask must be a CPU tensor");
+  TORCH_CHECK(!a.is_sparse(), "a must be a dense tensor");
+  TORCH_CHECK(!b.is_sparse(), "b must be a dense tensor");
+  //TORCH_CHECK(mask.is_sparse(), "mask must be a sparse tensor");
+  */
+
+  int64_t B = query.size(0);
+  int64_t M = query.size(1);
+  int64_t N = key.size(1);
+  int64_t K = query.size(2);
+
+  at::Tensor res = at::empty({B, M, K}, query.options());
+  at::Tensor grad_q = at::zeros_like(query);
+  at::Tensor grad_k = at::zeros_like(key);
+  at::Tensor grad_v = at::zeros_like(value);
+
+  int64_t grain_size = 32; // TODO: tune this
+  // at::Tensor buffer = at::empty({B, grain_size, K}, query.options());
+  at::Tensor buffer = at::empty({at::get_num_threads(), 1, K}, query.options());
+  at::Tensor buffer2 =
+      at::zeros({at::get_num_threads(), N, K + 1}, query.options());
+  at::Tensor buffer3 =
+      at::zeros({at::get_num_threads(), 1, M}, query.options());
+
+  // TODO this should be an argument from the function
+  at::Tensor logsumexp = query.bmm(key.transpose(-2, -1)).logsumexp(-1);
+
+  AT_DISPATCH_FLOATING_TYPES(
+      query.scalar_type(), "attention_backward_kernel", [&] {
+        attention_backward_kernel<scalar_t>(
+            grad_q.accessor<scalar_t, 3>(),
+            grad_k.accessor<scalar_t, 3>(),
+            grad_v.accessor<scalar_t, 3>(),
+            grad_out.accessor<scalar_t, 3>(),
+            query.accessor<scalar_t, 3>(),
+            key.accessor<scalar_t, 3>(),
+            value.accessor<scalar_t, 3>(),
+            logsumexp.accessor<scalar_t, 2>(),
+            buffer.accessor<scalar_t, 3>(),
+            buffer2.accessor<scalar_t, 3>(),
+            buffer3.accessor<scalar_t, 3>()
+            // idxs.accessor<int64_t, 2>()
+        );
+      });
+
+  return std::make_tuple(grad_q, grad_k, grad_v);
+}
+
 } // namespace
 
 TORCH_LIBRARY_IMPL(xformers, CPU, m) {
   m.impl(
       TORCH_SELECTIVE_NAME("xformers::efficient_attention"),
       TORCH_FN(attention));
+  m.impl(
+      TORCH_SELECTIVE_NAME("xformers::efficient_attention_backward"),
+      TORCH_FN(attention_backward));
 }

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -178,7 +178,6 @@ void attention_backward_kernel(
     auto buf = buffer[at::get_thread_num()][0];
     auto buf2 = buffer2[at::get_thread_num()][0];
     for (int64_t i = start; i < end; i++) {
-
       for (int64_t j = 0; j < M; j++) {
         for (int64_t k = 0; k < K; k++) {
           buf[k] = 0;
@@ -244,8 +243,6 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
     const at::Tensor& logsumexp
     // const at::Tensor& mask
 ) {
-
-
   TORCH_CHECK(query.dim() == grad_out.dim());
   TORCH_CHECK(query.dim() == key.dim());
   TORCH_CHECK(query.dim() == value.dim());

--- a/xformers/components/attention/csrc/cpu/attention.cpp
+++ b/xformers/components/attention/csrc/cpu/attention.cpp
@@ -232,7 +232,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
     const at::Tensor& grad_out,
     const at::Tensor& query,
     const at::Tensor& key,
-    const at::Tensor& value
+    const at::Tensor& value,
+    const at::Tensor& logsumexp
     // const at::Tensor& mask
 ) {
 
@@ -281,7 +282,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
       at::zeros({at::get_num_threads(), 1, N}, query.options());
 
   // TODO this should be an argument from the function
-  at::Tensor logsumexp = query.bmm(key.transpose(-2, -1)).logsumexp(-1);
+  //at::Tensor logsumexp = query.bmm(key.transpose(-2, -1)).logsumexp(-1);
 
   AT_DISPATCH_FLOATING_TYPES(
       query.scalar_type(), "attention_backward_kernel", [&] {

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -1052,7 +1052,7 @@ __global__ void attention_backward_kernel2(
   scalar_t tmp_sum[BLOCK];
 
   constexpr int KS1 = 32;
-  constexpr int KS2 = 16;
+  constexpr int KS2 = 32;
 
   //__shared__ vec_t query_cache[KS1][BUFFER_SIZE+1];
   //__shared__ vec_t key_cache[KS2][BUFFER_SIZE+1];
@@ -1251,8 +1251,8 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
   //dim3 grid2(ceil_div(M, int64_t(TILE_SIZE2Q)), ceil_div(N, int64_t(TILE_SIZE2K)), B);
   //dim3 block2(TILE_SIZE2Q / kBlockSizeQ2, TILE_SIZE2K / kBlockSizeK2);
 
-  dim3 grid2(ceil_div(M, int64_t(32)), ceil_div(N, int64_t(16)), B);
-  dim3 block2(8, 4);
+  dim3 grid2(ceil_div(M, int64_t(32)), ceil_div(N, int64_t(32)), B);
+  dim3 block2(8, 8);
   // TODO: try adding a blockDim.x to iterate over k
 
   attention_backward_kernel2<

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -1054,21 +1054,14 @@ __global__ void attention_backward_kernel2(
   constexpr int KS1 = 16;
   constexpr int KS2 = 16;
 
-  __shared__ vec_t query_cache[KS1][BUFFER_SIZE];
-  __shared__ vec_t key_cache[KS2][BUFFER_SIZE];
-  //__shared__ vec_t value_cache[KS2][BUFFER_SIZE];
-  //__shared__ vec_t grad_out_cache[KS1][BUFFER_SIZE];
-  __shared__ scalar_t fact[KS1][KS2];
+  __shared__ vec_t query_cache[KS1][BUFFER_SIZE+1];
+  __shared__ vec_t key_cache[KS2][BUFFER_SIZE+1];
+  __shared__ scalar_t fact[KS1][KS2+1];
 
   auto qb = reinterpret_cast<vec_t*>(query[batch_idx][query_idx].data());
   auto kb = reinterpret_cast<vec_t*>(key[batch_idx][l].data());
   auto vb = reinterpret_cast<vec_t*>(value[batch_idx][l].data());
   auto gb = reinterpret_cast<vec_t*>(grad_out[batch_idx][query_idx].data());
-
-  //__shared__ vec_t tmp_grad1[KS1][BUFFER_SIZE];
-  //__shared__ vec_t tmp_grad2[KS2][BUFFER_SIZE];
-  //vec_t query_cache[KS1][BUFFER_SIZE];
-  //vec_t key_cache[KS2][BUFFER_SIZE];
 
   vec_t zero = {0};
   for (int64_t k = 0; k < K / kVecSize; k++) {
@@ -1076,8 +1069,6 @@ __global__ void attention_backward_kernel2(
       query_cache[BLOCK * threadIdx.x + i][k] = qb[k + K / kVecSize * i];
     for (int i = 0; i < BLOCK; i++)
       key_cache[BLOCK2 * threadIdx.y + i][k] = kb[k + K / kVecSize * i];
-    //value_cache[threadIdx.y][k] = vb[k];
-    //grad_out_cache[threadIdx.x][k] = gb[k];
   }
   //__syncwarp();
   __syncthreads();

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -622,6 +622,7 @@ __global__ void attention_backward_kernel(
     at::PackedTensorAccessor<scalar_t, 3> query,
     at::PackedTensorAccessor<scalar_t, 3> key,
     at::PackedTensorAccessor<scalar_t, 3> value,
+    at::PackedTensorAccessor<scalar_t, 2> tmp_sum_i,
     at::PackedTensorAccessor<scalar_t, 2> logsumexp_normalizer) {
   int64_t K = query.size(2);
   int64_t B = query.size(0);
@@ -637,12 +638,12 @@ __global__ void attention_backward_kernel(
   if (query_idx >= M)
     return;
 
-  vec_t temp_buffer[kBlockSizeQ][BUFFER_SIZE] = {0};
-  vec_t temp_grad_q[kBlockSizeQ][BUFFER_SIZE] = {0};
+  //vec_t temp_buffer[kBlockSizeQ][BUFFER_SIZE] = {0};
+  //vec_t temp_grad_q[kBlockSizeQ][BUFFER_SIZE] = {0};
 
   vec_t* query_block[kBlockSizeQ];
   vec_t* grad_out_block[kBlockSizeQ];
-  vec_t* grad_q_block[kBlockSizeQ];
+  //vec_t* grad_q_block[kBlockSizeQ];
   scalar_t normalizer[kBlockSizeQ];
 
   //__shared__ vec_t query_cache[kBlockSizeQ][BUFFER_SIZE];
@@ -654,8 +655,8 @@ __global__ void attention_backward_kernel(
         reinterpret_cast<vec_t*>(query[batch_idx][index].data());
     grad_out_block[q_item_idx] =
         reinterpret_cast<vec_t*>(grad_out[batch_idx][index].data());
-    grad_q_block[q_item_idx] =
-        reinterpret_cast<vec_t*>(grad_q[batch_idx][index].data());
+    //grad_q_block[q_item_idx] =
+    //    reinterpret_cast<vec_t*>(grad_q[batch_idx][index].data());
     normalizer[q_item_idx] = logsumexp_normalizer[batch_idx][index];
     //for (int64_t k = threadIdx.x; k < K / kVecSize; k += blockDim.x) {
     //  query_cache[q_item_idx][k] = query_block[q_item_idx][k];
@@ -721,7 +722,7 @@ __global__ void attention_backward_kernel(
         tmp_sum[q_item_idx] += tmp[q_item_idx][k_item_idx];
       }
     }
-
+/*
     // grad_q is easy
     for (int64_t k = 0; k < K / kVecSize; k++) {
 #pragma unroll
@@ -735,7 +736,7 @@ __global__ void attention_backward_kernel(
         }
       }
     }
-
+*/
     //  but grad_k is a bit trickier
 
     for (int64_t k = 0; k < K / kVecSize; k++) {
@@ -756,6 +757,7 @@ __global__ void attention_backward_kernel(
 #pragma unroll
   for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
     tmp_sum[q_item_idx] = warpSum<scalar_t, 32>(tmp_sum[q_item_idx]);
+    tmp_sum_i[batch_idx][query_idx + q_item_idx] = tmp_sum[q_item_idx];
   }
 
   for (int64_t l = threadIdx.x * kBlockSizeK; l < N;
@@ -789,6 +791,7 @@ __global__ void attention_backward_kernel(
       }
     }
   }
+  /*
   for (int64_t k = 0; k < K / kVecSize; k++) {
 #pragma unroll
     for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
@@ -812,8 +815,122 @@ __global__ void attention_backward_kernel(
         grad_q_block[q_item_idx][k].w = temp_grad_q[q_item_idx][k].w -
             temp_buffer[q_item_idx][k].w * tmp_sum[q_item_idx];
       }
-    }
+    }*/
 }
+
+
+template <
+    typename scalar_t,
+    typename vec_t,
+    int kBlockSizeQ,
+    int kBlockSizeK,
+    int BUFFER_SIZE>
+__global__ void attention_backward_kernel2(
+    at::PackedTensorAccessor<scalar_t, 3> grad_q,
+    at::PackedTensorAccessor<scalar_t, 3> grad_k,
+    at::PackedTensorAccessor<scalar_t, 3> grad_v,
+    at::PackedTensorAccessor<scalar_t, 3> grad_out,
+    at::PackedTensorAccessor<scalar_t, 3> query,
+    at::PackedTensorAccessor<scalar_t, 3> key,
+    at::PackedTensorAccessor<scalar_t, 3> value,
+    at::PackedTensorAccessor<scalar_t, 2> tmp_sum_i,
+    at::PackedTensorAccessor<scalar_t, 2> logsumexp_normalizer) {
+  int64_t K = query.size(2);
+  int64_t B = query.size(0);
+  int64_t M = query.size(1);
+  int64_t N = key.size(1);
+
+  constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
+
+  int64_t batch_idx = blockIdx.y;
+  int64_t query_idx =
+      blockIdx.x * blockDim.y * kBlockSizeQ + threadIdx.y * kBlockSizeQ;
+
+  if (query_idx >= M)
+    return;
+
+  vec_t* query_block[kBlockSizeQ];
+  vec_t* grad_out_block[kBlockSizeQ];
+  scalar_t normalizer[kBlockSizeQ];
+  scalar_t tmp_sum[kBlockSizeQ];
+
+  //__shared__ vec_t query_cache[kBlockSizeQ][BUFFER_SIZE];
+
+  for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+    int64_t index = query_idx + q_item_idx;
+    index = index >= M ? M - 1 : index;
+    query_block[q_item_idx] =
+        reinterpret_cast<vec_t*>(query[batch_idx][index].data());
+    grad_out_block[q_item_idx] =
+        reinterpret_cast<vec_t*>(grad_out[batch_idx][index].data());
+    normalizer[q_item_idx] = logsumexp_normalizer[batch_idx][index];
+    tmp_sum[q_item_idx] = tmp_sum_i[batch_idx][index];
+    //for (int64_t k = threadIdx.x; k < K / kVecSize; k += blockDim.x) {
+    //  query_cache[q_item_idx][k] = query_block[q_item_idx][k];
+   // }
+  }
+  //__syncthreads();
+
+  //scalar_t tmp_sum[kBlockSizeQ] = {0};
+
+  for (int64_t l = threadIdx.x * kBlockSizeK; l < N;
+       l += blockDim.x * kBlockSizeK) {
+    auto key_j = reinterpret_cast<vec_t*>(key[batch_idx][l].data());
+    scalar_t attn_v[kBlockSizeQ][kBlockSizeK] = {0};
+    compute_dot<scalar_t, vec_t, kBlockSizeK, kBlockSizeQ>(
+        query_block, key_j, attn_v, K);
+
+#pragma unroll
+    for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+#pragma unroll
+      for (int64_t k_item_idx = 0; k_item_idx < kBlockSizeK; k_item_idx++) {
+        attn_v[q_item_idx][k_item_idx] =
+            std::exp(attn_v[q_item_idx][k_item_idx] - normalizer[q_item_idx]);
+      }
+    }
+
+    scalar_t grad_attn_v[kBlockSizeQ][kBlockSizeK] = {0};
+    auto value_j = reinterpret_cast<vec_t*>(value[batch_idx][l].data());
+
+    for (int64_t k = 0; k < K / kVecSize; k++) {
+      vec_t temp_i[kBlockSizeQ];
+#pragma unroll
+      for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+        temp_i[q_item_idx] = __ldg(grad_out_block[q_item_idx] + k);
+      }
+
+#pragma unroll
+      for (int64_t k_item_idx = 0; k_item_idx < kBlockSizeK; k_item_idx++) {
+        vec_t v = value_j[k + K / kVecSize * k_item_idx];
+#pragma unroll
+        for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+          sputnik::VectorCompute<vec_t>::Dot(
+              temp_i[q_item_idx], v, &grad_attn_v[q_item_idx][k_item_idx]);
+        }
+      }
+    }
+
+    for (int64_t k = 0; k < K / kVecSize; k++) {
+        vec_t res[kBlockSizeQ] = {0};
+#pragma unroll
+      for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+#pragma unroll
+        for (int64_t k_item_idx = 0; k_item_idx < kBlockSizeK; k_item_idx++) {
+          vec_t ttt = key_j[k + K / kVecSize * k_item_idx];
+          scalar_t ttmp = attn_v[q_item_idx][k_item_idx] * grad_attn_v[q_item_idx][k_item_idx] - attn_v[q_item_idx][k_item_idx] * tmp_sum[q_item_idx];
+          sputnik::VectorCompute<vec_t>::FMA(ttmp, ttt, &res[q_item_idx]);
+        }
+      }
+#pragma unroll
+      for (int64_t q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
+        myGpuAtomicAdd(&grad_q[batch_idx][query_idx + q_item_idx][k * kVecSize], res[q_item_idx]);
+
+      }
+    }
+
+  }
+}
+
 
 std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
     const at::Tensor& grad_out,
@@ -859,10 +976,12 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
   int64_t N = key.size(1);
   int64_t K = query.size(2);
 
-  at::Tensor res = at::empty({B, M, K}, query.options());
+  //at::Tensor res = at::empty({B, M, K}, query.options());
   at::Tensor grad_q = at::zeros_like(query);
   at::Tensor grad_k = at::zeros_like(key);
   at::Tensor grad_v = at::zeros_like(value);
+
+  at::Tensor tmp_sum_i = at::empty({B, M}, query.options());
 
   using scalar_t = float;
   using vec_t = float4;
@@ -895,8 +1014,36 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
       query.packed_accessor<scalar_t, 3>(),
       key.packed_accessor<scalar_t, 3>(),
       value.packed_accessor<scalar_t, 3>(),
+      tmp_sum_i.packed_accessor<scalar_t, 2>(),
       logsumexp.packed_accessor<scalar_t, 2>());
   //   });
+
+
+  constexpr int TILE_SIZE2 = 32;
+
+  constexpr int64_t kBlockSizeQ2 = 2;
+  constexpr int64_t kBlockSizeK2 = 32;
+
+  dim3 grid2(ceil_div(M, int64_t(TILE_SIZE2)), B);
+  dim3 block2(4, TILE_SIZE2 / kBlockSizeQ2);
+
+  attention_backward_kernel2<
+      scalar_t,
+      vec_t,
+      kBlockSizeQ2,
+      kBlockSizeK2,
+      BUFFER_SIZE><<<grid2, block2, 0, stream>>>(
+      grad_q.packed_accessor<scalar_t, 3>(),
+      grad_k.packed_accessor<scalar_t, 3>(),
+      grad_v.packed_accessor<scalar_t, 3>(),
+      grad_out.packed_accessor<scalar_t, 3>(),
+      query.packed_accessor<scalar_t, 3>(),
+      key.packed_accessor<scalar_t, 3>(),
+      value.packed_accessor<scalar_t, 3>(),
+      tmp_sum_i.packed_accessor<scalar_t, 2>(),
+      logsumexp.packed_accessor<scalar_t, 2>());
+  //   });
+
 
   AT_CUDA_CHECK(cudaGetLastError());
 

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -887,12 +887,12 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
   using vec_t = float4;
   // using vec_t = float;
 
-  constexpr int TILE_SIZE = 16 * 2;
+  constexpr int TILE_SIZE = 16 * 4;
   constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
 
   constexpr int64_t BUFFER_SIZE = 32 / kVecSize;
-  constexpr int64_t kBlockSizeQ = 8;
-  constexpr int64_t kBlockSizeK = 8;
+  constexpr int64_t kBlockSizeQ = 16;
+  constexpr int64_t kBlockSizeK = 4;
 
   dim3 grid(ceil_div(M, int64_t(TILE_SIZE)), B);
   dim3 block(32, TILE_SIZE / kBlockSizeQ);

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -933,7 +933,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
   at::Tensor grad_k = at::zeros_like(key);
   at::Tensor grad_v = at::zeros_like(value);
 
-  at::Tensor tmp_sum_i = at::empty({B, M}, query.options());
+  at::Tensor tmp_sum_i = at::zeros({B, M}, query.options());
 
   using scalar_t = float;
   using vec_t = float4;

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -887,7 +887,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
   using vec_t = float4;
   // using vec_t = float;
 
-  constexpr int TILE_SIZE = 16 * 4;
+  constexpr int TILE_SIZE = 16 * 8;
   constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
 
   constexpr int64_t BUFFER_SIZE = 32 / kVecSize;

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -1032,7 +1032,7 @@ __global__ void attention_backward_kernel2(
   int64_t N = key.size(1);
 
   constexpr int kVecSize = sizeof(vec_t) / sizeof(scalar_t);
-  constexpr int BLOCK = 8; // KS1 / blockDim.x
+  constexpr int BLOCK = 4; // KS1 / blockDim.x
   constexpr int BLOCK2 = 4;
 
   int64_t batch_idx = blockIdx.z;
@@ -1252,7 +1252,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> attention_backward(
   //dim3 block2(TILE_SIZE2Q / kBlockSizeQ2, TILE_SIZE2K / kBlockSizeK2);
 
   dim3 grid2(ceil_div(M, int64_t(32)), ceil_div(N, int64_t(16)), B);
-  dim3 block2(4, 4);
+  dim3 block2(8, 4);
   // TODO: try adding a blockDim.x to iterate over k
 
   attention_backward_kernel2<

--- a/xformers/components/attention/csrc/cuda/attention.cu
+++ b/xformers/components/attention/csrc/cuda/attention.cu
@@ -926,9 +926,8 @@ __global__ void attention_backward_grad_qk_kernel(
     for (int q_item_idx = 0; q_item_idx < kBlockSizeQ; q_item_idx++) {
       fact[kBlockSizeQ * threadIdx.x + q_item_idx]
           [kBlockSizeK * threadIdx.y + k_item_idx] =
-              attn_v[q_item_idx][k_item_idx] * scale * (
-              grad_attn_v[q_item_idx][k_item_idx] -
-              tmp_sum[q_item_idx]);
+              attn_v[q_item_idx][k_item_idx] * scale *
+          (grad_attn_v[q_item_idx][k_item_idx] - tmp_sum[q_item_idx]);
     }
   }
   __syncthreads();

--- a/xformers/ops.py
+++ b/xformers/ops.py
@@ -53,6 +53,7 @@ def memory_efficient_attention(
     `"Self-Attention Does Not Need O(n^2) Memory" <http://arxiv.org/abs/2112.05682>`_.
 
     """
+    # fast-path that doesn't require computing the logsumexp for backward computation
     if all(x.requires_grad is False for x in [query, key, value]):
         return torch.ops.xformers.efficient_attention(query, key, value, False)[0]
     return _MemoryEfficientAttentionOp.apply(query, key, value)

--- a/xformers/ops.py
+++ b/xformers/ops.py
@@ -39,7 +39,7 @@ class _MemoryEfficientAttentionOp(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad):
         query, key, value, lse = ctx.saved_tensors
-        grad_q, grad_k, grad_v = torch.ops.xformers.efficient_attention(
+        grad_q, grad_k, grad_v = torch.ops.xformers.efficient_attention_backward(
             grad, query, key, value, lse
         )
         return grad_q, grad_k, grad_v


### PR DESCRIPTION
## What does this PR do?

This PR implements the memory-efficient attention mechanism from https://arxiv.org/pdf/2112.05682v2.pdf, with both CPU and CUDA kernels, targetting the backward implementation. For now, only fp32 is supported.

The CPU implementation is naive and not meant to be fast, and is there only as a reference.

The CUDA implementation has competitive runtimes compared to a vanilla PyTorch implementation, while using 10x+ less memory. 

Contrary to the forward implementation, the backwards supports inputs of arbitrary number of embedding sizes. I'll probably update the forward implementation to use a similar approach in the future.

In order to keep the backwards somewhat efficient, we need to return the `logsumexp` during forward as well. For some reason, I needed to template it in CUDA otherwise I would face performance slowdowns.

In the same vein, in order to support arbitrary sequence lengths, I use a masking approach. But the masking (and in particular the `min(index, M)` operations) are very slow, so I templated this as well so that we don't need to run this if the sequence length is a multiple of 32.

<details>

<summary>
Full details for the benchmark I run can be found in here
</summary>

```
Backward
===== (1, 127, 16) =====
Optimized Memory used: 0.07861328125 MB
Vanilla Memory used: 0.310546875 MB
===== (1, 127, 32) =====
Optimized Memory used: 0.15673828125 MB
Vanilla Memory used: 0.373046875 MB
===== (1, 128, 16) =====
Optimized Memory used: 0.07861328125 MB
Vanilla Memory used: 0.3125 MB
===== (1, 128, 32) =====
Optimized Memory used: 0.15673828125 MB
Vanilla Memory used: 0.375 MB
===== (1, 512, 16) =====
Optimized Memory used: 0.314453125 MB
Vanilla Memory used: 4.25 MB
===== (1, 512, 32) =====
Optimized Memory used: 0.626953125 MB
Vanilla Memory used: 4.5 MB
===== (1, 513, 16) =====
Optimized Memory used: 0.31982421875 MB
Vanilla Memory used: 4.271484375 MB
===== (1, 513, 32) =====
Optimized Memory used: 0.63232421875 MB
Vanilla Memory used: 4.521484375 MB
===== (1, 1023, 16) =====
Optimized Memory used: 0.62890625 MB
Vanilla Memory used: 16.470703125 MB
===== (1, 1023, 32) =====
Optimized Memory used: 1.25390625 MB
Vanilla Memory used: 16.970703125 MB
===== (1, 1024, 16) =====
Optimized Memory used: 0.62890625 MB
Vanilla Memory used: 16.5 MB
===== (1, 1024, 32) =====
Optimized Memory used: 1.25390625 MB
Vanilla Memory used: 17.0 MB
===== (8, 127, 16) =====
Optimized Memory used: 0.6240234375 MB
Vanilla Memory used: 2.466796875 MB
===== (8, 127, 32) =====
Optimized Memory used: 1.244140625 MB
Vanilla Memory used: 2.962890625 MB
===== (8, 128, 16) =====
Optimized Memory used: 0.62890625 MB
Vanilla Memory used: 2.5 MB
===== (8, 128, 32) =====
Optimized Memory used: 1.25390625 MB
Vanilla Memory used: 3.0 MB
===== (8, 512, 16) =====
Optimized Memory used: 2.515625 MB
Vanilla Memory used: 34.0 MB
===== (8, 512, 32) =====
Optimized Memory used: 5.015625 MB
Vanilla Memory used: 36.0 MB
===== (8, 513, 16) =====
Optimized Memory used: 2.52099609375 MB
Vanilla Memory used: 34.130859375 MB
===== (8, 513, 32) =====
Optimized Memory used: 5.02587890625 MB
Vanilla Memory used: 36.134765625 MB
===== (8, 1023, 16) =====
Optimized Memory used: 5.0263671875 MB
Vanilla Memory used: 131.99609375 MB
===== (8, 1023, 32) =====
Optimized Memory used: 10.021484375 MB
Vanilla Memory used: 135.9921875 MB
===== (8, 1024, 16) =====
Optimized Memory used: 5.03125 MB
Vanilla Memory used: 132.0 MB
===== (8, 1024, 32) =====
Optimized Memory used: 10.03125 MB
Vanilla Memory used: 136.0 MB
===== (32, 127, 16) =====
Optimized Memory used: 2.49609375 MB
Vanilla Memory used: 9.861328125 MB
===== (32, 127, 32) =====
Optimized Memory used: 4.9765625 MB
Vanilla Memory used: 11.845703125 MB
===== (32, 128, 16) =====
Optimized Memory used: 2.515625 MB
Vanilla Memory used: 10.0 MB
===== (32, 128, 32) =====
Optimized Memory used: 5.015625 MB
Vanilla Memory used: 12.0 MB
===== (32, 512, 16) =====
Optimized Memory used: 10.0625 MB
Vanilla Memory used: 136.0 MB
===== (32, 512, 32) =====
Optimized Memory used: 20.0625 MB
Vanilla Memory used: 144.0 MB
===== (32, 513, 16) =====
Optimized Memory used: 13.9453125 MB
Vanilla Memory used: 140.2548828125 MB
===== (32, 513, 32) =====
Optimized Memory used: 23.08056640625 MB
Vanilla Memory used: 147.51171875 MB
===== (32, 1023, 16) =====
Optimized Memory used: 21.130859375 MB
Vanilla Memory used: 529.001953125 MB
===== (32, 1023, 32) =====
Optimized Memory used: 40.11328125 MB
Vanilla Memory used: 543.9765625 MB
===== (32, 1024, 16) =====
Optimized Memory used: 21.138671875 MB
Vanilla Memory used: 529.013671875 MB
===== (32, 1024, 32) =====
Optimized Memory used: 40.125 MB
Vanilla Memory used: 544.0 MB
===== (256, 127, 16) =====
Optimized Memory used: 20.0615234375 MB
Vanilla Memory used: 79.470703125 MB
===== (256, 127, 32) =====
Optimized Memory used: 40.216796875 MB
Vanilla Memory used: 95.6572265625 MB
===== (256, 128, 16) =====
Optimized Memory used: 20.234375 MB
Vanilla Memory used: 80.109375 MB
===== (256, 128, 32) =====
Optimized Memory used: 40.125 MB
Vanilla Memory used: 96.0 MB
===== (256, 512, 16) =====
Optimized Memory used: 80.5 MB
Vanilla Memory used: 1088.0 MB
===== (256, 512, 32) =====
Optimized Memory used: 160.5 MB
Vanilla Memory used: 1152.0 MB
===== (256, 513, 16) =====
Optimized Memory used: 80.6572265625 MB
Vanilla Memory used: 1096.125 MB
===== (256, 513, 32) =====
Optimized Memory used: 160.8134765625 MB
Vanilla Memory used: 1160.25 MB
===== (256, 1023, 16) =====
Optimized Memory used: 160.9990234375 MB
Vanilla Memory used: 4216.03515625 MB
===== (256, 1023, 32) =====
Optimized Memory used: 320.8427734375 MB
Vanilla Memory used: 4343.91015625 MB
===== (256, 1024, 16) =====
Optimized Memory used: 161.0 MB
Vanilla Memory used: 4224.0 MB
===== (256, 1024, 32) =====
Optimized Memory used: 321.0 MB
Vanilla Memory used: 4352.0 MB

[------------------- attention -------------------]
                           |  optimized  |  vanilla
1 threads: ----------------------------------------
      B=1, M=127, K=16     |     183.7   |    237.8
      B=1, M=127, K=32     |     183.9   |    239.5
      B=1, M=128, K=16     |     146.0   |    168.1
      B=1, M=128, K=32     |     144.5   |    167.1
      B=1, M=512, K=16     |     142.1   |    165.5
      B=1, M=512, K=32     |     142.1   |    165.0
      B=1, M=513, K=16     |     146.7   |    171.5
      B=1, M=513, K=32     |     146.8   |    171.6
      B=1, M=1023, K=16    |     156.5   |    186.3
      B=1, M=1023, K=32    |     229.5   |    211.8
      B=1, M=1024, K=16    |     166.0   |    195.8
      B=1, M=1024, K=32    |     208.0   |    184.9
      B=8, M=127, K=16     |     143.0   |    165.8
      B=8, M=127, K=32     |     141.2   |    165.9
      B=8, M=128, K=16     |     141.2   |    174.7
      B=8, M=128, K=32     |     149.3   |    206.2
      B=8, M=512, K=16     |     223.7   |    399.3
      B=8, M=512, K=32     |     380.1   |    408.9
      B=8, M=513, K=16     |     331.0   |    419.5
      B=8, M=513, K=32     |     527.2   |    432.3
      B=8, M=1023, K=16    |    1018.1   |   1220.1
      B=8, M=1023, K=32    |    1552.4   |   1243.4
      B=8, M=1024, K=16    |     752.7   |   1206.7
      B=8, M=1024, K=32    |    1324.3   |   1234.4
      B=32, M=127, K=16    |     142.0   |    167.4
      B=32, M=127, K=32    |     141.5   |    169.9
      B=32, M=128, K=16    |     146.4   |    168.7
      B=32, M=128, K=32    |     141.8   |    165.5
      B=32, M=512, K=16    |     766.8   |   1180.1
      B=32, M=512, K=32    |    1362.6   |   1227.0
      B=32, M=513, K=16    |    1201.3   |   1288.6
      B=32, M=513, K=32    |    1950.0   |   1359.9
      B=32, M=1023, K=16   |    3996.6   |   4392.1
      B=32, M=1023, K=32   |    5977.2   |   4546.1
      B=32, M=1024, K=16   |    2939.9   |   4347.4
      B=32, M=1024, K=32   |    5110.6   |   4508.7
      B=256, M=127, K=16   |     581.3   |    629.5
      B=256, M=127, K=32   |     946.7   |    706.3
      B=256, M=128, K=16   |     446.4   |    622.7
      B=256, M=128, K=32   |     828.6   |    695.7
      B=256, M=512, K=16   |    6017.2   |   8183.5
      B=256, M=512, K=32   |   10432.4   |   8744.9
      B=256, M=513, K=16   |    9561.7   |   9208.7
      B=256, M=513, K=32   |   15071.8   |   9893.5
      B=256, M=1023, K=16  |   31757.3   |  32366.8
      B=256, M=1023, K=32  |   47725.4   |  33994.0
      B=256, M=1024, K=16  |   23353.4   |  32033.4
      B=256, M=1024, K=32  |   40533.0   |  33811.4

Times are in microseconds (us).
```

</details>

Fixes https://github.com/facebookresearch/xformers/issues/161.