### PR TITLE
Remove double dropout in global attention

### DIFF
--- a/xformers/components/attention/global_tokens.py
+++ b/xformers/components/attention/global_tokens.py
@@ -116,7 +116,5 @@ class GlobalAttention(Attention):
             q=q_, k=k_, v=v_, att_mask=mask, dropout=self.attn_drop
         )
 
-        att = self.attn_drop(att)
-
         # Take into account an hypothetical padding
         return att[:, :seq_len, :]


### PR DESCRIPTION
## What does this PR do?

`scaled_dot_product_attention` already handles dropout internally.
In
https://github.com/facebookresearch/xformers/blob/8a0507086e5fca99da752258b3c2b56b233ceaa4/xformers/components/attention/global_tokens.py#L119
we are applying dropout in the output of the attention block, which is not intended.

This PR fixes it by removing the extra dropout