### PR TITLE
Add .contiguous() to several tensor in the sparse folder

### DIFF
--- a/xformers/sparse/_csr_ops.py
+++ b/xformers/sparse/_csr_ops.py
@@ -126,7 +126,7 @@ class _spmm(torch.autograd.Function):
         ctx, b, row_indices, values, row_offsets, column_indices, m, _transp_info
     ):
         out = torch.ops.xformers.spmm_sputnik(
-            b, row_indices, values, row_offsets, column_indices, m
+            b.contiguous(), row_indices, values, row_offsets, column_indices, m
         )
 
         ctx.save_for_backward(
@@ -149,7 +149,7 @@ class _spmm(torch.autograd.Function):
         # gradients w.r.t. values
         grad = grad.contiguous()
 
-        grad_sparse = _sddmm_func(grad, b, row_indices, row_offsets, column_indices)
+        grad_sparse = _sddmm_func(grad, b.contiguous(), row_indices, row_offsets, column_indices)
 
         (
             row_indices_t,

--- a/xformers/sparse/_csr_ops.py
+++ b/xformers/sparse/_csr_ops.py
@@ -149,7 +149,6 @@ class _spmm(torch.autograd.Function):
 
         # gradients w.r.t. values
         grad = grad.contiguous()
-        b = b.contiguous()
 
         grad_sparse = _sddmm_func(grad, b, row_indices, row_offsets, column_indices)
 

--- a/xformers/sparse/_csr_ops.py
+++ b/xformers/sparse/_csr_ops.py
@@ -125,8 +125,9 @@ class _spmm(torch.autograd.Function):
     def forward(
         ctx, b, row_indices, values, row_offsets, column_indices, m, _transp_info
     ):
+        b = b.contiguous()
         out = torch.ops.xformers.spmm_sputnik(
-            b.contiguous(), row_indices, values, row_offsets, column_indices, m
+            b, row_indices, values, row_offsets, column_indices, m
         )
 
         ctx.save_for_backward(
@@ -148,8 +149,9 @@ class _spmm(torch.autograd.Function):
 
         # gradients w.r.t. values
         grad = grad.contiguous()
+        b = b.contiguous()
 
-        grad_sparse = _sddmm_func(grad, b.contiguous(), row_indices, row_offsets, column_indices)
+        grad_sparse = _sddmm_func(grad, b, row_indices, row_offsets, column_indices)
 
         (
             row_indices_t,

--- a/xformers/sparse/csr_tensor.py
+++ b/xformers/sparse/csr_tensor.py
@@ -184,10 +184,9 @@ class SparseCSRTensor(torch.Tensor):
         row_offsets = mask.__row_offsets
         column_indices = mask.__column_indices
         a = a.contiguous()
-        b = b.contiguous()
         out = _csr_ops._sddmm.apply(
             a,
-            b.transpose(-2, -1),
+            b.transpose(-2, -1).contiguous(),
             row_indices,
             row_offsets,
             column_indices,

--- a/xformers/sparse/csr_tensor.py
+++ b/xformers/sparse/csr_tensor.py
@@ -184,8 +184,8 @@ class SparseCSRTensor(torch.Tensor):
         row_offsets = mask.__row_offsets
         column_indices = mask.__column_indices
         out = _csr_ops._sddmm.apply(
-            a,
-            b.transpose(-2, -1),
+            a.contiguous(),
+            b.transpose(-2, -1).contiguous(),
             row_indices,
             row_offsets,
             column_indices,

--- a/xformers/sparse/csr_tensor.py
+++ b/xformers/sparse/csr_tensor.py
@@ -183,9 +183,11 @@ class SparseCSRTensor(torch.Tensor):
         row_indices = mask.__row_indices
         row_offsets = mask.__row_offsets
         column_indices = mask.__column_indices
+        a = a.contiguous()
+        b = b.contiguous()
         out = _csr_ops._sddmm.apply(
-            a.contiguous(),
-            b.transpose(-2, -1).contiguous(),
+            a,
+            b.transpose(-2, -1),
             row_indices,
             row_offsets,
             column_indices,


### PR DESCRIPTION
## What does this PR do?
When training a transformer that uses SparseCSRTensor, I had a bug "Expected D1.is_contiguous() to be True but got False. It happened during the evaluation time. I also had bug when the batch size was 1 or when using only 1 GPU. 
These little fixes solved my problem and they would be useful since I need to release a model that uses xformers. 
## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
