### PR TITLE
Pass `use_triton` flag to LayerNorm module

### DIFF
--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -147,7 +147,9 @@ class xFormerEncoderBlock(torch.nn.Module):
             config.layer_norm_style == LayerNormStyle.Pre
             and config.layer_position.is_last()
         ):
-            self.wrap_ff = PostNorm(config.dim_model, self.wrap_ff)
+            self.wrap_ff = PostNorm(
+                config.dim_model, self.wrap_ff, use_triton=config.use_triton
+            )
 
         # Simplicial embeddings are only used if specified, and on the last layer
         self.simplicial_embedding: Optional[SimplicialEmbedding] = None


### PR DESCRIPTION
## What does this PR do?

When creating the model, `use_triton` isn't passed to the Norm module in the factory. This is required when skipping the triton-based layer norm implementation when using BFloat16.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
