### PR TITLE
[CI] Lock protobuf to 3.20.1

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,6 +11,7 @@ mypy == 0.812
 pyre-check == 0.9.8
 pyre-extensions == 0.0.23
 click == 8.0.4
+protobuf==3.20.1
 
 # Tools for unit tests & coverage.
 pytest == 5.4.1


### PR DESCRIPTION
## What does this PR do?
Fixes broken dependencies that protobuf 4.20 caused

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
