### PR TITLE
[feat] Adding a conv MLP, following VAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Four blocksparsity layouts from DeepSpeed [#320]
 - Support several initialization options [#312]
+- Conv2DFeedforward feedforward part [#321]
 
 
 ## [0.0.11] - 2022-05-30

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Patrick et al., 2021](https://arxiv.org/abs/2106.05392)*
 - [MLP](xformers/components/feedforward/mlp.py)
 - [Fused](xformers/components/feedforward/fused_mlp.py)
 - [Mixture of Experts](xformers/components/feedforward/mixture_of_experts.py)
+- [Conv2DFeedforward](xformers/components/feedforward/conv_mlp.py)
 
 </p></details>
 

--- a/examples/cifarMetaformer.py
+++ b/examples/cifarMetaformer.py
@@ -89,7 +89,7 @@ class MetaVisionTransformer(VisionTransformer):
             use_rotary_embeddings=use_rotary_embeddings,
             mlp_multiplier=4,
             dim_head=32,
-            feedforward="ConvMLP",
+            feedforward="Conv2DFeedforward",
         )
 
         # Now instantiate the metaformer trunk

--- a/examples/cifarMetaformer.py
+++ b/examples/cifarMetaformer.py
@@ -89,6 +89,7 @@ class MetaVisionTransformer(VisionTransformer):
             use_rotary_embeddings=use_rotary_embeddings,
             mlp_multiplier=4,
             dim_head=32,
+            feedforward="ConvMLP",
         )
 
         # Now instantiate the metaformer trunk

--- a/tests/test_block_factory.py
+++ b/tests/test_block_factory.py
@@ -237,7 +237,10 @@ def test_xformer_decoder_block(
         )
 
     # Test different sequence lengths when encoding and decoding
-    if not decoder_block.requires_same_k_q_dimensions:
+    if (
+        not decoder_block.requires_same_k_q_dimensions
+        and not decoder_block.requires_squared_context_length
+    ):
         if not causal or not decoder_block.causal_attention:
             _ = decoder_block(inputs[:, :-16], encoded)
         else:

--- a/tests/test_feedforward.py
+++ b/tests/test_feedforward.py
@@ -12,7 +12,7 @@ from xformers.components.feedforward.mixture_of_experts import GateConfig
 from xformers.helpers.test_utils import init_torch_distributed_local
 
 BATCH = 4
-SEQ = 512
+SEQ = 256
 EMBD = 16
 LATENT = 128
 DROPOUT = 0.5

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -199,9 +199,10 @@ def test_presets(config, reversible, tie_embedding_weights, layer_norm_style, de
 
 
 @pytest.mark.parametrize("weight_init", [w.value for w in xFormerWeightInit])
+@pytest.mark.parametrize("feedforward", ["MLP", "Conv2DFeedforward"])
 @pytest.mark.parametrize("deepnorm", [False, True])
 @pytest.mark.parametrize("device", DEVICES)
-def test_weight_init(weight_init, deepnorm, device):
+def test_weight_init(weight_init, feedforward, deepnorm, device):
     torch.cuda.manual_seed(42)
     torch.manual_seed(42)
 
@@ -209,6 +210,8 @@ def test_weight_init(weight_init, deepnorm, device):
 
     if deepnorm:
         config["encoder"]["layer_norm_style"] = "deepnorm"
+        config["encoder"]["feedforward_config"]["name"] = feedforward
+
         config["decoder"]["layer_norm_style"] = "deepnorm"
 
     # Make sure that all the init methods catch all the weights

--- a/xformers/components/feedforward/base.py
+++ b/xformers/components/feedforward/base.py
@@ -35,7 +35,12 @@ class Feedforward(nn.Module, metaclass=ABCMeta):
         **kwargs,
     ):
         super().__init__()
+
+        # This feedforward requires a CUDA accelerator
         self.requires_cuda = False
+
+        # This feedforward requires a context length which is squared, often due to 2D pooling
+        self.requires_squared_context = False
 
     @classmethod
     def from_config(cls: Type[Self], config: FeedforwardConfig) -> Self:

--- a/xformers/components/feedforward/conv_mlp.py
+++ b/xformers/components/feedforward/conv_mlp.py
@@ -1,0 +1,105 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# CREDITS: Largely reusing the code from the reference VAN implementation
+# see https://github.com/Visual-Attention-Network
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import torch.nn as nn
+
+from xformers.components import Activation, build_activation
+from xformers.components.feedforward import Feedforward, FeedforwardConfig
+from xformers.factory.weight_init import _no_grad_trunc_normal_
+
+from . import register_feedforward
+
+
+@dataclass
+class ConvMlpConfig(FeedforwardConfig):
+    hidden_layer_multiplier: int
+    dim_model: int
+    dim_model_out: Optional[int]
+    act_layer: Activation
+    dropout: float
+
+
+@register_feedforward("ConvMLP", ConvMlpConfig)
+class ConvMLP(Feedforward):
+    """
+    A Convolutional feed-forward network, as proposed in VAN_ (Vision Attention Network, Guo et al.)
+
+    .. _VAN: https://arxiv.org/pdf/2202.09741.pdf
+    """
+
+    def __init__(
+        self,
+        dim_model: int,
+        hidden_layer_multiplier: int = 1,
+        dim_model_out: Optional[int] = None,
+        activation: Activation = Activation.GeLU,
+        dropout=0.0,
+        *args,
+        **kwargs,
+    ):
+        super().__init__()
+        out_features = dim_model_out or dim_model
+        hidden_features = hidden_layer_multiplier * dim_model
+
+        self.conv_mlp = nn.Sequential(
+            nn.Conv2d(dim_model, hidden_features, 1),
+            nn.Conv2d(
+                hidden_features,
+                hidden_features,
+                3,
+                1,
+                1,
+                bias=True,
+                groups=hidden_features,
+            ),
+            build_activation(activation),
+            nn.Conv2d(hidden_features, out_features, 1),
+            nn.Dropout(dropout),
+        )
+
+        # This feedforward requires a context length which is squared, often due to 2D pooling
+        self.requires_squared_context = True
+
+    def init_weights(self, **kwargs):
+        # Follow the original init, but also make it possible to initialize from the outside
+        def init_module(m: nn.Module):
+            if isinstance(m, nn.Linear):
+                _no_grad_trunc_normal_(m.weight, mean=0.0, std=0.02, a=2.0, b=-2.0)
+                if isinstance(m, nn.Linear) and m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.LayerNorm):
+                nn.init.constant_(m.bias, 0)
+                nn.init.constant_(m.weight, 1.0)
+            elif isinstance(m, nn.Conv2d):
+                fan_out = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
+                fan_out //= m.groups
+                m.weight.data.normal_(0, math.sqrt(2.0 / fan_out))
+                if m.bias is not None:
+                    m.bias.data.zero_()
+
+        self.apply(init_module)
+
+    def forward(self, x):
+        # The conv layers expect NCHW, we have NLC by default
+        B, L, C = x.shape
+        HW = int(math.sqrt(x.shape[-2]))
+        assert HW**2 == L, "ConvMLP is 2D by default, and it assumes square pictures"
+
+        x = x.reshape((B, HW, HW, C)).swapdims(1, -1)
+
+        # The actual FW, including the 2d convolutions
+        x = self.conv_mlp(x)
+
+        # back to NLC
+        x = x.transpose(1, -1)
+        return x.flatten(1, 2)

