### PR TITLE
[hotfix] looks like triton matmul op is initially too slow for CI

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -26,4 +26,4 @@ hydra-core >= 1.1
 fairscale >= 0.4.5
 
 # Dependency for fused layers, optional
-triton == 2.0.0.dev20220514
+triton == 2.0.0.dev20220403

--- a/xformers/triton/k_fused_matmul_bw.py
+++ b/xformers/triton/k_fused_matmul_bw.py
@@ -135,8 +135,8 @@ def fused_matmul_backward(
         grad_out_ = grad_act
 
     # The following ops can also be handled by triton
-    grad_in = triton.ops.matmul(grad_out_, weight)
-    grad_weight = triton.ops.matmul(grad_out_.transpose(1, 0), inputs_) if trainable_weight else None
+    grad_in = grad_out_ @ weight
+    grad_weight = grad_out_.transpose(1, 0) @ inputs_ if trainable_weight else None
     grad_bias = sum_2d_dim_0(grad_out_) if trainable_bias else None
 
     return grad_in.reshape_as(inputs), grad_weight, grad_bias


### PR DESCRIPTION
## What does this PR do?
worked on my machine.. (tm). Looks like the initial JIt or micro benchs are too slow for our CI, reverting to an older version which works. 

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
