### PR TITLE
[docs/cleanup] updated TimmAttentionWrapper to TimmSparseAttention 

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -159,7 +159,7 @@ Let's say you're used to working with a given Transformer based model, and want 
 import timm
 from timm.models.vision_transformer import VisionTransformer
 from xformers.components.attention import ScaledDotProduct
-from xformers.components.attention.helpers import TimmAttentionWrapper
+from xformers.helpers.timm_sparse_attention import TimmSparseAttention
 img_size = 224
 patch_size = 16
 
@@ -180,11 +180,12 @@ def replace_attn_with_xformers_one(module, att_mask):
     if isinstance(module, timm.models.vision_transformer.Attention):
         qkv = module.qkv
         dim = qkv.weight.shape[1] * module.num_heads
-        # Extra parameters can be exposed in TimmAttentionWrapper, this is a minimal example
-        module_output = TimmAttentionWrapper(dim, module.num_heads, attn_mask=att_mask)
+        # Extra parameters can be exposed in TimmSparseAttention, this is a minimal example
+        module_output = TimmSparseAttention(dim, module.num_heads, attn_mask=att_mask)
     for name, child in module.named_children():
         module_output.add_module(name, replace_attn_with_xformers_one(child, att_mask))
     del module
+
     return module_output
 
 # Now we can just patch our reference model, and get a sparse-aware variation

--- a/tests/test_timm_sparse.py
+++ b/tests/test_timm_sparse.py
@@ -20,7 +20,7 @@ _device_list = ["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"]
 
 @pytest.mark.skipif(timm is None, reason="requires timm")
 @pytest.mark.parametrize("device", _device_list)
-def test_timm_sparse(device):
+def test_timm_sparse_attention(device):
     img_size = 224
     patch_size = 16
     batch = 8

--- a/tests/test_timm_sparse.py
+++ b/tests/test_timm_sparse.py
@@ -20,7 +20,7 @@ _device_list = ["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"]
 
 @pytest.mark.skipif(timm is None, reason="requires timm")
 @pytest.mark.parametrize("device", _device_list)
-def test_timm_wrapper(device):
+def test_timm_sparse(device):
     img_size = 224
     patch_size = 16
     batch = 8


### PR DESCRIPTION
## What does this PR do?
Fixes documentation to reflect correct revised class name "TimmSparseAttention" instead of "TimmAttentionWrapper"
Changes test file name and method name to reflect same

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
