### PR TITLE
[hotfix] doubled bias in FusedMLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## TBD
 ### Fixed
+- Removed dupliacated biases in the FusedMLP layers [#317]
 
 ### Added
 

--- a/xformers/benchmarks/benchmark_mlp.py
+++ b/xformers/benchmarks/benchmark_mlp.py
@@ -19,8 +19,8 @@ SHAPES = [
     (8, 512, 1024),
     (4, 1024, 1024),
     (2, 2048, 2048),
-    (1, 2048, 12288),
-    (2, 4096, 4096),
+    (1, 2048, 4096),
+    (1, 1024, 12288),
 ]
 
 HIDDEN_LAYER_MULTIPLIER = [4]
@@ -70,7 +70,7 @@ def bench_MLP(backward: bool, bias: bool, dropout: float, activation: Activation
                 for testcase in [
                     TestCase(
                         mlp_standard,
-                        "standard - {} - {}bias - {} drop - fw{}".format(
+                        "standard - {} - {} bias - {} drop - fw{}".format(
                             activation,
                             "no" if not bias else "",
                             dropout,
@@ -88,7 +88,7 @@ def bench_MLP(backward: bool, bias: bool, dropout: float, activation: Activation
                     ),
                 ]:
                     time = triton.testing.do_bench(testcase.function)[0]
-                    key = f"B={B}, M={M}, K={K}, HLM={hlm}"
+                    key = f"{B} x {M} x {K} - {hlm}"
                     if key not in results:
                         results[key] = {}
 
@@ -97,7 +97,7 @@ def bench_MLP(backward: bool, bias: bool, dropout: float, activation: Activation
         pretty_print(
             results,
             title=f"\n --- Type: {dtype} --- ",
-            units="runtime in ms, lower is better",
+            units="runtime in ms, lower is better. BMK - mul: ",
         )
         pretty_plot(
             results,

--- a/xformers/components/feedforward/fused_mlp.py
+++ b/xformers/components/feedforward/fused_mlp.py
@@ -46,16 +46,26 @@ if torch.cuda.is_available():
                 dim_mlp = hidden_layer_multiplier * dim_model
 
                 self.mlp = nn.Sequential(
-                    nn.Linear(in_features=dim_model, out_features=dim_mlp, bias=bias),
+                    nn.Linear(
+                        in_features=dim_model, out_features=dim_mlp, bias=False
+                    ),  # bias is handled in the next layer
                     # pyre-ignore[16]: TODO(T101400990): Pyre did not recognize
                     # the `FusedLinear` import.
                     FusedDropoutBias(
-                        p=dropout, bias_shape=dim_mlp, activation=activation
+                        p=dropout,
+                        bias_shape=dim_mlp if bias else None,
+                        activation=activation,
                     ),
-                    nn.Linear(in_features=dim_mlp, out_features=dim_model, bias=bias),
+                    nn.Linear(
+                        in_features=dim_mlp, out_features=dim_model, bias=False
+                    ),  # bias is handled in the next layer
                     # pyre-ignore[16]: TODO(T101400990): Pyre did not recognize
                     # the `FusedLinear` import.
-                    FusedDropoutBias(p=dropout, bias_shape=dim_model, activation=None),
+                    FusedDropoutBias(
+                        p=dropout,
+                        bias_shape=dim_model if bias else None,
+                        activation=None,
+                    ),
                 )
                 self.requires_cuda = True
 


### PR DESCRIPTION
## What does this PR do?
Fixes the FusedMLP block having twice the bias layers, found randomly when working on the weight inits (#312)

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
