### PR TITLE
Fix nystromformer attention

### DIFF
--- a/tests/test_nystrom_attention.py
+++ b/tests/test_nystrom_attention.py
@@ -137,11 +137,6 @@ def test_nystrom_attention(
         )
         r_nystrom = nystrom_attention(a, a, a, key_padding_mask=key_padding_mask)
         r_sdp = sdp_attention(a, a, a, att_mask=mask)
-        # account for when nan != nan
-        if r_nystrom.isnan().any() or r_sdp.isnan().any():
-            rand = random.uniform(0, 1)
-            r_nystrom = r_nystrom.masked_fill(r_nystrom.isnan(), rand)
-            r_sdp = r_sdp.masked_fill(r_sdp.isnan(), rand)
 
         # Not very close, but more so testing functionality.
         assert torch.allclose(

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -91,7 +91,8 @@ def _matmul_with_mask(
         return torch.ops.xformers.matmul_with_mask(a, b, mask)
 
     # Non optimized codepath
-    assert not isinstance(mask, SparseCS)
+    if _is_sparse_available:
+        assert not isinstance(mask, SparseCS)
 
     att = a @ b
     if mask.dtype == torch.bool:


### PR DESCRIPTION
## What does this PR do?
Fixes #360. When using `key_padding_mask`, nystroformer attention was raising NaN because of masking on calculation of `kernel_1`. Although `key_padding_mask` was used as `mask_1`, key was the compressed by pooing already.

Following the original code of [Nystromformer](https://github.com/mlpen/Nystromformer/blob/main/code/attention_nystrom.py), I have updated the corresponding codes. Concretely, padding tokens in query and key were masked before pooling, and masks of calculation in `kernel_1` and `kernel_2` were deleted.

After that, I have confirmed that `NaN` was not raised. In addition, I have deleted replacement of NaN with random values in the test because existing NaN in output are not expected.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
