### PR TITLE
[fix] Deepnorm self-attention value proj init scaling missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix FourierMix being compatible with AMP [#258]
 - Better asserts on QKV dimensions [#264]
 - Better perfs for FusedMLP and FusedLinearLayer [#283]
+- Deepnorm init missing self-attention [#284]
 
 ### Added
 - Simplicial Embeddings [#259]

--- a/examples/microViT.py
+++ b/examples/microViT.py
@@ -258,11 +258,13 @@ if __name__ == "__main__":
         num_classes=num_classes,
         attention="scaled_dot_product",
         classifier=Classifier.TOKEN,
+        layer_norm_style="deepnorm",
+        use_rotary_embeddings=False,
     )
     trainer = pl.Trainer(
         gpus=GPUS,
         max_epochs=MAX_EPOCHS,
-        detect_anomaly=True,
+        detect_anomaly=False,
         precision=16,
         accumulate_grad_batches=REF_BATCH // BATCH,
     )

--- a/xformers/components/residual.py
+++ b/xformers/components/residual.py
@@ -133,7 +133,7 @@ def get_deepnorm_coefficients(
     See DeepNet_.
 
     Returns alpha and beta depending on the number of encoder and decoder layers,
-    first tuple is for the  for the encoder and second for the decoder
+    first tuple is for the encoder and second for the decoder
 
     .. _DeepNet: https://arxiv.org/pdf/2203.00555v1.pdf
     """

--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -233,11 +233,13 @@ class xFormer(torch.nn.Module):
             elif is_self_attn_proj_weight(n):
                 # The input projection is packed in a single weight matrix
                 # Init normally, then scale the slice which corresponds to the value projection
-                torch.nn.init.xavier_normal_(p, gain=1)
                 # The Value projection is the last chunk, the projection matrix is
-                # 3N x N
-                _, N = p.shape
-                torch.nn.init.xavier_normal_(p[-N:, :], gain=encoder_gain)
+                # 3K x N
+                M, _ = p.shape
+                K = M // 3
+                torch.nn.init.xavier_normal_(p[:K, :], gain=1)
+                torch.nn.init.xavier_normal_(p[K:-K, :], gain=1)
+                torch.nn.init.xavier_normal_(p[-K:, :], gain=encoder_gain)
             elif "weight" in n and p.ndim > 1:
                 torch.nn.init.xavier_normal_(p, gain=1)
 
@@ -248,11 +250,13 @@ class xFormer(torch.nn.Module):
             elif is_self_attn_proj_weight(n):
                 # The input projection is packed in a single weight matrix
                 # Init normally, then scale the slice which corresponds to the value projection
-                torch.nn.init.xavier_normal_(p, gain=1)
                 # The Value projection is the last chunk, the projection matrix is
-                # 3N x N
-                _, N = p.shape
-                torch.nn.init.xavier_normal_(p[-N:, :], gain=decoder_gain)
+                # 3K x N
+                M, _ = p.shape
+                K = M // 3
+                torch.nn.init.xavier_normal_(p[:K, :], gain=1)
+                torch.nn.init.xavier_normal_(p[K:-K, :], gain=1)
+                torch.nn.init.xavier_normal_(p[-K:, :], gain=decoder_gain)
             elif "weight" in n and p.ndim > 1:
                 torch.nn.init.xavier_normal_(p, gain=1)
 


### PR DESCRIPTION
## What does this PR do?
Hotfix an init of the projection matrix for the value being skipped when using deepnorm and self attention. See bottom of #219 for context.

TODO:
- [x] Init seperately Q, K, V weights when using a common buffer
- [x] Add a unit test to catch faulty weight inits with deepnorm

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
