### PR TITLE
[feat] Natively support PatchEmbedding layers

### DIFF
--- a/xformers/components/__init__.py
+++ b/xformers/components/__init__.py
@@ -15,6 +15,8 @@ from .attention import Attention, build_attention  # noqa
 from .in_proj_container import InProjContainer, InProjParams  # noqa
 from .multi_head_dispatch import MultiHeadDispatch  # noqa
 from .multi_head_dispatch import MultiHeadDispatchConfig
+from .patch_embedding import PatchEmbeddingConfig  # noqa
+from .patch_embedding import build_patch_embedding  # noqa
 from .residual import LayerNormStyle  # noqa; noqa
 from .residual import PostNorm  # noqa
 from .residual import PreNorm  # noqa

--- a/xformers/components/patch_embedding.py
+++ b/xformers/components/patch_embedding.py
@@ -1,0 +1,79 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+
+import torch
+
+
+class PoolType(str, Enum):
+    Conv2D = "CONV_2D"
+    # ...
+    # TODO: Support more cases ?
+
+
+@dataclass
+class PatchEmbeddingConfig:
+    """
+    The configuration for the patch embedding layer, which takes the raw token passed in
+    and returns a pooled representation along a given embedding dimension.
+
+    This typically trades the spatial (context length) representation with the embedding size
+
+    This is canonicaly used by ViT, but other papers (like MetaFormer or other hierarchical transformers)
+    propose a more general use case for this
+    """
+
+    in_channels: int
+    out_channels: int
+    kernel_size: int
+    stride: int
+    padding: int = 0
+    pool_type: PoolType = PoolType.Conv2D
+
+
+class ConditionalReshape(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, x):
+        if x.ndim == 3:
+            B, HW, C = x.shape
+            # NOTE: We're assuming a square sample here
+            H = int(math.sqrt(HW))
+            assert H * H == HW, f"{H, HW}"
+            x = x.transpose(1, 2).reshape(B, C, H, H)
+
+        return x
+
+
+class PatchToSequence(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def forward(self, x):
+        return x.flatten(2, 3).transpose(1, 2).contiguous()  # B HW C
+
+
+def build_patch_embedding(config: PatchEmbeddingConfig):
+    if not isinstance(config, PatchEmbeddingConfig):
+        config = PatchEmbeddingConfig(**config)
+
+    if config.pool_type == PoolType.Conv2D:
+        pool = torch.nn.Conv2d(
+            config.in_channels,
+            config.out_channels,
+            kernel_size=config.kernel_size,
+            stride=config.stride,
+            padding=config.padding,
+        )
+    else:
+        raise NotImplementedError
+
+    # The patch embedding supposes that the input really is 2D in essence
+    # If this block is in the middle of a stack, we need to reshape
+    return torch.nn.Sequential(ConditionalReshape(), pool, PatchToSequence())

--- a/xformers/components/positional_embedding/param.py
+++ b/xformers/components/positional_embedding/param.py
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from dataclasses import dataclass
+
+import torch
+
+from xformers.components.positional_embedding import (
+    PositionEmbedding,
+    PositionEmbeddingConfig,
+    register_positional_embedding,
+)
+
+
+@dataclass
+class LearnablePositionalEmbeddingConfig(PositionEmbeddingConfig):
+    name: str
+    seq_len: int
+    dim_model: int
+    add_class_token: bool
+
+
+@register_positional_embedding("learnable", LearnablePositionalEmbeddingConfig)
+class LearnablePositionalEmbedding(PositionEmbedding):
+    def __init__(
+        self, seq_len: int, dim_model: int, add_class_token: bool = False, *_, **__
+    ):
+        super().__init__()
+
+        # 0.02 is BERT initialization
+        self.pos_emb = torch.nn.Parameter(
+            torch.randn(1, seq_len + int(add_class_token), dim_model) * 0.02
+        )
+
+        self.class_token = (
+            torch.nn.Parameter(torch.zeros(dim_model)) if add_class_token else None
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.class_token is not None:
+            # Prepend class token
+            clf_token = (
+                torch.ones(x.shape[0], 1, self.pos_emb.shape[-1], device=x.device)
+                * self.class_token
+            )
+            x = torch.cat([clf_token, x], dim=1)
+
+        if x.ndim == 2:
+            x = x.unsqueeze(-1)
+
+        return x + self.pos_emb

--- a/xformers/factory/block_configs.py
+++ b/xformers/factory/block_configs.py
@@ -1,0 +1,224 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from xformers.components import LayerNormStyle
+from xformers.components.feedforward import FEEDFORWARD_REGISTRY, FeedforwardConfig
+from xformers.components.positional_embedding import (
+    POSITION_EMBEDDING_REGISTRY,
+    PositionEmbeddingConfig,
+)
+from xformers.utils import generate_matching_config
+
+
+class LayerPositionBitmask(int, Enum):
+    First = 0b01
+    Last = 0b10
+    Default = 0b11
+
+
+class LayerPosition:
+    """Bitmask to mark this layer as first, last, nothing or both"""
+
+    def __init__(self):
+        self.bitmask = LayerPositionBitmask.Default
+
+    def is_first(self):
+        return bool(self.bitmask & LayerPositionBitmask.First)
+
+    def is_last(self):
+        return bool(self.bitmask & LayerPositionBitmask.Last)
+
+    def mark_not_first(self):
+        self.bitmask &= ~LayerPositionBitmask.First
+
+    def mark_not_last(self):
+        self.bitmask &= ~LayerPositionBitmask.Last
+
+
+class BlockType(str, Enum):
+    Encoder = "encoder"
+    Decoder = "decoder"
+
+
+@dataclass(init=False)  # handle constructors explicitly to force type changes
+class xFormerBlockConfig:
+    """
+    The configuration structure to define a Transformer block.
+    This base class is applicable to both encoder and decoder definitions.
+
+    This completely defines each of the blocks, for instance in terms of dimensions,
+    position encoding, pre or post layer norms or reversibility.
+    """
+
+    dim_model: int
+    feedforward_config: FeedforwardConfig
+    position_encoding_config: Optional[PositionEmbeddingConfig]
+    block_type: BlockType
+    layer_norm_style: LayerNormStyle
+    layer_position: LayerPosition
+    use_triton: bool
+    reversible: bool
+    num_layers: int
+
+    def __init__(
+        self,
+        dim_model: int,
+        feedforward_config: Dict[str, Any],
+        position_encoding_config: Optional[Dict[str, Any]],
+        block_type: BlockType,
+        layer_norm_style: LayerNormStyle = LayerNormStyle("post"),
+        reversible: bool = False,
+        num_layers: int = 1,
+        layer_position: Optional[LayerPosition] = None,
+    ):
+
+        self.dim_model = dim_model
+        self.block_type = block_type
+        self.layer_norm_style = layer_norm_style
+        self.reversible = reversible
+        self.num_layers = num_layers
+
+        # Fill in possible gaps in the config for subparts of the block
+        self.feedforward_config = generate_matching_config(
+            feedforward_config,
+            FEEDFORWARD_REGISTRY[feedforward_config["name"]].config,
+        )
+
+        self.position_encoding_config = (
+            generate_matching_config(
+                position_encoding_config,
+                POSITION_EMBEDDING_REGISTRY[position_encoding_config["name"]].config,
+            )
+            if position_encoding_config is not None
+            else None
+        )
+
+        # Default is that this layer is the only one, so both first and last
+        if layer_position:
+            self.layer_position = layer_position
+        else:
+            self.layer_position = LayerPosition()
+
+
+@dataclass(init=False)
+class xFormerEncoderConfig(xFormerBlockConfig):
+    """
+    The configuration structure for an encoder block
+    """
+
+    multi_head_config: Dict[str, Any]
+    use_triton: bool
+    simplicial_embeddings: Optional[Dict[str, Any]]
+    patch_embedding_config: Optional[Dict[str, Any]]
+
+    def __init__(
+        self,
+        dim_model: int,
+        feedforward_config: Dict[str, Any],
+        multi_head_config: Dict[str, Any],
+        position_encoding_config: Optional[Dict[str, Any]] = None,
+        layer_norm_style: str = "post",
+        use_triton: bool = True,
+        simplicial_embeddings: Optional[Dict[str, Any]] = None,
+        patch_embedding_config: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ):
+        # Convenience, fill in duplicated field
+        try:
+            if "dim_model" not in multi_head_config.keys():
+                multi_head_config["dim_model"] = dim_model
+
+            if "dim_model" not in feedforward_config.keys():
+                feedforward_config["dim_model"] = dim_model
+
+            if (
+                position_encoding_config is not None
+                and "dim_model" not in position_encoding_config.keys()
+            ):
+                position_encoding_config["dim_model"] = dim_model
+
+        except AttributeError:
+            # A config instance was passed in, this is fine
+            pass
+        if "block_type" in kwargs:
+            assert kwargs["block_type"] == "encoder"
+        kwargs["block_type"] = BlockType("encoder")
+        super().__init__(
+            dim_model=dim_model,
+            feedforward_config=feedforward_config,
+            position_encoding_config=position_encoding_config,
+            layer_norm_style=LayerNormStyle(layer_norm_style),
+            **kwargs,
+        )
+
+        self.multi_head_config = multi_head_config
+        self.use_triton = use_triton
+        self.simplicial_embeddings = simplicial_embeddings
+        self.patch_embedding_config = patch_embedding_config
+
+
+@dataclass(init=False)
+class xFormerDecoderConfig(xFormerBlockConfig):
+    """
+    The configuration structure for a decoder block.
+
+    This specifically defines the masked and cross attention mechanisms,
+    on top of the settings defining all blocks.
+    """
+
+    multi_head_config_masked: Dict[str, Any]  # prior to encoder output
+    multi_head_config_cross: Dict[str, Any]  # cross attention, takes encoder output
+
+    def __init__(
+        self,
+        dim_model: int,
+        feedforward_config: Dict[str, Any],
+        multi_head_config_masked: Dict[str, Any],
+        multi_head_config_cross: Dict[str, Any],
+        position_encoding_config: Optional[Dict[str, Any]] = None,
+        layer_norm_style: str = "post",
+        use_triton: bool = True,
+        **kwargs,
+    ):
+
+        # Convenience, fill in duplicated field
+        try:
+            if "dim_model" not in multi_head_config_masked.keys():
+                multi_head_config_masked["dim_model"] = dim_model
+
+            if "dim_model" not in multi_head_config_cross.keys():
+                multi_head_config_cross["dim_model"] = dim_model
+
+            if "dim_model" not in feedforward_config.keys():
+                feedforward_config["dim_model"] = dim_model
+
+            if (
+                position_encoding_config is not None
+                and "dim_model" not in position_encoding_config.keys()
+            ):
+                position_encoding_config["dim_model"] = dim_model
+        except AttributeError:
+            # A config instance was passed in, this is fine
+            pass
+        if "block_type" in kwargs.keys():
+            assert kwargs["block_type"] == "decoder"
+        kwargs["block_type"] = BlockType("decoder")
+
+        super().__init__(
+            dim_model=dim_model,
+            feedforward_config=feedforward_config,
+            position_encoding_config=position_encoding_config,
+            layer_norm_style=LayerNormStyle(layer_norm_style),
+            **kwargs,
+        )
+
+        self.multi_head_config_masked = multi_head_config_masked
+        self.multi_head_config_cross = multi_head_config_cross
+        self.use_triton = use_triton

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -5,63 +5,26 @@
 
 
 import logging
-from dataclasses import asdict, dataclass
-from enum import Enum
-from typing import Any, Dict, Optional, Tuple, Union
+from dataclasses import asdict
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 
 from xformers.components import (
     LayerNormStyle,
+    PatchEmbeddingConfig,
     PostNorm,
     PreNorm,
     Residual,
     build_multi_head_attention,
+    build_patch_embedding,
 )
-from xformers.components.feedforward import (
-    FEEDFORWARD_REGISTRY,
-    FeedforwardConfig,
-    build_feedforward,
-)
-from xformers.components.positional_embedding import (
-    POSITION_EMBEDDING_REGISTRY,
-    PositionEmbeddingConfig,
-    build_positional_embedding,
-)
+from xformers.components.feedforward import build_feedforward
+from xformers.components.positional_embedding import build_positional_embedding
 from xformers.components.residual import get_deepnorm_coefficients
 from xformers.components.simplicial_embedding import SimplicialEmbedding
-from xformers.utils import generate_matching_config
-
-
-class LayerPositionBitmask(int, Enum):
-    First = 0b01
-    Last = 0b10
-    Default = 0b11
-
-
-class LayerPosition:
-    """Bitmask to mark this layer as first, last, nothing or both"""
-
-    def __init__(self):
-        self.bitmask = LayerPositionBitmask.Default
-
-    def is_first(self):
-        return bool(self.bitmask & LayerPositionBitmask.First)
-
-    def is_last(self):
-        return bool(self.bitmask & LayerPositionBitmask.Last)
-
-    def mark_not_first(self):
-        self.bitmask &= ~LayerPositionBitmask.First
-
-    def mark_not_last(self):
-        self.bitmask &= ~LayerPositionBitmask.Last
-
-
-class BlockType(str, Enum):
-    Encoder = "encoder"
-    Decoder = "decoder"
+from xformers.factory.block_configs import xFormerDecoderConfig, xFormerEncoderConfig
 
 
 def _get_ln_factory(
@@ -116,180 +79,6 @@ def _get_ln_factory(
     return ln_factory
 
 
-@dataclass(init=False)  # handle constructors explicitly to force type changes
-class xFormerBlockConfig:
-    """
-    The configuration structure to define a Transformer block.
-    This base class is applicable to both encoder and decoder definitions.
-
-    This completely defines each of the blocks, for instance in terms of dimensions,
-    position encoding, pre or post layer norms or reversibility.
-    """
-
-    dim_model: int
-    feedforward_config: FeedforwardConfig
-    position_encoding_config: Optional[PositionEmbeddingConfig]
-    block_type: BlockType
-    layer_norm_style: LayerNormStyle
-    layer_position: LayerPosition
-    use_triton: bool
-    reversible: bool
-    num_layers: int
-
-    def __init__(
-        self,
-        dim_model: int,
-        feedforward_config: Dict[str, Any],
-        position_encoding_config: Optional[Dict[str, Any]],
-        block_type: BlockType,
-        layer_norm_style: LayerNormStyle = LayerNormStyle("post"),
-        reversible: bool = False,
-        num_layers: int = 1,
-        layer_position: Optional[LayerPosition] = None,
-    ):
-
-        self.dim_model = dim_model
-        self.block_type = block_type
-        self.layer_norm_style = layer_norm_style
-        self.reversible = reversible
-        self.num_layers = num_layers
-
-        # Fill in possible gaps in the config for subparts of the block
-        self.feedforward_config = generate_matching_config(
-            feedforward_config,
-            FEEDFORWARD_REGISTRY[feedforward_config["name"]].config,
-        )
-
-        self.position_encoding_config = (
-            generate_matching_config(
-                position_encoding_config,
-                POSITION_EMBEDDING_REGISTRY[position_encoding_config["name"]].config,
-            )
-            if position_encoding_config is not None
-            else None
-        )
-
-        # Default is that this layer is the only one, so both first and last
-        if layer_position:
-            self.layer_position = layer_position
-        else:
-            self.layer_position = LayerPosition()
-
-
-@dataclass(init=False)
-class xFormerEncoderConfig(xFormerBlockConfig):
-    """
-    The configuration structure for an encoder block
-    """
-
-    multi_head_config: Dict[str, Any]
-    use_triton: bool
-    simplicial_embeddings: Optional[Dict[str, Any]]
-
-    def __init__(
-        self,
-        dim_model: int,
-        feedforward_config: Dict[str, Any],
-        multi_head_config: Dict[str, Any],
-        position_encoding_config: Optional[Dict[str, Any]] = None,
-        layer_norm_style: str = "post",
-        use_triton: bool = True,
-        simplicial_embeddings: Optional[Dict[str, Any]] = None,
-        **kwargs,
-    ):
-        # Convenience, fill in duplicated field
-        try:
-            if "dim_model" not in multi_head_config.keys():
-                multi_head_config["dim_model"] = dim_model
-
-            if "dim_model" not in feedforward_config.keys():
-                feedforward_config["dim_model"] = dim_model
-
-            if (
-                position_encoding_config is not None
-                and "dim_model" not in position_encoding_config.keys()
-            ):
-                position_encoding_config["dim_model"] = dim_model
-
-        except AttributeError:
-            # A config instance was passed in, this is fine
-            pass
-        if "block_type" in kwargs:
-            assert kwargs["block_type"] == "encoder"
-        kwargs["block_type"] = BlockType("encoder")
-        super().__init__(
-            dim_model=dim_model,
-            feedforward_config=feedforward_config,
-            position_encoding_config=position_encoding_config,
-            layer_norm_style=LayerNormStyle(layer_norm_style),
-            **kwargs,
-        )
-
-        self.multi_head_config = multi_head_config
-        self.use_triton = use_triton
-        self.simplicial_embeddings = simplicial_embeddings
-
-
-@dataclass(init=False)
-class xFormerDecoderConfig(xFormerBlockConfig):
-    """
-    The configuration structure for a decoder block.
-
-    This specifically defines the masked and cross attention mechanisms,
-    on top of the settings defining all blocks.
-    """
-
-    multi_head_config_masked: Dict[str, Any]  # prior to encoder output
-    multi_head_config_cross: Dict[str, Any]  # cross attention, takes encoder output
-
-    def __init__(
-        self,
-        dim_model: int,
-        feedforward_config: Dict[str, Any],
-        multi_head_config_masked: Dict[str, Any],
-        multi_head_config_cross: Dict[str, Any],
-        position_encoding_config: Optional[Dict[str, Any]] = None,
-        layer_norm_style: str = "post",
-        use_triton: bool = True,
-        **kwargs,
-    ):
-
-        # Convenience, fill in duplicated field
-        try:
-            if "dim_model" not in multi_head_config_masked.keys():
-                multi_head_config_masked["dim_model"] = dim_model
-
-            if "dim_model" not in multi_head_config_cross.keys():
-                multi_head_config_cross["dim_model"] = dim_model
-
-            if "dim_model" not in feedforward_config.keys():
-                feedforward_config["dim_model"] = dim_model
-
-            if (
-                position_encoding_config is not None
-                and "dim_model" not in position_encoding_config.keys()
-            ):
-                position_encoding_config["dim_model"] = dim_model
-        except AttributeError:
-            # A config instance was passed in, this is fine
-            pass
-        if "block_type" in kwargs.keys():
-            assert kwargs["block_type"] == "decoder"
-        kwargs["block_type"] = BlockType("decoder")
-
-        super().__init__(
-            dim_model=dim_model,
-            feedforward_config=feedforward_config,
-            position_encoding_config=position_encoding_config,
-            layer_norm_style=LayerNormStyle(layer_norm_style),
-            **kwargs,
-        )
-
-        self.multi_head_config_masked = multi_head_config_masked
-        self.multi_head_config_cross = multi_head_config_cross
-        self.use_triton = use_triton
-
-
 class xFormerEncoderBlock(torch.nn.Module):
     r"""A vanilla Transformer Encoder block"""
 
@@ -314,11 +103,9 @@ class xFormerEncoderBlock(torch.nn.Module):
             mha_dim = config.multi_head_config["dim_model"]
 
             if pos_encoding_dim != mha_dim:
-
                 logging.warning(
                     f"The embedding dim and model dim do not match ({pos_encoding_dim} vs {mha_dim}), adding a projector layer."  # noqa
                 )
-
                 self.embedding_projector = nn.Linear(pos_encoding_dim, mha_dim)
         else:
             self.pose_encoding = None
@@ -362,6 +149,17 @@ class xFormerEncoderBlock(torch.nn.Module):
                 **config.simplicial_embeddings
             )
 
+        # Optional patch embedding
+        self.patch_emb: Optional[nn.Module] = None
+
+        if (
+            config.patch_embedding_config is not None
+            and config.layer_position.is_first()
+        ):
+            self.patch_emb = build_patch_embedding(
+                PatchEmbeddingConfig(**config.patch_embedding_config)
+            )
+
     @classmethod
     def from_config(cls, config: xFormerEncoderConfig):
         return cls(config)
@@ -388,6 +186,9 @@ class xFormerEncoderBlock(torch.nn.Module):
         att_mask: Optional[torch.Tensor] = None,
         input_mask: Optional[torch.Tensor] = None,
     ):
+        if self.patch_emb is not None:
+            x = self.patch_emb(x)
+
         if self.pose_encoding is not None:
             x = self.pose_encoding(x)
 

--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -12,13 +12,12 @@ import torch
 
 from xformers.components import reversible as rv
 from xformers.components.residual import LayerNormStyle, get_deepnorm_coefficients
-from xformers.factory.block_factory import (
+from xformers.factory.block_configs import (
     xFormerBlockConfig,
-    xFormerDecoderBlock,
     xFormerDecoderConfig,
-    xFormerEncoderBlock,
     xFormerEncoderConfig,
 )
+from xformers.factory.block_factory import xFormerDecoderBlock, xFormerEncoderBlock
 
 
 @dataclass(init=False)


### PR DESCRIPTION
## What does this PR do?
- First step to close #285, we actually need to support the patch embedding part to be able to generate all [Metaformers](https://arxiv.org/pdf/2111.11418.pdf). We could expose more options as of what function is used to "pool" the patches, this PR follows ViT in that it's a Conv2d
- Add a learnable position embedding, somehow not there
- Change the microViT example so that it benefits from this new support
- Testing a "classic" small ViT training on CIFAR, seems alright

TODO:
- [x] Add a matching unit test

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
