### PR TITLE
Support partial tiles for attention fw/bw

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -642,7 +642,8 @@ struct AttentionBackwardKernel {
           shared_storage.after_qk.attn_shared_storage,
           thread_id,
           warp_id,
-          lane_id);
+          lane_id,
+          problem_size.k());
 
       typename Mma::FragmentC accum;
 
@@ -834,7 +835,8 @@ struct AttentionBackwardKernel {
           shared_storage.after_qk.after_doivj.doivj_shared_storage,
           thread_id,
           warp_id,
-          lane_id);
+          lane_id,
+          problem_size.k());
 
       typename Mma::FragmentC accum;
 
@@ -924,7 +926,8 @@ struct AttentionBackwardKernel {
           shared_storage.after_qk.attn_shared_storage, // storing tmp.T
           thread_id,
           warp_id,
-          lane_id);
+          lane_id,
+          problem_size.k());
 
       typename Mma::FragmentC accum;
 

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -493,10 +493,7 @@ struct AttentionBackwardKernel {
 
     extern __shared__ char smem_buffer[];
     SharedStorage& shared_storage = *((SharedStorage*)smem_buffer);
-    // int32_t key_start = blockIdx.x * kBlockSizeJ;
-    // int32_t query_start = blockIdx.y * kBlockSizeI;
     int32_t thread_id = threadIdx.x + threadIdx.y * blockDim.x;
-    int32_t warp_id = threadIdx.y;
 
     auto clearSmem = [&]() {
       // Initialize shared-memory. It can contain `nans` otherwise that screw up

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -269,7 +269,8 @@ struct AttentionKernel {
             shared_storage_si,
             thread_id(),
             warp_id(),
-            lane_id());
+            lane_id(),
+            problem_size.k());
 
         int gemm_k_iterations =
             (problem_size.k() + Mma::Shape::kK - 1) / Mma::Shape::kK;

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_simt_tile_iterator_residual.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_simt_tile_iterator_residual.h
@@ -1,12 +1,12 @@
 /***************************************************************************************************
- * Copyright (c) 2017 - 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2017 - 2022 NVIDIA CORPORATION & AFFILIATES. All rights
+ *reserved. SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *
- * 1. Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
@@ -18,27 +18,28 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *POSSIBILITY OF SUCH DAMAGE.
  *
  **************************************************************************************************/
 /*! \file
-    \brief Iterator over OperandA in shared memory in SIMT cases, used for fused-matmuls
-        Mostly copied from cutlass/gemm/warp/mma_simt_tile_iterator.h
+    \brief Iterator over OperandA in shared memory in SIMT cases, used for
+   fused-matmuls Mostly copied from cutlass/gemm/warp/mma_simt_tile_iterator.h
 */
 
 #pragma once
 
-#include "cutlass/cutlass.h"
 #include "cutlass/array.h"
-#include "cutlass/tensor_ref.h"
+#include "cutlass/cutlass.h"
 #include "cutlass/matrix_shape.h"
+#include "cutlass/tensor_ref.h"
 
 #include "cutlass/arch/memory_sm75.h"
 
@@ -55,22 +56,22 @@ namespace warp {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Iterates over operands to warp-level matrix multiply operations targeting SIMT instructions
+/// Iterates over operands to warp-level matrix multiply operations targeting
+/// SIMT instructions
 ///
 /// concept: MutableRandomAccessContiguousTileIteratorConcept
 ///
 template <
-  /// Size of the matrix to load (concept: MatrixShape)
-  typename Shape_,
-  /// Operand identity
-  Operand Operand,
-  /// Data type of A elements
-  typename Element_,
-  /// Layout of operand
-  typename Layout_,
-  /// Shape of the warp in units of thread (concept: MmaSimtPolicy)
-  typename Policy_
->
+    /// Size of the matrix to load (concept: MatrixShape)
+    typename Shape_,
+    /// Operand identity
+    Operand Operand,
+    /// Data type of A elements
+    typename Element_,
+    /// Layout of operand
+    typename Layout_,
+    /// Shape of the warp in units of thread (concept: MmaSimtPolicy)
+    typename Policy_>
 class MmaSimtTileIteratorWithResidual;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -80,16 +81,19 @@ class MmaSimtTileIteratorWithResidual;
 /// Concept: MutableRandomAccessContiguousTileIteratorConcept
 ///
 template <
-  /// Size of the matrix to load (concept: MatrixShape)
-  typename Shape_,
-  /// Data type of A elements
-  typename Element_,
-  /// Shape of the warp in units of thread (concept: MmaSimtPolicy)
-  typename Policy_
->
-class MmaSimtTileIteratorWithResidual<Shape_, Operand::kA, Element_, layout::ColumnMajor, Policy_> {
-public:
-
+    /// Size of the matrix to load (concept: MatrixShape)
+    typename Shape_,
+    /// Data type of A elements
+    typename Element_,
+    /// Shape of the warp in units of thread (concept: MmaSimtPolicy)
+    typename Policy_>
+class MmaSimtTileIteratorWithResidual<
+    Shape_,
+    Operand::kA,
+    Element_,
+    layout::ColumnMajor,
+    Policy_> {
+ public:
   static int const kIterations = 8;
 
   /// Shape of tile to load (concept: MatrixShape)
@@ -123,36 +127,42 @@ public:
   // Derived quantities
   //
 
-  static_assert(!(Shape::kRow % Policy::WarpShape::kRow),
-    "The warp-level GEMM M size must be divisible by the number of threads arranged along the M dimension.");
+  static_assert(
+      !(Shape::kRow % Policy::WarpShape::kRow),
+      "The warp-level GEMM M size must be divisible by the number of threads arranged along the M dimension.");
 
   static_assert(Shape::kRow > 0, "Shape::kRow must be greater than zero.");
-  static_assert(Shape::kColumn > 0, "Shape::kColumn must be greater than zero.");
-  static_assert(Policy::WarpShape::kRow > 0, "Policy::WarpShape::kRow must be greater than zero.");
-  static_assert(Shape::kRow / Policy::WarpShape::kRow > 0, "Shape::kRow / Policy::WarpShape::kRow must be greater than zero.");
+  static_assert(
+      Shape::kColumn > 0,
+      "Shape::kColumn must be greater than zero.");
+  static_assert(
+      Policy::WarpShape::kRow > 0,
+      "Policy::WarpShape::kRow must be greater than zero.");
+  static_assert(
+      Shape::kRow / Policy::WarpShape::kRow > 0,
+      "Shape::kRow / Policy::WarpShape::kRow must be greater than zero.");
 
   /// Thread-level shape of a fragment
-  using ThreadShape = MatrixShape<
-    Shape::kRow / Policy::WarpShape::kRow,
-    Shape::kColumn
-  >;
+  using ThreadShape =
+      MatrixShape<Shape::kRow / Policy::WarpShape::kRow, Shape::kColumn>;
 
-  static_assert(!(ThreadShape::kRow % Policy::LaneMmaShape::kM),
-    "Thread-level GEMM must be divisible by Policy::LaneMmaShape.");
+  static_assert(
+      !(ThreadShape::kRow % Policy::LaneMmaShape::kM),
+      "Thread-level GEMM must be divisible by Policy::LaneMmaShape.");
 
   /// Number of individual loads
   using Iterations = MatrixShape<
-    ThreadShape::kRow / Policy::LaneMmaShape::kM,
-    ThreadShape::kColumn
-  >;
+      ThreadShape::kRow / Policy::LaneMmaShape::kM,
+      ThreadShape::kColumn>;
 
   /// Fragment object holding a thread's part of a tile
   using Fragment = Array<Element, ThreadShape::kCount>;
 
-private:
-
+ private:
   /// Internal reference
-  cutlass::TensorRef<Array<Element, Policy::LaneMmaShape::kM>, layout::ColumnMajor> ref_;
+  cutlass::
+      TensorRef<Array<Element, Policy::LaneMmaShape::kM>, layout::ColumnMajor>
+          ref_;
 
   /// residual access
   bool is_residual_;
@@ -162,119 +172,116 @@ private:
 
   int iterations_;
 
-public:
-
+ public:
   /// Default ctor constructs null iterator
   CUTLASS_HOST_DEVICE
-  MmaSimtTileIteratorWithResidual(): is_residual_(false), iterations_(0) { }
+  MmaSimtTileIteratorWithResidual() : is_residual_(false), iterations_(0) {}
 
   /// Constructor from TensorRef
   CUTLASS_HOST_DEVICE
-  MmaSimtTileIteratorWithResidual(
-    TensorRef ref,
-    int lane_id
-  ): is_residual_(false), iterations_(0) {
-
+  MmaSimtTileIteratorWithResidual(TensorRef ref, int lane_id)
+      : is_residual_(false), iterations_(0) {
     // compute offset based on thread ID and lane layout
     typename Policy::LaneLayout lane_layout = Policy::get_lane_layout();
 
-    MatrixCoord lane_offset = lane_layout.inverse(lane_id) *
-      MatrixCoord(Policy::LaneMmaShape::kM, 0);
+    MatrixCoord lane_offset =
+        lane_layout.inverse(lane_id) * MatrixCoord(Policy::LaneMmaShape::kM, 0);
 
     ref.add_coord_offset(lane_offset);
 
     ref_.reset(
-      reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM> *>(ref.data()),
-      ref.stride(0) / Policy::LaneMmaShape::kM);
+        reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM>*>(ref.data()),
+        ref.stride(0) / Policy::LaneMmaShape::kM);
   }
   CUTLASS_HOST_DEVICE
   MmaSimtTileIteratorWithResidual(
-    TensorRef ref,
-    TensorCoord extent,
-    int lane_id
-  ): is_residual_(false), iterations_(0) {
-
+      TensorRef ref,
+      TensorCoord extent,
+      int lane_id)
+      : is_residual_(false), iterations_(0) {
     // compute offset based on thread ID and lane layout
     typename Policy::LaneLayout lane_layout = Policy::get_lane_layout();
 
-    MatrixCoord lane_offset = lane_layout.inverse(lane_id) *
-      MatrixCoord(Policy::LaneMmaShape::kM, 0);
+    MatrixCoord lane_offset =
+        lane_layout.inverse(lane_id) * MatrixCoord(Policy::LaneMmaShape::kM, 0);
 
     ref.add_coord_offset(lane_offset);
 
     ref_.reset(
-      reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM> *>(ref.data()),
-      ref.stride(0) / Policy::LaneMmaShape::kM);
+        reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM>*>(ref.data()),
+        ref.stride(0) / Policy::LaneMmaShape::kM);
 
     typename TensorCoord::Index residual_size =
-      extent.column() % (kIterations * Shape::kColumn);
-    if(residual_size) {
+        extent.column() % (kIterations * Shape::kColumn);
+    if (residual_size) {
       is_residual_ = true;
-      residual_offset_ = make_Coord(0, residual_size - kIterations * Shape::kColumn);
+      residual_offset_ =
+          make_Coord(0, residual_size - kIterations * Shape::kColumn);
     }
   }
 
-
   /// Adds a pointer offset to internal pointer(s) to advance through memory
   CUTLASS_HOST_DEVICE
-  MmaSimtTileIteratorWithResidual &add_pointer_offset(LongIndex offset) {
+  MmaSimtTileIteratorWithResidual& add_pointer_offset(LongIndex offset) {
     ref_.add_pointer_offset(offset);
     return *this;
   }
 
-  /// Advances an iterator along logical dimensions of matrix in units of whole tiles
+  /// Advances an iterator along logical dimensions of matrix in units of whole
+  /// tiles
   CUTLASS_HOST_DEVICE
-  MmaSimtTileIteratorWithResidual &add_tile_offset(TensorCoord const &coord) {
-
-    ref_.add_coord_offset({
-      coord.row() * Shape::kRow / Policy::LaneMmaShape::kM,
-      coord.column() * Shape::kColumn});
+  MmaSimtTileIteratorWithResidual& add_tile_offset(TensorCoord const& coord) {
+    ref_.add_coord_offset(
+        {coord.row() * Shape::kRow / Policy::LaneMmaShape::kM,
+         coord.column() * Shape::kColumn});
 
     return *this;
   }
 
   /// Advances the iterator along the advance dimension
   CUTLASS_HOST_DEVICE
-  MmaSimtTileIteratorWithResidual & operator++() {
+  MmaSimtTileIteratorWithResidual& operator++() {
     ref_.add_coord_offset({0, Shape::kColumn});
     ++iterations_;
 
     if (iterations_ >= kIterations) {
-        if (is_residual_) {
-            is_residual_ = false;
-            ref_.add_coord_offset(residual_offset_);
-        }
-        iterations_ = 0;
+      if (is_residual_) {
+        is_residual_ = false;
+        ref_.add_coord_offset(residual_offset_);
+      }
+      iterations_ = 0;
     }
 
     return *this;
   }
 
-  /// Loads a fragment from memory at the location pointed to by the iterator. (vector loads)
+  /// Loads a fragment from memory at the location pointed to by the iterator.
+  /// (vector loads)
   CUTLASS_HOST_DEVICE
-  void load_with_pointer_offset(Fragment &frag, Index pointer_offset) const {
-    Array<Element, Policy::LaneMmaShape::kM> *dst_ptr =
-      reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM> *>(&frag);
+  void load_with_pointer_offset(Fragment& frag, Index pointer_offset) const {
+    Array<Element, Policy::LaneMmaShape::kM>* dst_ptr =
+        reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM>*>(&frag);
 
     CUTLASS_PRAGMA_UNROLL
     for (int k = 0; k < Iterations::kColumn; ++k) {
       CUTLASS_PRAGMA_UNROLL
       for (int m = 0; m < Iterations::kRow; ++m) {
-
-        // This logic has been replaced with calls to inline PTX to guarantee vectorization.
-        #if 0
+// This logic has been replaced with calls to inline PTX to guarantee
+// vectorization.
+#if 0
         dst_ptr[m + k * Iterations::kRow] =
           *(ref_.data() + ref_.offset({m * Policy::WarpShape::kRow, k}) + pointer_offset / Policy::LaneMmaShape::kM);
-        #endif
+#endif
 
-        auto ptr = ref_.data() + ref_.offset({m * Policy::WarpShape::kRow, k}) + pointer_offset / Policy::LaneMmaShape::kM;
+        auto ptr = ref_.data() + ref_.offset({m * Policy::WarpShape::kRow, k}) +
+            pointer_offset / Policy::LaneMmaShape::kM;
         arch::shared_load(dst_ptr[m + k * Iterations::kRow], ptr);
       }
     }
   }
   /// Loads a fragment from memory at the location pointed to by the iterator.
   CUTLASS_HOST_DEVICE
-  void load(Fragment &frag) const {
+  void load(Fragment& frag) const {
     load_with_pointer_offset(frag, 0);
   }
 
@@ -290,6 +297,6 @@ public:
     // no operation here
   }
 };
-}
-}
-}
+} // namespace warp
+} // namespace gemm
+} // namespace cutlass

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_simt_tile_iterator_residual.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_simt_tile_iterator_residual.h
@@ -243,7 +243,6 @@ public:
         if (is_residual_) {
             is_residual_ = false;
             ref_.add_coord_offset(residual_offset_);
-            PRINT_T0_L0("ITA: End residual (offset %d)", int(residual_offset_.column()));
         }
         iterations_ = 0;
     }

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_simt_tile_iterator_residual.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_simt_tile_iterator_residual.h
@@ -1,0 +1,296 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Iterator over OperandA in shared memory in SIMT cases, used for fused-matmuls
+        Mostly copied from cutlass/gemm/warp/mma_simt_tile_iterator.h
+*/
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/array.h"
+#include "cutlass/tensor_ref.h"
+#include "cutlass/matrix_shape.h"
+
+#include "cutlass/arch/memory_sm75.h"
+
+#include "cutlass/layout/matrix.h"
+
+#include "cutlass/gemm/gemm.h"
+#include "cutlass/gemm/warp/mma_simt_policy.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass {
+namespace gemm {
+namespace warp {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Iterates over operands to warp-level matrix multiply operations targeting SIMT instructions
+///
+/// concept: MutableRandomAccessContiguousTileIteratorConcept
+///
+template <
+  /// Size of the matrix to load (concept: MatrixShape)
+  typename Shape_,
+  /// Operand identity
+  Operand Operand,
+  /// Data type of A elements
+  typename Element_,
+  /// Layout of operand
+  typename Layout_,
+  /// Shape of the warp in units of thread (concept: MmaSimtPolicy)
+  typename Policy_
+>
+class MmaSimtTileIteratorWithResidual;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Specialization for A operands of column-major layouts
+///
+/// Concept: MutableRandomAccessContiguousTileIteratorConcept
+///
+template <
+  /// Size of the matrix to load (concept: MatrixShape)
+  typename Shape_,
+  /// Data type of A elements
+  typename Element_,
+  /// Shape of the warp in units of thread (concept: MmaSimtPolicy)
+  typename Policy_
+>
+class MmaSimtTileIteratorWithResidual<Shape_, Operand::kA, Element_, layout::ColumnMajor, Policy_> {
+public:
+
+  static int const kIterations = 8;
+
+  /// Shape of tile to load (concept: MatrixShape)
+  using Shape = Shape_;
+
+  /// Operand tag
+  static Operand const kOperand = Operand::kA;
+
+  /// Element type
+  using Element = Element_;
+
+  /// Layout of policy
+  using Layout = layout::ColumnMajor;
+
+  /// Decomposition of elements among threads
+  using Policy = Policy_;
+
+  /// TensorRef type for loading element from a tensor
+  using TensorRef = TensorRef<Element, Layout>;
+
+  /// Index type
+  using Index = typename TensorRef::Index;
+
+  /// Long Index type
+  using LongIndex = typename TensorRef::LongIndex;
+
+  /// Coordinate for an element in the tensor
+  using TensorCoord = typename TensorRef::TensorCoord;
+
+  //
+  // Derived quantities
+  //
+
+  static_assert(!(Shape::kRow % Policy::WarpShape::kRow),
+    "The warp-level GEMM M size must be divisible by the number of threads arranged along the M dimension.");
+
+  static_assert(Shape::kRow > 0, "Shape::kRow must be greater than zero.");
+  static_assert(Shape::kColumn > 0, "Shape::kColumn must be greater than zero.");
+  static_assert(Policy::WarpShape::kRow > 0, "Policy::WarpShape::kRow must be greater than zero.");
+  static_assert(Shape::kRow / Policy::WarpShape::kRow > 0, "Shape::kRow / Policy::WarpShape::kRow must be greater than zero.");
+
+  /// Thread-level shape of a fragment
+  using ThreadShape = MatrixShape<
+    Shape::kRow / Policy::WarpShape::kRow,
+    Shape::kColumn
+  >;
+
+  static_assert(!(ThreadShape::kRow % Policy::LaneMmaShape::kM),
+    "Thread-level GEMM must be divisible by Policy::LaneMmaShape.");
+
+  /// Number of individual loads
+  using Iterations = MatrixShape<
+    ThreadShape::kRow / Policy::LaneMmaShape::kM,
+    ThreadShape::kColumn
+  >;
+
+  /// Fragment object holding a thread's part of a tile
+  using Fragment = Array<Element, ThreadShape::kCount>;
+
+private:
+
+  /// Internal reference
+  cutlass::TensorRef<Array<Element, Policy::LaneMmaShape::kM>, layout::ColumnMajor> ref_;
+
+  /// residual access
+  bool is_residual_;
+
+  /// residual offset applied after first block
+  TensorCoord residual_offset_;
+
+  int iterations_;
+
+public:
+
+  /// Default ctor constructs null iterator
+  CUTLASS_HOST_DEVICE
+  MmaSimtTileIteratorWithResidual(): is_residual_(false), iterations_(0) { }
+
+  /// Constructor from TensorRef
+  CUTLASS_HOST_DEVICE
+  MmaSimtTileIteratorWithResidual(
+    TensorRef ref,
+    int lane_id
+  ): is_residual_(false), iterations_(0) {
+
+    // compute offset based on thread ID and lane layout
+    typename Policy::LaneLayout lane_layout = Policy::get_lane_layout();
+
+    MatrixCoord lane_offset = lane_layout.inverse(lane_id) *
+      MatrixCoord(Policy::LaneMmaShape::kM, 0);
+
+    ref.add_coord_offset(lane_offset);
+
+    ref_.reset(
+      reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM> *>(ref.data()),
+      ref.stride(0) / Policy::LaneMmaShape::kM);
+  }
+  CUTLASS_HOST_DEVICE
+  MmaSimtTileIteratorWithResidual(
+    TensorRef ref,
+    TensorCoord extent,
+    int lane_id
+  ): is_residual_(false), iterations_(0) {
+
+    // compute offset based on thread ID and lane layout
+    typename Policy::LaneLayout lane_layout = Policy::get_lane_layout();
+
+    MatrixCoord lane_offset = lane_layout.inverse(lane_id) *
+      MatrixCoord(Policy::LaneMmaShape::kM, 0);
+
+    ref.add_coord_offset(lane_offset);
+
+    ref_.reset(
+      reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM> *>(ref.data()),
+      ref.stride(0) / Policy::LaneMmaShape::kM);
+
+    typename TensorCoord::Index residual_size =
+      extent.column() % (kIterations * Shape::kColumn);
+    if(residual_size) {
+      is_residual_ = true;
+      residual_offset_ = make_Coord(0, residual_size - kIterations * Shape::kColumn);
+    }
+  }
+
+
+  /// Adds a pointer offset to internal pointer(s) to advance through memory
+  CUTLASS_HOST_DEVICE
+  MmaSimtTileIteratorWithResidual &add_pointer_offset(LongIndex offset) {
+    ref_.add_pointer_offset(offset);
+    return *this;
+  }
+
+  /// Advances an iterator along logical dimensions of matrix in units of whole tiles
+  CUTLASS_HOST_DEVICE
+  MmaSimtTileIteratorWithResidual &add_tile_offset(TensorCoord const &coord) {
+
+    ref_.add_coord_offset({
+      coord.row() * Shape::kRow / Policy::LaneMmaShape::kM,
+      coord.column() * Shape::kColumn});
+
+    return *this;
+  }
+
+  /// Advances the iterator along the advance dimension
+  CUTLASS_HOST_DEVICE
+  MmaSimtTileIteratorWithResidual & operator++() {
+    ref_.add_coord_offset({0, Shape::kColumn});
+    ++iterations_;
+
+    if (iterations_ >= kIterations) {
+        if (is_residual_) {
+            is_residual_ = false;
+            ref_.add_coord_offset(residual_offset_);
+            PRINT_T0_L0("ITA: End residual (offset %d)", int(residual_offset_.column()));
+        }
+        iterations_ = 0;
+    }
+
+    return *this;
+  }
+
+  /// Loads a fragment from memory at the location pointed to by the iterator. (vector loads)
+  CUTLASS_HOST_DEVICE
+  void load_with_pointer_offset(Fragment &frag, Index pointer_offset) const {
+    Array<Element, Policy::LaneMmaShape::kM> *dst_ptr =
+      reinterpret_cast<Array<Element, Policy::LaneMmaShape::kM> *>(&frag);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int k = 0; k < Iterations::kColumn; ++k) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int m = 0; m < Iterations::kRow; ++m) {
+
+        // This logic has been replaced with calls to inline PTX to guarantee vectorization.
+        #if 0
+        dst_ptr[m + k * Iterations::kRow] =
+          *(ref_.data() + ref_.offset({m * Policy::WarpShape::kRow, k}) + pointer_offset / Policy::LaneMmaShape::kM);
+        #endif
+
+        auto ptr = ref_.data() + ref_.offset({m * Policy::WarpShape::kRow, k}) + pointer_offset / Policy::LaneMmaShape::kM;
+        arch::shared_load(dst_ptr[m + k * Iterations::kRow], ptr);
+      }
+    }
+  }
+  /// Loads a fragment from memory at the location pointed to by the iterator.
+  CUTLASS_HOST_DEVICE
+  void load(Fragment &frag) const {
+    load_with_pointer_offset(frag, 0);
+  }
+
+  /// Notify the iterator which k-group it is currently pointing to.
+  ///
+  /// This does not advance the iterator. Rather, it overrides its internal
+  /// tracking with constant-valued k-group index to enable the compiler to
+  /// fold constants and achieve more efficient code.
+  ///
+  /// This is used by some nontrivial permuted layouts.
+  CUTLASS_DEVICE
+  void set_kgroup_index(int k_group) {
+    // no operation here
+  }
+};
+}
+}
+}


