### PR TITLE
[hotfix][minor] Poolformer does not need projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed dupliacated biases in the FusedMLP layers [#317]
 - Rotary embeddings respecting input types [#326]
+- Poolformer style instantiating useless projection layers [#349]
 
 ### Added
 - Four blocksparsity layouts from DeepSpeed [#320]

--- a/xformers/components/attention/pooling.py
+++ b/xformers/components/attention/pooling.py
@@ -58,6 +58,7 @@ class Pooling(Attention):
 
         # This "attention" (token mixing) skips the multihead attention altogether
         self.requires_skip_multi_head = True
+        self.requires_input_projection = False
 
         # This operator does not really handle q,k,v
         self.requires_same_k_q_dimensions = True


### PR DESCRIPTION
## What does this PR do?
Not a functional bug, but the projection layers were built for something like poolformer (using the pooling attention mechanism), even if not being used. This took some space in memory, and led to a false number of exposed parameters for the whole model. There was one flag missing to tell xformers that this mechanism does not require projections.
Issue caught when having a look at #347

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
