### PR TITLE
AttentionForward: Change block size to 64x64

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/epilogue_rescale_output.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/epilogue_rescale_output.h
@@ -73,7 +73,7 @@ template <
     typename ElementCompute_, ///< Data type used to compute linear combination
     bool isFirst,
     bool isLast,
-    typename FragmentAlphaBeta_ = Array<ElementCompute_, 32>,
+    typename FragmentAlphaBeta_,
     FloatRoundStyle Round = FloatRoundStyle::round_to_nearest>
 class MemoryEfficientAttentionNormalize {
  public:


### PR DESCRIPTION
Significant performance improvements for `K <= 64`. Performance is worse for `K >= 64`. Let's keep this as a TODO (https://github.com/facebookresearch/xformers/issues/380) for later

30e73b1 or 170f9b0ef1cea3a543c8c507a375469826c822c5: reference
7e34b16: This PR

**A100**
```
[---------------- attention (attn_bias=<class 'NoneType'>) ---------------]
                                         |  7e34b16  |  vanilla  |  30e73b1
1 threads: ----------------------------------------------------------------
      f16 fwd_gen B=256, M=128, K=16     |     42.3  |     61.6  |     37.9
      f32 fwd_gen B=256, M=128, K=16     |     73.4  |    159.2  |     89.8
      f16 fwd_gen B=256, M=128, K=32     |     43.7  |     61.8  |     38.9
      f32 fwd_gen B=256, M=128, K=32     |     75.3  |    173.4  |     91.3
      f16 fwd_gen B=256, M=128, K=64     |     52.6  |     62.7  |     42.9
      f32 fwd_gen B=256, M=128, K=64     |     87.0  |    199.8  |    103.2
      f16 fwd_gen B=256, M=128, K=128    |     76.2  |     77.0  |     54.5
      f32 fwd_gen B=256, M=128, K=128    |    145.5  |    264.5  |    130.1
      f16 fwd_gen B=256, M=512, K=16     |    473.1  |    542.8  |    422.2
      f32 fwd_gen B=256, M=512, K=16     |    924.4  |   1893.0  |   1226.8
      f16 fwd_gen B=256, M=512, K=32     |    481.1  |    556.3  |    428.4
      f32 fwd_gen B=256, M=512, K=32     |    940.2  |   2040.9  |   1242.6
      f16 fwd_gen B=256, M=512, K=64     |    561.0  |    605.5  |    474.5
      f32 fwd_gen B=256, M=512, K=64     |   1109.1  |   2352.9  |   1412.1
      f16 fwd_gen B=256, M=512, K=128    |    824.0  |    674.5  |    572.4
      f32 fwd_gen B=256, M=512, K=128    |   1888.7  |   2962.8  |   1732.6
      f16 fwd_gen B=256, M=1024, K=16    |   1763.8  |   2204.4  |   1614.3
      f32 fwd_gen B=256, M=1024, K=16    |   3559.7  |   7198.0  |   4840.4
      f16 fwd_gen B=256, M=1024, K=32    |   1784.0  |   2226.2  |   1637.4
      f32 fwd_gen B=256, M=1024, K=32    |   3603.3  |   7764.0  |   4880.3
      f16 fwd_gen B=256, M=1024, K=64    |   2024.9  |   2377.5  |   1778.2
      f32 fwd_gen B=256, M=1024, K=64    |   4233.6  |   8975.9  |   5531.9
      f16 fwd_gen B=256, M=1024, K=128   |   3008.5  |   2593.8  |   2121.4
      f32 fwd_gen B=256, M=1024, K=128   |   7286.8  |  11309.7  |   6799.0
      f16 fwd_gen B=1024, M=128, K=16    |    134.1  |    186.6  |    119.7
      f32 fwd_gen B=1024, M=128, K=16    |    245.8  |    513.3  |    320.1
      f16 fwd_gen B=1024, M=128, K=32    |    140.0  |    195.2  |    124.3
      f32 fwd_gen B=1024, M=128, K=32    |    253.2  |    567.9  |    328.8
      f16 fwd_gen B=1024, M=128, K=64    |    171.8  |    238.4  |    158.9
      f32 fwd_gen B=1024, M=128, K=64    |    308.3  |    668.1  |    382.3
      f16 fwd_gen B=1024, M=128, K=128   |    258.0  |    311.7  |    212.5
      f32 fwd_gen B=1024, M=128, K=128   |    519.9  |    875.0  |    482.9
      f16 fwd_gen B=1024, M=512, K=16    |   1795.2  |   2013.6  |   1660.2
      f32 fwd_gen B=1024, M=512, K=16    |   3579.3  |   7256.2  |   4930.7
      f16 fwd_gen B=1024, M=512, K=32    |   1822.7  |   2061.0  |   1681.1
      f32 fwd_gen B=1024, M=512, K=32    |   3635.3  |   7830.1  |   4985.3
      f16 fwd_gen B=1024, M=512, K=64    |   2058.5  |   2263.1  |   1839.9
      f32 fwd_gen B=1024, M=512, K=64    |   4286.0  |   9081.3  |   5641.2
      f16 fwd_gen B=1024, M=512, K=128   |   3088.5  |   2564.9  |   2227.4
      f32 fwd_gen B=1024, M=512, K=128   |   7345.9  |  11519.0  |   6872.3
      f16 fwd_gen B=1024, M=1024, K=16   |   6983.0  |   8662.2  |   6360.1
      f32 fwd_gen B=1024, M=1024, K=16   |  14046.0  |  28668.7  |  19290.6
      f16 fwd_gen B=1024, M=1024, K=32   |   7041.0  |   8790.6  |   6442.5
      f32 fwd_gen B=1024, M=1024, K=32   |  14194.4  |  30908.9  |  19454.6
      f16 fwd_gen B=1024, M=1024, K=64   |   7864.0  |   9423.6  |   7044.9
      f32 fwd_gen B=1024, M=1024, K=64   |  16694.7  |  35754.8  |  22022.8
      f16 fwd_gen B=1024, M=1024, K=128  |  11945.6  |  10256.1  |   8499.4
      f32 fwd_gen B=1024, M=1024, K=128  |  28824.7  |  45047.2  |  27081.4
      f32 fwd_gen B=1024, M=197, K=80    |           |   1689.6  |   1353.8
      f32 fwd_gen B=1024, M=197, K=88    |           |   1750.5  |   1365.7

Times are in microseconds (us).
```

**V100 / P100**
```
[------------------------------------------ attention (attn_bias=<class 'NoneType'>) -----------------------------------------]
                                                            |  7e34b16  |  170f9b0ef1cea3a543c8c507a375469826c822c5  |  vanilla
1 threads: --------------------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f16 fwd_gen B=256, M=128, K=16    |    192.4  |                    269.6                   |    220.8
                          f32 fwd_gen B=256, M=128, K=16    |    178.7  |                    275.2                   |    257.5
                          f16 fwd_gen B=256, M=128, K=32    |    217.6  |                    292.9                   |    240.8
                          f32 fwd_gen B=256, M=128, K=32    |    204.0  |                    300.9                   |    287.0
                          f16 fwd_gen B=256, M=128, K=64    |    272.2  |                    352.2                   |    289.8
                          f32 fwd_gen B=256, M=128, K=64    |    259.7  |                    353.4                   |    340.6
                          f16 fwd_gen B=256, M=128, K=128   |    532.1  |                    473.7                   |    381.2
                          f32 fwd_gen B=256, M=128, K=128   |    492.4  |                    463.6                   |    452.7
                          f16 fwd_gen B=256, M=512, K=16    |   2709.1  |                   3944.7                   |   2995.5
                          f32 fwd_gen B=256, M=512, K=16    |   2504.6  |                   3984.6                   |   3482.4
                          f16 fwd_gen B=256, M=512, K=32    |   3055.0  |                   4297.2                   |   3275.1
                          f32 fwd_gen B=256, M=512, K=32    |   2859.0  |                   4309.3                   |   3733.5
                          f16 fwd_gen B=256, M=512, K=64    |   3963.1  |                   5277.8                   |   3914.8
                          f32 fwd_gen B=256, M=512, K=64    |   3810.4  |                   5148.1                   |   4340.8
                          f16 fwd_gen B=256, M=512, K=128   |   7653.6  |                   7169.0                   |   5034.8
                          f32 fwd_gen B=256, M=512, K=128   |   6964.2  |                   6970.7                   |   5638.2
                          f16 fwd_gen B=256, M=1024, K=16   |  10633.1  |                  15608.9                   |  12005.9
                          f32 fwd_gen B=256, M=1024, K=16   |   9878.6  |                  15627.5                   |  13543.0
                          f16 fwd_gen B=256, M=1024, K=32   |  12186.3  |                  17237.0                   |  13130.7
                          f32 fwd_gen B=256, M=1024, K=32   |  11349.0  |                  17174.9                   |  14693.4
                          f16 fwd_gen B=256, M=1024, K=64   |  15869.3  |                  20761.5                   |  15391.0
                          f32 fwd_gen B=256, M=1024, K=64   |  15133.3  |                  20332.4                   |  16948.2
                          f16 fwd_gen B=256, M=1024, K=128  |  30273.8  |                  28561.2                   |  19739.0
                          f32 fwd_gen B=256, M=1024, K=128  |  27843.4  |                  27649.7                   |  21497.9
                          f16 fwd_gen B=1024, M=197, K=80   |   5414.6  |                                            |   3614.7
                          f32 fwd_gen B=1024, M=197, K=80   |   5040.9  |                                            |   3901.8
                          f16 fwd_gen B=1024, M=197, K=88   |   5704.4  |                                            |   3738.6
                          f32 fwd_gen B=1024, M=197, K=88   |   5302.3  |                                            |   4075.3
  (Tesla_V100_SXM2_16GB)  f16 fwd_gen B=256, M=128, K=16    |     63.3  |                     62.9                   |    111.0
                          f32 fwd_gen B=256, M=128, K=16    |    100.8  |                    134.7                   |    118.3
                          f16 fwd_gen B=256, M=128, K=32    |     63.5  |                     65.2                   |    103.4
                          f32 fwd_gen B=256, M=128, K=32    |    115.8  |                    149.7                   |    142.9
                          f16 fwd_gen B=256, M=128, K=64    |     86.8  |                     81.7                   |    103.7
                          f32 fwd_gen B=256, M=128, K=64    |    152.1  |                    177.7                   |    199.1
                          f16 fwd_gen B=256, M=128, K=128   |    159.8  |                    109.8                   |    134.2
                          f32 fwd_gen B=256, M=128, K=128   |    294.2  |                    240.3                   |    322.0
                          f16 fwd_gen B=256, M=512, K=16    |    802.1  |                    825.9                   |    794.6
                          f32 fwd_gen B=256, M=512, K=16    |   1397.4  |                   1967.6                   |   1768.2
                          f16 fwd_gen B=256, M=512, K=32    |    744.7  |                    848.7                   |    836.3
                          f32 fwd_gen B=256, M=512, K=32    |   1631.6  |                   2170.2                   |   1925.0
                          f16 fwd_gen B=256, M=512, K=64    |    878.6  |                    962.5                   |    984.9
                          f32 fwd_gen B=256, M=512, K=64    |   2206.5  |                   2569.8                   |   2236.7
                          f16 fwd_gen B=256, M=512, K=128   |   1888.9  |                   1242.9                   |   1142.7
                          f32 fwd_gen B=256, M=512, K=128   |   4283.9  |                   3536.7                   |   3567.3
                          f16 fwd_gen B=256, M=1024, K=16   |   2825.5  |                   3188.0                   |   3334.2
                          f32 fwd_gen B=256, M=1024, K=16   |   6002.2  |                   7651.4                   |   7087.0
                          f16 fwd_gen B=256, M=1024, K=32   |   2882.0  |                   3250.7                   |   3460.7
                          f32 fwd_gen B=256, M=1024, K=32   |   6412.2  |                   8408.9                   |   7675.6
                          f16 fwd_gen B=256, M=1024, K=64   |   3554.3  |                   3666.4                   |   3812.1
                          f32 fwd_gen B=256, M=1024, K=64   |   9725.5  |                  10087.3                   |   8891.9
                          f16 fwd_gen B=256, M=1024, K=128  |   7813.2  |                   4751.5                   |   4210.6
                          f32 fwd_gen B=256, M=1024, K=128  |  16293.2  |                  14023.9                   |  14304.6

Times are in microseconds (us).
```