--- a/xformers/components/feedforward/conv_mlp.py
+++ b/xformers/components/feedforward/conv_mlp.py
@@ -29,8 +29,8 @@ class ConvMlpConfig(FeedforwardConfig):
     dropout: float
 
 
-@register_feedforward("ConvMLP", ConvMlpConfig)
-class ConvMLP(Feedforward):
+@register_feedforward("Conv2DFeedforward", ConvMlpConfig)
+class Conv2DFeedforward(Feedforward):
     """
     A Convolutional feed-forward network, as proposed in VAN_ (Vision Attention Network, Guo et al.)
 
@@ -93,7 +93,7 @@ class ConvMLP(Feedforward):
         # The conv layers expect NCHW, we have NLC by default
         B, L, C = x.shape
         HW = int(math.sqrt(x.shape[-2]))
-        assert HW**2 == L, "ConvMLP is 2D by default, and it assumes square pictures"
+        assert HW**2 == L, "Conv2DFeedforward requires squared context lengths"
 
         x = x.reshape((B, HW, HW, C)).swapdims(1, -1)
 

--- a/xformers/components/feedforward/conv_mlp.py
+++ b/xformers/components/feedforward/conv_mlp.py
@@ -15,7 +15,6 @@ import torch.nn as nn
 
 from xformers.components import Activation, build_activation
 from xformers.components.feedforward import Feedforward, FeedforwardConfig
-from xformers.factory.weight_init import _no_grad_trunc_normal_
 
 from . import register_feedforward
 
@@ -73,14 +72,7 @@ class Conv2DFeedforward(Feedforward):
     def init_weights(self, **kwargs):
         # Follow the original init, but also make it possible to initialize from the outside
         def init_module(m: nn.Module):
-            if isinstance(m, nn.Linear):
-                _no_grad_trunc_normal_(m.weight, mean=0.0, std=0.02, a=2.0, b=-2.0)
-                if isinstance(m, nn.Linear) and m.bias is not None:
-                    nn.init.constant_(m.bias, 0)
-            elif isinstance(m, nn.LayerNorm):
-                nn.init.constant_(m.bias, 0)
-                nn.init.constant_(m.weight, 1.0)
-            elif isinstance(m, nn.Conv2d):
+            if isinstance(m, nn.Conv2d):
                 fan_out = m.kernel_size[0] * m.kernel_size[1] * m.out_channels
                 fan_out //= m.groups
                 m.weight.data.normal_(0, math.sqrt(2.0 / fan_out))

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -275,9 +275,11 @@ class xFormerDecoderBlock(torch.nn.Module):
         cross_mha = build_multi_head_attention(config.multi_head_config_cross)
         feedforward = build_feedforward(config.feedforward_config)
 
-        # Expose attention specific capabilities
+        # Expose attention or feedforward specific capabilities
         self.supports_attention_mask = mha.attention.supports_attention_mask
         self.requires_same_k_q_dimensions = mha.attention.requires_same_k_q_dimensions
+        self.requires_squared_context_length = feedforward.requires_squared_context
+
         self.causal_attention = (
             mha.attention.causal if hasattr(mha.attention, "causal") else False
         )

--- a/xformers/factory/weight_init.py
+++ b/xformers/factory/weight_init.py
@@ -30,10 +30,6 @@ class xFormerWeightInit(str, Enum):
     Small = "small"
 
 
-# TODO: Check with a bunch of quick trainings whether all the inits are in the green
-# TODO: Check test coverage
-
-
 def get_weight_init_fn(init_choice: xFormerWeightInit):
     """
     Provide the xFormers factory with weight init routines.