### PR DESCRIPTION
Implemented for:
- SIMT (P100 + V100 f32)
- A100

NOTE: In any case, when using f16, we still want `num_keys % 2 == 0` to read entire smem banks at once.
For this special case, and for V100, we will pad the inputs (in a further PR, because it also requires to implement masking)

**TEST PLAN**
- Tested on P100/V100 that it does not change the runtime of the kernels
- Added test cases

<details>
<summary>A100 perf</summary>
20134bb = this PR
170f9b0ef1cea3a543c8c507a375469826c822c5 = main

```
[-------------------------------- attention (attn_bias=<class 'NoneType'>) --------------------------------]
                                         |  20134bb  |  vanilla  |  170f9b0ef1cea3a543c8c507a375469826c822c5
1 threads: -------------------------------------------------------------------------------------------------
      f16 fwd_gen B=256, M=128, K=16     |     37.6  |     60.5  |                     38.0                 
      f32 fwd_gen B=256, M=128, K=16     |     92.3  |    125.3  |                     92.4                 
      f16 fwd_gen B=256, M=128, K=32     |     38.6  |     60.6  |                     39.0                 
      f32 fwd_gen B=256, M=128, K=32     |     93.9  |    136.4  |                     94.0                 
      f16 fwd_gen B=256, M=128, K=64     |     42.6  |     60.6  |                     42.7                 
      f32 fwd_gen B=256, M=128, K=64     |    105.8  |    158.2  |                    105.6                 
      f16 fwd_gen B=256, M=128, K=128    |     53.7  |     61.1  |                     53.5                 
      f32 fwd_gen B=256, M=128, K=128    |    131.3  |    215.7  |                    131.6                 
      f16 fwd_gen B=256, M=512, K=16     |    418.5  |    475.6  |                    422.9                 
      f32 fwd_gen B=256, M=512, K=16     |   1228.8  |   1567.6  |                   1220.1                 
      f16 fwd_gen B=256, M=512, K=32     |    424.3  |    496.1  |                    429.2                 
      f32 fwd_gen B=256, M=512, K=32     |   1248.3  |   1680.6  |                   1243.1                 
      f16 fwd_gen B=256, M=512, K=64     |    468.8  |    540.5  |                    474.5                 
      f32 fwd_gen B=256, M=512, K=64     |   1416.9  |   1925.0  |                   1414.3                 
      f16 fwd_gen B=256, M=512, K=128    |    565.9  |    615.3  |                    572.7                 
      f32 fwd_gen B=256, M=512, K=128    |   1730.7  |   2420.0  |                   1726.9                 
      f16 fwd_gen B=256, M=1024, K=16    |   1595.2  |   1870.4  |                   1618.2                 
      f32 fwd_gen B=256, M=1024, K=16    |   4861.6  |   5971.4  |                   4837.5                 
      f16 fwd_gen B=256, M=1024, K=32    |   1620.1  |   1910.6  |                   1641.1                 
      f32 fwd_gen B=256, M=1024, K=32    |   4907.5  |   6393.3  |                   4884.9                 
      f16 fwd_gen B=256, M=1024, K=64    |   1757.2  |   2009.1  |                   1780.6                 
      f32 fwd_gen B=256, M=1024, K=64    |   5549.1  |   7334.9  |                   5522.7                 
      f16 fwd_gen B=256, M=1024, K=128   |   2099.7  |   2233.5  |                   2122.9                 
      f32 fwd_gen B=256, M=1024, K=128   |   6824.5  |   9201.0  |                   6797.3                 
      f16 fwd_gen B=1024, M=128, K=16    |    118.6  |    160.8  |                    120.1                 
      f32 fwd_gen B=1024, M=128, K=16    |    328.9  |    427.6  |                    328.6                 
      f16 fwd_gen B=1024, M=128, K=32    |    123.6  |    169.7  |                    125.0                 
      f32 fwd_gen B=1024, M=128, K=32    |    338.5  |    475.8  |                    338.2                 
      f16 fwd_gen B=1024, M=128, K=64    |    156.7  |    216.3  |                    157.6                 
      f32 fwd_gen B=1024, M=128, K=64    |    392.8  |    560.5  |                    391.3                 
      f16 fwd_gen B=1024, M=128, K=128   |    211.7  |    292.1  |                    213.1                 
      f32 fwd_gen B=1024, M=128, K=128   |    487.6  |    730.3  |                    486.9                 
      f32 fwd_gen B=1024, M=197, K=80    |   1357.4  |   1690.0  |                                          
      f32 fwd_gen B=1024, M=197, K=88    |   1365.8  |   1751.1  |                                          
      f16 fwd_gen B=1024, M=512, K=16    |   1636.2  |   1788.8  |                   1650.0                 
      f32 fwd_gen B=1024, M=512, K=16    |   4926.3  |   6053.6  |                   4867.4                 
      f16 fwd_gen B=1024, M=512, K=32    |   1661.0  |   1862.7  |                   1677.2                 
      f32 fwd_gen B=1024, M=512, K=32    |   4971.2  |   6461.2  |                   4928.5                 
      f16 fwd_gen B=1024, M=512, K=64    |   1818.2  |   2028.8  |                   1835.9                 
      f32 fwd_gen B=1024, M=512, K=64    |   5602.4  |   7430.0  |                   5590.6                 
      f16 fwd_gen B=1024, M=512, K=128   |   2203.9  |   2337.9  |                   2221.7                 
      f32 fwd_gen B=1024, M=512, K=128   |   6849.9  |   9419.4  |                   6805.9                 
      f16 fwd_gen B=1024, M=1024, K=16   |   6288.4  |   7358.6  |                   6392.7                 
      f32 fwd_gen B=1024, M=1024, K=16   |  19362.6  |  23814.2  |                  19232.9                 
      f16 fwd_gen B=1024, M=1024, K=32   |   6371.6  |   7529.5  |                   6473.6                 
      f32 fwd_gen B=1024, M=1024, K=32   |  19524.6  |  25486.8  |                  19401.5                 
      f16 fwd_gen B=1024, M=1024, K=64   |   6965.8  |   8023.8  |                   7078.2                 
      f32 fwd_gen B=1024, M=1024, K=64   |  22068.0  |  29236.0  |                  21952.1                 
      f16 fwd_gen B=1024, M=1024, K=128  |   8402.0  |   8794.6  |                   8498.2                 
      f32 fwd_gen B=1024, M=1024, K=128  |  27142.1  |  36672.6  |                  27032.3                 

Times are in microseconds (us).

[--------------------------- attention backward (attn_bias=<class 'NoneType'>) ----------------------------]
                                         |  20134bb  |  vanilla  |  170f9b0ef1cea3a543c8c507a375469826c822c5
1 threads: -------------------------------------------------------------------------------------------------
      f16 fwd_gen B=256, M=128, K=16     |    130.5  |    155.8  |                    120.6                 
      f32 fwd_gen B=256, M=128, K=16     |    148.9  |    352.0  |                    148.7                 
      f16 fwd_gen B=256, M=128, K=32     |    122.2  |    155.5  |                    129.9                 
      f32 fwd_gen B=256, M=128, K=32     |    169.2  |    378.3  |                    170.1                 
      f16 fwd_gen B=256, M=128, K=64     |    139.3  |    154.3  |                    140.5                 
      f32 fwd_gen B=256, M=128, K=64     |    238.4  |    426.5  |                    238.9                 
      f16 fwd_gen B=256, M=128, K=128    |    269.0  |    209.5  |                    268.9                 
      f32 fwd_gen B=256, M=128, K=128    |    487.6  |    550.6  |                    486.4                 
      f16 fwd_gen B=256, M=512, K=16     |    745.9  |   1144.7  |                    749.0                 
      f32 fwd_gen B=256, M=512, K=16     |   2048.9  |   4322.0  |                   2026.7                 
      f16 fwd_gen B=256, M=512, K=32     |    908.7  |   1205.5  |                    921.9                 
      f32 fwd_gen B=256, M=512, K=32     |   2341.5  |   4501.4  |                   2342.1                 
      f16 fwd_gen B=256, M=512, K=64     |   1374.3  |   1343.4  |                   1380.3                 
      f32 fwd_gen B=256, M=512, K=64     |   3010.8  |   4875.2  |                   3006.3                 
      f16 fwd_gen B=256, M=512, K=128    |   2703.0  |   1637.6  |                   2689.2                 
      f32 fwd_gen B=256, M=512, K=128    |   6302.7  |   5620.9  |                   6314.0                 
      f16 fwd_gen B=256, M=1024, K=16    |   2931.6  |   4139.3  |                   2968.2                 
      f32 fwd_gen B=256, M=1024, K=16    |   8638.7  |  16437.1  |                   8641.6                 
      f16 fwd_gen B=256, M=1024, K=32    |   3755.4  |   4289.1  |                   3778.9                 
      f32 fwd_gen B=256, M=1024, K=32    |   9128.0  |  16995.2  |                   9123.7                 
      f16 fwd_gen B=256, M=1024, K=64    |   4903.9  |   4585.3  |                   4927.8                 
      f32 fwd_gen B=256, M=1024, K=64    |  11917.1  |  18157.8  |                  11923.2                 
      f16 fwd_gen B=256, M=1024, K=128   |   9642.0  |   5251.4  |                   9660.8                 
      f32 fwd_gen B=256, M=1024, K=128   |  24082.0  |  20534.3  |                  24086.3                 
      f16 fwd_gen B=1024, M=128, K=16    |    233.4  |    384.9  |                    236.1                 
      f32 fwd_gen B=1024, M=128, K=16    |    454.3  |   1188.1  |                    455.1                 
      f16 fwd_gen B=1024, M=128, K=32    |    309.3  |    443.5  |                    310.4                 
      f32 fwd_gen B=1024, M=128, K=32    |    555.7  |   1295.3  |                    556.3                 
      f16 fwd_gen B=1024, M=128, K=64    |    527.5  |    575.0  |                    530.7                 
      f32 fwd_gen B=1024, M=128, K=64    |    847.1  |   1508.7  |                    847.8                 
      f16 fwd_gen B=1024, M=128, K=128   |   1048.2  |    873.6  |                   1055.1                 
      f32 fwd_gen B=1024, M=128, K=128   |   1676.1  |   1930.5  |                   1677.1                 
      f32 fwd_gen B=1024, M=197, K=80    |   4536.9  |   4039.6  |                                          
      f32 fwd_gen B=1024, M=197, K=88    |   4712.1  |   4145.2  |                                          
      f16 fwd_gen B=1024, M=512, K=16    |   2557.5  |   4286.4  |                   2569.6                 
      f32 fwd_gen B=1024, M=512, K=16    |   6542.1  |  16671.1  |                   6576.9                 
      f16 fwd_gen B=1024, M=512, K=32    |   3539.7  |   4590.1  |                   3617.0                 
      f32 fwd_gen B=1024, M=512, K=32    |   7575.2  |  17315.8  |                   7592.2                 
      f16 fwd_gen B=1024, M=512, K=64    |   4851.0  |   5120.0  |                   4887.9                 
      f32 fwd_gen B=1024, M=512, K=64    |   9749.5  |  18744.3  |                   9770.8                 
      f16 fwd_gen B=1024, M=512, K=128   |  10211.1  |   6306.9  |                  10244.4                 
      f32 fwd_gen B=1024, M=512, K=128   |  20129.6  |  21758.5  |                  20137.4                 
      f16 fwd_gen B=1024, M=1024, K=16   |  11529.9  |  16469.8  |                  11884.5                 
      f32 fwd_gen B=1024, M=1024, K=16   |  27368.4  |  65589.9  |                  27439.5                 
      f16 fwd_gen B=1024, M=1024, K=32   |  13161.6  |  17103.3  |                  13268.9                 
      f32 fwd_gen B=1024, M=1024, K=32   |  28990.4  |  67748.9  |                  29158.1                 
      f16 fwd_gen B=1024, M=1024, K=64   |  17218.7  |  18340.9  |                  17346.1                 
      f32 fwd_gen B=1024, M=1024, K=64   |  36985.3  |  72579.6  |                  36973.8                 
      f16 fwd_gen B=1024, M=1024, K=128  |  37653.3  |  20819.3  |                  37998.2                 
      f32 fwd_gen B=1024, M=1024, K=128  |  76628.1  |  81978.5  |                  76642.1                 

Times are in microseconds (us).
```

</details>