--- a/xformers/helpers/hierarchical_configs.py
+++ b/xformers/helpers/hierarchical_configs.py
@@ -27,6 +27,7 @@ def get_hierarchical_configuration(
     use_rotary_embeddings: bool = True,
     mlp_multiplier: int = 4,
     dim_head=32,
+    feedforward="MLP",
 ):
     """
     A small helper to generate hierarchical xformers configurations,
@@ -49,7 +50,7 @@ def get_hierarchical_configuration(
             },
         },
         "feedforward_config": {
-            "name": "MLP",
+            "name": feedforward,
             "activation": "gelu",
             "hidden_layer_multiplier": mlp_multiplier,
             "dropout": 0.0,


### PR DESCRIPTION
## What does this PR do?
One step towards #319, adding the MLP/Conv2d hybrid proposed by the [VAN paper](https://arxiv.org/pdf/2202.09741.pdf). Interestingly, testing this with a "Metaformer" (in true xformers fashion you can mix and match) on a tiny example does bring a measurable benefit.

 <details>
<summary>Small (6M) Metaformer on Cifar10</summary>
Orange is the default (scaled dot product attention, not poolformer) + MLP
White is the same but with the ConvMLP that this PR introduces

![Screenshot from 2022-06-02 22-07-12](https://user-images.githubusercontent.com/3072861/171790313-23789992-d6af-4b74-96d2-f7c7c9b9676f.png)

</details>


## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
