### PR TITLE
MemEffAttention: Add causal support

### DIFF
--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -4,11 +4,11 @@ TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention(Tensor query, Tensor key, Tensor value, bool compute_logsumexp, Tensor? attn_bias, float p) -> (Tensor, Tensor, int, int)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention_forward_generic(Tensor query, Tensor key, Tensor value, bool compute_logsumexp, Tensor? attn_bias, float p) -> (Tensor, Tensor, int, int)"));
+      "xformers::efficient_attention_forward_generic(Tensor query, Tensor key, Tensor value, bool compute_logsumexp, Tensor? attn_bias, float p, bool causal) -> (Tensor, Tensor, int, int)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, Tensor? attn_bias, float p, int rng_seed, int rng_offset) -> (Tensor, Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention_backward_generic(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, Tensor? attn_bias, float p, int rng_seed, int rng_offset) -> (Tensor, Tensor, Tensor)"));
+      "xformers::efficient_attention_backward_generic(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, Tensor? attn_bias, float p, int rng_seed, int rng_offset, bool causal) -> (Tensor, Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::_temp_dropout(Tensor out, float p) -> Tensor"));
 }

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -12,7 +12,8 @@ mem_efficient_attention_backward_generic(
     const c10::optional<at::Tensor>& attn_bias_,
     double p,
     int64_t rng_seed,
-    int64_t rng_offset) {
+    int64_t rng_offset,
+    bool causal) {
   TORCH_CHECK(query.dim() == grad_out_.dim());
   TORCH_CHECK(query.dim() == key.dim());
   TORCH_CHECK(query.dim() == 3);
@@ -151,6 +152,7 @@ mem_efficient_attention_backward_generic(
             params.num_queries = query.size(1);
             params.num_keys = key.size(1);
             params.num_batches = B;
+            params.causal = causal;
 
             constexpr auto kernel_fn = attention_kernel_backward_batched<AK>;
 

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -8,7 +8,8 @@ efficient_attention_forward_generic(
     const at::Tensor& value,
     bool compute_logsumexp,
     const c10::optional<at::Tensor>& attn_bias_,
-    double p) {
+    double p,
+    bool causal) {
   TORCH_CHECK(p == 0.0, "Dropout is not supported at the moment");
   TORCH_CHECK(
       !attn_bias_.has_value(), "attn_bias is not supported at the moment");
@@ -182,6 +183,7 @@ efficient_attention_forward_generic(
                   p.num_queries = query.size(1);
                   p.num_keys = key.size(1);
                   p.num_batches = B;
+                  p.causal = causal;
                   kernel_fn<<<
                       p.getBlocksGrid(),
                       p.getThreadsGrid(),


### PR DESCRIPTION
<details>
<summary>V100/P100 perf fw</summary>

```
[----------------------------------- attention (attn_bias=<class 'NoneType'>) ----------------------------------]
                                                             |  1722b913_causal  |  74460174_outputrf  |  vanilla
1 threads: ------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f32 fwd_gen B=256, M=128, K=16     |         162.3     |          163.0      |    300.5
                          f16 fwd_gen B=256, M=128, K=16     |         168.0     |          167.1      |    221.2
                          f32 fwd_gen B=256, M=128, K=32     |         177.6     |          178.3      |    284.3
                          f16 fwd_gen B=256, M=128, K=32     |         196.4     |          196.7      |    239.2
                          f32 fwd_gen B=256, M=128, K=64     |         236.2     |          235.8      |    337.4
                          f16 fwd_gen B=256, M=128, K=64     |         252.3     |          251.5      |    287.1
                          f32 fwd_gen B=256, M=128, K=128    |         461.7     |          456.6      |    447.8
                          f16 fwd_gen B=256, M=128, K=128    |         464.6     |          465.7      |    376.3
                          f32 fwd_gen B=256, M=128, K=256    |         938.4     |          928.3      |    925.2
                          f16 fwd_gen B=256, M=128, K=256    |         911.5     |          919.2      |    665.5
                          f32 fwd_gen B=256, M=512, K=16     |        2097.2     |         2077.6      |   3431.6
                          f16 fwd_gen B=256, M=512, K=16     |        2299.8     |         2273.7      |   2979.2
                          f32 fwd_gen B=256, M=512, K=32     |        2452.6     |         2428.2      |   3679.6
                          f16 fwd_gen B=256, M=512, K=32     |        2699.7     |         2669.1      |   3255.9
                          f32 fwd_gen B=256, M=512, K=64     |        3182.0     |         3117.4      |   4332.0
                          f16 fwd_gen B=256, M=512, K=64     |        3532.8     |         3507.0      |   3818.5
                          f32 fwd_gen B=256, M=512, K=128    |        6368.4     |         6234.7      |   5557.7
                          f16 fwd_gen B=256, M=512, K=128    |        6885.2     |         6803.8      |   4972.9
                          f32 fwd_gen B=256, M=512, K=256    |       13686.6     |        13458.7      |   9817.9
                          f16 fwd_gen B=256, M=512, K=256    |       13980.2     |        13796.8      |   8889.7
                          f32 fwd_gen B=256, M=1024, K=16    |        8402.2     |         8222.4      |  13489.7
                          f16 fwd_gen B=256, M=1024, K=16    |        9140.8     |         8943.9      |  11938.8
                          f32 fwd_gen B=256, M=1024, K=32    |        9570.4     |         9470.6      |  14535.1
                          f16 fwd_gen B=256, M=1024, K=32    |       10737.2     |        10575.2      |  13053.4
                          f32 fwd_gen B=256, M=1024, K=64    |       12676.2     |        12254.0      |  16756.4
                          f16 fwd_gen B=256, M=1024, K=64    |       13804.2     |        13727.8      |  15444.9
                          f32 fwd_gen B=256, M=1024, K=128   |       25020.0     |        24338.0      |  21463.9
                          f16 fwd_gen B=256, M=1024, K=128   |       26766.3     |        26237.9      |  19672.3
                          f32 fwd_gen B=256, M=1024, K=256   |       54858.5     |        53495.4      |  38034.3
                          f16 fwd_gen B=256, M=1024, K=256   |       55071.9     |        54749.4      |  35115.6
                          f32 fwd_gen B=1024, M=128, K=16    |         574.0     |          565.5      |    972.1
                          f16 fwd_gen B=1024, M=128, K=16    |         622.7     |          613.8      |    841.1
                          f32 fwd_gen B=1024, M=128, K=32    |         695.2     |          669.9      |   1073.2
                          f16 fwd_gen B=1024, M=128, K=32    |         754.4     |          743.9      |    922.2
                          f32 fwd_gen B=1024, M=128, K=64    |         899.6     |          878.9      |   1284.6
                          f16 fwd_gen B=1024, M=128, K=64    |         966.1     |          961.8      |   1100.6
                          f32 fwd_gen B=1024, M=128, K=128   |        1835.9     |         1791.2      |   1713.1
                          f16 fwd_gen B=1024, M=128, K=128   |        1855.9     |         1827.1      |   1439.1
                          f32 fwd_gen B=1024, M=128, K=256   |        3680.4     |         3629.9      |   3537.1
                          f16 fwd_gen B=1024, M=128, K=256   |        3621.9     |         3565.0      |   2609.6
                          f32 fwd_gen B=1024, M=512, K=16    |        8479.8     |         8300.2      |  13778.7
                          f16 fwd_gen B=1024, M=512, K=16    |        9243.8     |         9127.8      |  12027.8
                          f32 fwd_gen B=1024, M=512, K=32    |        9889.0     |         9718.5      |  15034.5
                          f16 fwd_gen B=1024, M=512, K=32    |       10863.7     |        10675.5      |  13198.1
                          f32 fwd_gen B=1024, M=512, K=64    |       12797.7     |        12452.6      |  17390.2
                          f16 fwd_gen B=1024, M=512, K=64    |       13976.5     |        13828.7      |  15562.6
                          f32 fwd_gen B=1024, M=512, K=128   |       25732.4     |        25282.8      |  22196.7
                          f16 fwd_gen B=1024, M=512, K=128   |       27259.4     |        26785.7      |  19783.2
                          f32 fwd_gen B=1024, M=512, K=256   |       55139.3     |        54202.4      |  39889.6
                          f16 fwd_gen B=1024, M=512, K=256   |       55655.6     |        55217.5      |  36222.7
                          f32 fwd_gen B=1024, M=1024, K=16   |       33089.8     |        32343.0      |         
                          f16 fwd_gen B=1024, M=1024, K=16   |       36165.8     |        35512.4      |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       38608.0     |        37812.6      |         
                          f16 fwd_gen B=1024, M=1024, K=32   |       42441.5     |        41725.7      |         
                          f32 fwd_gen B=1024, M=1024, K=64   |       49091.9     |        48749.8      |         
                          f16 fwd_gen B=1024, M=1024, K=64   |       54568.4     |        54067.9      |         
                          f32 fwd_gen B=1024, M=1024, K=128  |      101246.3     |        99456.8      |         
                          f16 fwd_gen B=1024, M=1024, K=128  |      108420.4     |       107736.7      |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      220887.0     |       215878.3      |         
                          f16 fwd_gen B=1024, M=1024, K=256  |      221047.3     |       219332.7      |         
                          f32 fwd_gen B=384, M=192, K=88     |                   |         1402.6      |         
                          f16 fwd_gen B=384, M=192, K=88     |                   |         1430.6      |         
  (Tesla_V100_SXM2_16GB)  f32 fwd_gen B=256, M=128, K=16     |          94.4     |          101.7      |    171.9
                          f16 fwd_gen B=256, M=128, K=16     |          49.0     |           52.9      |     98.2
                          f32 fwd_gen B=256, M=128, K=32     |         101.4     |          103.1      |    142.7
                          f16 fwd_gen B=256, M=128, K=32     |          53.4     |           52.4      |     97.7
                          f32 fwd_gen B=256, M=128, K=64     |         132.4     |          137.9      |    198.0
                          f16 fwd_gen B=256, M=128, K=64     |          71.5     |           72.1      |     99.4
                          f32 fwd_gen B=256, M=128, K=128    |         244.6     |          256.5      |    325.5
                          f16 fwd_gen B=256, M=128, K=128    |         109.7     |          111.9      |    133.9
                          f32 fwd_gen B=256, M=128, K=256    |         490.0     |          510.7      |    600.2
                          f16 fwd_gen B=256, M=128, K=256    |         220.0     |          218.8      |    203.4
                          f32 fwd_gen B=256, M=512, K=16     |        1132.3     |         1135.1      |   1758.7
                          f16 fwd_gen B=256, M=512, K=16     |         506.2     |          488.2      |    788.7
                          f32 fwd_gen B=256, M=512, K=32     |        1308.0     |         1352.1      |   1911.6
                          f16 fwd_gen B=256, M=512, K=32     |         522.3     |          510.5      |    841.8
                          f32 fwd_gen B=256, M=512, K=64     |        1691.5     |         1778.8      |   2215.9
                          f16 fwd_gen B=256, M=512, K=64     |         632.4     |          647.0      |    966.5
                          f32 fwd_gen B=256, M=512, K=128    |        3331.2     |         3464.2      |   3535.0
                          f16 fwd_gen B=256, M=512, K=128    |        1097.3     |         1108.4      |   1131.2
                          f32 fwd_gen B=256, M=512, K=256    |        7066.5     |         7368.2      |   6177.4
                          f16 fwd_gen B=256, M=512, K=256    |        2884.3     |         2903.1      |   1690.3
                          f32 fwd_gen B=256, M=1024, K=16    |        4420.3     |         4425.0      |   7031.8
                          f16 fwd_gen B=256, M=1024, K=16    |        1927.8     |         1855.5      |   3313.8
                          f32 fwd_gen B=256, M=1024, K=32    |        5080.6     |         5271.8      |   7586.0
                          f16 fwd_gen B=256, M=1024, K=32    |        1965.9     |         1912.2      |   3420.3
                          f32 fwd_gen B=256, M=1024, K=64    |        6566.9     |         6896.7      |   8794.9
                          f16 fwd_gen B=256, M=1024, K=64    |        2318.2     |         2394.0      |   3810.9
                          f32 fwd_gen B=256, M=1024, K=128   |       12981.5     |        13560.6      |  14190.1
                          f16 fwd_gen B=256, M=1024, K=128   |        4020.8     |         4129.0      |   4196.3
                          f32 fwd_gen B=256, M=1024, K=256   |       27839.1     |        28880.0      |  24765.7
                          f16 fwd_gen B=256, M=1024, K=256   |       11531.0     |        11453.4      |   6153.9
                          f32 fwd_gen B=384, M=192, K=88     |                   |          740.7      |         
                          f16 fwd_gen B=384, M=192, K=88     |                   |          283.4      |         
                          f32 fwd_gen B=1024, M=128, K=16    |         305.8     |          305.8      |    439.1
                          f16 fwd_gen B=1024, M=128, K=16    |         153.6     |          150.2      |    229.2
                          f32 fwd_gen B=1024, M=128, K=32    |         356.5     |          371.2      |    522.2
                          f16 fwd_gen B=1024, M=128, K=32    |         170.9     |          167.1      |    258.0
                          f32 fwd_gen B=1024, M=128, K=64    |         483.0     |          506.0      |    674.7
                          f16 fwd_gen B=1024, M=128, K=64    |         236.0     |          235.9      |    322.6
                          f32 fwd_gen B=1024, M=128, K=128   |         941.8     |          974.6      |   1100.7
                          f16 fwd_gen B=1024, M=128, K=128   |         387.7     |          395.6      |    448.6
                          f32 fwd_gen B=1024, M=128, K=256   |        1881.1     |         1929.5      |   1896.8
                          f16 fwd_gen B=1024, M=128, K=256   |         821.7     |          820.9      |    716.6
                          f32 fwd_gen B=1024, M=512, K=16    |        4365.7     |         4422.6      |   7113.5
                          f16 fwd_gen B=1024, M=512, K=16    |        1949.7     |         1883.8      |   3042.4
                          f32 fwd_gen B=1024, M=512, K=32    |        5046.7     |         5270.0      |   7936.5
                          f16 fwd_gen B=1024, M=512, K=32    |        2010.8     |         1976.8      |   3244.2
                          f32 fwd_gen B=1024, M=512, K=64    |        6739.2     |         7004.8      |   9127.6
                          f16 fwd_gen B=1024, M=512, K=64    |        2438.2     |         2511.6      |   3813.0
                          f32 fwd_gen B=1024, M=512, K=128   |       13237.3     |        13882.4      |  14391.9
                          f16 fwd_gen B=1024, M=512, K=128   |        4259.9     |         4339.8      |   4442.0
                          f32 fwd_gen B=1024, M=512, K=256   |       27905.3     |        29005.0      |  25848.2
                          f16 fwd_gen B=1024, M=512, K=256   |       11597.4     |        11593.5      |   6675.1
                          f32 fwd_gen B=1024, M=1024, K=16   |       17136.9     |        17434.5      |         
                          f16 fwd_gen B=1024, M=1024, K=16   |        7429.1     |         7199.5      |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       19723.1     |        20789.8      |         
                          f16 fwd_gen B=1024, M=1024, K=32   |        7575.4     |         7492.1      |         
                          f32 fwd_gen B=1024, M=1024, K=64   |       26021.2     |        27308.5      |         
                          f16 fwd_gen B=1024, M=1024, K=64   |        9111.1     |         9288.9      |         
                          f32 fwd_gen B=1024, M=1024, K=128  |       51597.0     |        53925.8      |         
                          f16 fwd_gen B=1024, M=1024, K=128  |       15899.8     |        16159.0      |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      110483.7     |       115206.1      |         
                          f16 fwd_gen B=1024, M=1024, K=256  |       44698.9     |        44742.1      |         

Times are in microseconds (us).

[------------ attention (attn_bias=<class 'xformers.ops.LowerTriangularMask'>) -----------]
                                                             |  1722b913_causal  |  vanilla
1 threads: --------------------------------------------------------------------------------
  (Quadro_GP100)          f32 fwd_gen B=256, M=128, K=16     |         128.0     |    359.5
                          f16 fwd_gen B=256, M=128, K=16     |         140.5     |    293.4
                          f32 fwd_gen B=256, M=128, K=32     |         149.5     |    380.4
                          f16 fwd_gen B=256, M=128, K=32     |         164.4     |    308.3
                          f32 fwd_gen B=256, M=128, K=64     |         193.2     |    425.3
                          f16 fwd_gen B=256, M=128, K=64     |         209.0     |    346.1
                          f32 fwd_gen B=256, M=128, K=128    |         401.4     |    529.7
                          f16 fwd_gen B=256, M=128, K=128    |         398.7     |    431.5
                          f32 fwd_gen B=256, M=128, K=256    |         770.7     |   1006.4
                          f16 fwd_gen B=256, M=128, K=256    |         761.6     |    721.5
                          f32 fwd_gen B=256, M=512, K=16     |        1243.1     |   4966.4
                          f16 fwd_gen B=256, M=512, K=16     |        1378.4     |   3834.6
                          f32 fwd_gen B=256, M=512, K=32     |        1453.8     |   5074.8
                          f16 fwd_gen B=256, M=512, K=32     |        1614.9     |   4064.7
                          f32 fwd_gen B=256, M=512, K=64     |        1892.0     |   5543.7
                          f16 fwd_gen B=256, M=512, K=64     |        2083.4     |   4657.5
                          f32 fwd_gen B=256, M=512, K=128    |        3956.8     |   6632.5
                          f16 fwd_gen B=256, M=512, K=128    |        4081.3     |   5735.3
                          f32 fwd_gen B=256, M=512, K=256    |        8195.1     |  10779.2
                          f16 fwd_gen B=256, M=512, K=256    |        8197.0     |   9752.0
                          f32 fwd_gen B=256, M=1024, K=16    |        4500.6     |  19519.8
                          f16 fwd_gen B=256, M=1024, K=16    |        4983.3     |  15613.2
                          f32 fwd_gen B=256, M=1024, K=32    |        5251.9     |  20162.2
                          f16 fwd_gen B=256, M=1024, K=32    |        5839.4     |  16836.2
                          f32 fwd_gen B=256, M=1024, K=64    |        6847.7     |  21641.7
                          f16 fwd_gen B=256, M=1024, K=64    |        7638.5     |  18864.6
                          f32 fwd_gen B=256, M=1024, K=128   |       14162.8     |  25990.3
                          f16 fwd_gen B=256, M=1024, K=128   |       14714.4     |  23007.0
                          f32 fwd_gen B=256, M=1024, K=256   |       30101.1     |  42275.9
                          f16 fwd_gen B=256, M=1024, K=256   |       30089.9     |  38852.7
                          f32 fwd_gen B=1024, M=128, K=16    |         463.1     |   1332.4
                          f16 fwd_gen B=1024, M=128, K=16    |         501.0     |   1081.6
                          f32 fwd_gen B=1024, M=128, K=32    |         545.6     |   1428.0
                          f16 fwd_gen B=1024, M=128, K=32    |         594.1     |   1150.2
                          f32 fwd_gen B=1024, M=128, K=64    |         717.1     |   1611.7
                          f16 fwd_gen B=1024, M=128, K=64    |         773.6     |   1311.2
                          f32 fwd_gen B=1024, M=128, K=128   |        1590.1     |   2023.0
                          f16 fwd_gen B=1024, M=128, K=128   |        1556.1     |   1666.1
                          f32 fwd_gen B=1024, M=128, K=256   |        3012.8     |   3855.0
                          f16 fwd_gen B=1024, M=128, K=256   |        2966.6     |   2789.5
                          f32 fwd_gen B=1024, M=512, K=16    |        4899.9     |  19547.4
                          f16 fwd_gen B=1024, M=512, K=16    |        5335.8     |  15390.2
                          f32 fwd_gen B=1024, M=512, K=32    |        5728.1     |  20125.7
                          f16 fwd_gen B=1024, M=512, K=32    |        6276.6     |  16544.3
                          f32 fwd_gen B=1024, M=512, K=64    |        7418.9     |  22002.8
                          f16 fwd_gen B=1024, M=512, K=64    |        8191.3     |  18644.6
                          f32 fwd_gen B=1024, M=512, K=128   |       15839.3     |  26455.6
                          f16 fwd_gen B=1024, M=512, K=128   |       16274.2     |  23226.6
                          f32 fwd_gen B=1024, M=512, K=256   |       32633.8     |  43653.8
                          f16 fwd_gen B=1024, M=512, K=256   |       32383.5     |  39175.7
                          f32 fwd_gen B=1024, M=1024, K=16   |       18006.4     |         
                          f16 fwd_gen B=1024, M=1024, K=16   |       19691.2     |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       20972.7     |         
                          f16 fwd_gen B=1024, M=1024, K=32   |       22979.0     |         
                          f32 fwd_gen B=1024, M=1024, K=64   |       26979.9     |         
                          f16 fwd_gen B=1024, M=1024, K=64   |       29799.0     |         
                          f32 fwd_gen B=1024, M=1024, K=128  |       56408.7     |         
                          f16 fwd_gen B=1024, M=1024, K=128  |       58468.5     |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      119990.1     |         
                          f16 fwd_gen B=1024, M=1024, K=256  |      119822.6     |         
  (Tesla_V100_SXM2_16GB)  f32 fwd_gen B=256, M=128, K=16     |          75.3     |    189.4
                          f16 fwd_gen B=256, M=128, K=16     |          47.2     |    112.9
                          f32 fwd_gen B=256, M=128, K=32     |          87.9     |    208.4
                          f16 fwd_gen B=256, M=128, K=32     |          46.6     |    117.1
                          f32 fwd_gen B=256, M=128, K=64     |         114.2     |    260.3
                          f16 fwd_gen B=256, M=128, K=64     |          60.2     |    133.2
                          f32 fwd_gen B=256, M=128, K=128    |         205.6     |    386.3
                          f16 fwd_gen B=256, M=128, K=128    |          96.4     |    171.0
                          f32 fwd_gen B=256, M=128, K=256    |         402.6     |    663.2
                          f16 fwd_gen B=256, M=128, K=256    |         186.4     |    235.4
                          f32 fwd_gen B=256, M=512, K=16     |         676.7     |   2750.8
                          f16 fwd_gen B=256, M=512, K=16     |         325.7     |   1297.0
                          f32 fwd_gen B=256, M=512, K=32     |         789.9     |   2895.9
                          f16 fwd_gen B=256, M=512, K=32     |         340.4     |   1341.9
                          f32 fwd_gen B=256, M=512, K=64     |        1021.5     |   2999.0
                          f16 fwd_gen B=256, M=512, K=64     |         408.1     |   1418.1
                          f32 fwd_gen B=256, M=512, K=128    |        2016.1     |   4220.3
                          f16 fwd_gen B=256, M=512, K=128    |         696.8     |   1552.3
                          f32 fwd_gen B=256, M=512, K=256    |        4175.7     |   6798.5
                          f16 fwd_gen B=256, M=512, K=256    |        1720.5     |   2073.0
                          f32 fwd_gen B=256, M=1024, K=16    |        2391.2     |  10989.8
                          f16 fwd_gen B=256, M=1024, K=16    |        1096.4     |   5452.0
                          f32 fwd_gen B=256, M=1024, K=32    |        2771.4     |  11391.6
                          f16 fwd_gen B=256, M=1024, K=32    |        1127.7     |   5530.4
                          f32 fwd_gen B=256, M=1024, K=64    |        3625.7     |  11651.5
                          f16 fwd_gen B=256, M=1024, K=64    |        1323.9     |   5673.2
                          f32 fwd_gen B=256, M=1024, K=128   |        7262.5     |  16862.0
                          f16 fwd_gen B=256, M=1024, K=128   |        2282.3     |   5912.5
                          f32 fwd_gen B=256, M=1024, K=256   |       15242.4     |  27124.4
                          f16 fwd_gen B=256, M=1024, K=256   |        6004.6     |   7799.2
                          f32 fwd_gen B=1024, M=128, K=16    |         248.6     |    687.8
                          f16 fwd_gen B=1024, M=128, K=16    |         132.9     |    365.4
                          f32 fwd_gen B=1024, M=128, K=32    |         294.4     |    755.2
                          f16 fwd_gen B=1024, M=128, K=32    |         147.4     |    394.3
                          f32 fwd_gen B=1024, M=128, K=64    |         387.1     |    892.5
                          f16 fwd_gen B=1024, M=128, K=64    |         203.7     |    455.8
                          f32 fwd_gen B=1024, M=128, K=128   |         782.2     |   1279.9
                          f16 fwd_gen B=1024, M=128, K=128   |         345.8     |    583.1
                          f32 fwd_gen B=1024, M=128, K=256   |        1541.0     |   2063.8
                          f16 fwd_gen B=1024, M=128, K=256   |         714.6     |    837.5
                          f32 fwd_gen B=1024, M=512, K=16    |        2533.5     |  11128.6
                          f16 fwd_gen B=1024, M=512, K=16    |        1215.3     |   5062.7
                          f32 fwd_gen B=1024, M=512, K=32    |        2950.8     |  11694.3
                          f16 fwd_gen B=1024, M=512, K=32    |        1270.8     |   5233.9
                          f32 fwd_gen B=1024, M=512, K=64    |        3921.3     |  12153.6
                          f16 fwd_gen B=1024, M=512, K=64    |        1528.2     |   5572.1
                          f32 fwd_gen B=1024, M=512, K=128   |        7991.0     |  17163.9
                          f16 fwd_gen B=1024, M=512, K=128   |        2711.5     |   6078.7
                          f32 fwd_gen B=1024, M=512, K=256   |       16347.2     |  28312.1
                          f16 fwd_gen B=1024, M=512, K=256   |        6856.6     |   8211.7
                          f32 fwd_gen B=1024, M=1024, K=16   |        9236.4     |         
                          f16 fwd_gen B=1024, M=1024, K=16   |        4206.9     |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       10813.8     |         
                          f16 fwd_gen B=1024, M=1024, K=32   |        4330.0     |         
                          f32 fwd_gen B=1024, M=1024, K=64   |       14327.1     |         
                          f16 fwd_gen B=1024, M=1024, K=64   |        5126.6     |         
                          f32 fwd_gen B=1024, M=1024, K=128  |       28555.3     |         
                          f16 fwd_gen B=1024, M=1024, K=128  |        9085.5     |         
                          f32 fwd_gen B=1024, M=1024, K=256  |       60113.5     |         
                          f16 fwd_gen B=1024, M=1024, K=256  |       23929.4     |         

Times are in microseconds (us).
```
</details>

<details>
<summary>V100/P100 perf bw</summary>

```
[------------------- attention backward (attn_bias=<class 'NoneType'>) -------------------]
                                                             |  1722b913_causal  |  vanilla
1 threads: --------------------------------------------------------------------------------
  (Quadro_GP100)          f32 fwd_gen B=256, M=128, K=16     |         666.9     |    617.8
                          f16 fwd_gen B=256, M=128, K=16     |         558.0     |    504.8
                          f32 fwd_gen B=256, M=128, K=32     |         744.3     |    699.5
                          f16 fwd_gen B=256, M=128, K=32     |         664.3     |    559.6
                          f32 fwd_gen B=256, M=128, K=64     |        1037.9     |    857.9
                          f16 fwd_gen B=256, M=128, K=64     |         903.7     |    684.8
                          f32 fwd_gen B=256, M=128, K=128    |        2109.5     |   1231.5
                          f16 fwd_gen B=256, M=128, K=128    |        1713.4     |    968.6
                          f32 fwd_gen B=256, M=128, K=256    |        4471.7     |   2333.4
                          f16 fwd_gen B=256, M=128, K=256    |        3455.2     |   1767.2
                          f32 fwd_gen B=256, M=512, K=16     |        9552.5     |   8261.6
                          f16 fwd_gen B=256, M=512, K=16     |        8302.6     |   6675.7
                          f32 fwd_gen B=256, M=512, K=32     |       10800.1     |   8759.2
                          f16 fwd_gen B=256, M=512, K=32     |        9437.1     |   7109.0
                          f32 fwd_gen B=256, M=512, K=64     |       14898.9     |   9876.6
                          f16 fwd_gen B=256, M=512, K=64     |       12350.1     |   8070.8
                          f32 fwd_gen B=256, M=512, K=128    |       30810.9     |  13131.2
                          f16 fwd_gen B=256, M=512, K=128    |       24580.6     |  10829.9
                          f32 fwd_gen B=256, M=512, K=256    |       66705.8     |  22284.5
                          f16 fwd_gen B=256, M=512, K=256    |       50361.3     |  19546.0
                          f32 fwd_gen B=256, M=1024, K=16    |       38192.8     |  31991.9
                          f16 fwd_gen B=256, M=1024, K=16    |       32690.1     |  25978.9
                          f32 fwd_gen B=256, M=1024, K=32    |       42753.5     |  34220.7
                          f16 fwd_gen B=256, M=1024, K=32    |       37471.7     |  27317.1
                          f32 fwd_gen B=256, M=1024, K=64    |       57965.7     |  37232.9
                          f16 fwd_gen B=256, M=1024, K=64    |       48923.1     |  30350.1
                          f32 fwd_gen B=256, M=1024, K=128   |      124009.0     |  46988.8
                          f16 fwd_gen B=256, M=1024, K=128   |      101489.6     |  39981.4
                          f32 fwd_gen B=256, M=1024, K=256   |      253876.9     |  83195.4
                          f16 fwd_gen B=256, M=1024, K=256   |      201811.9     |  72498.3
                          f32 fwd_gen B=1024, M=128, K=16    |        2261.4     |   2305.6
                          f16 fwd_gen B=1024, M=128, K=16    |        1853.7     |   1857.8
                          f32 fwd_gen B=1024, M=128, K=32    |        2776.6     |   2581.7
                          f16 fwd_gen B=1024, M=128, K=32    |        2236.4     |   2066.4
                          f32 fwd_gen B=1024, M=128, K=64    |        3945.9     |   3221.6
                          f16 fwd_gen B=1024, M=128, K=64    |        3073.9     |   2512.5
                          f32 fwd_gen B=1024, M=128, K=128   |        8186.4     |   4789.4
                          f16 fwd_gen B=1024, M=128, K=128   |        6083.7     |   3662.5
                          f32 fwd_gen B=1024, M=128, K=256   |       17277.3     |   9196.1
                          f16 fwd_gen B=1024, M=128, K=256   |       12602.3     |   6934.8
                          f32 fwd_gen B=1024, M=512, K=16    |       36015.5     |  32338.4
                          f16 fwd_gen B=1024, M=512, K=16    |       27719.4     |  26229.3
                          f32 fwd_gen B=1024, M=512, K=32    |       40522.2     |  34509.5
                          f16 fwd_gen B=1024, M=512, K=32    |       31978.3     |  28058.9
                          f32 fwd_gen B=1024, M=512, K=64    |       56653.6     |  39178.1
                          f16 fwd_gen B=1024, M=512, K=64    |       43112.0     |  31578.1
                          f32 fwd_gen B=1024, M=512, K=128   |      120342.7     |  52245.2
                          f16 fwd_gen B=1024, M=512, K=128   |       88707.3     |  42251.0
                          f32 fwd_gen B=1024, M=512, K=256   |      248823.7     |  89889.7
                          f16 fwd_gen B=1024, M=512, K=256   |      176448.0     |  78134.5
                          f32 fwd_gen B=1024, M=1024, K=16   |      144795.6     |         
                          f16 fwd_gen B=1024, M=1024, K=16   |      110038.6     |         
                          f32 fwd_gen B=1024, M=1024, K=32   |      162025.8     |         
                          f16 fwd_gen B=1024, M=1024, K=32   |      128694.2     |         
                          f32 fwd_gen B=1024, M=1024, K=64   |      225786.6     |         
                          f16 fwd_gen B=1024, M=1024, K=64   |      169785.2     |         
                          f32 fwd_gen B=1024, M=1024, K=128  |      464660.2     |         
                          f16 fwd_gen B=1024, M=1024, K=128  |      335432.2     |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      965548.2     |         
                          f16 fwd_gen B=1024, M=1024, K=256  |      673563.2     |         
  (Tesla_V100_SXM2_16GB)  f32 fwd_gen B=256, M=128, K=16     |         279.8     |    312.9
                          f16 fwd_gen B=256, M=128, K=16     |         200.5     |    222.5
                          f32 fwd_gen B=256, M=128, K=32     |         364.7     |    367.9
                          f16 fwd_gen B=256, M=128, K=32     |         192.6     |    225.9
                          f32 fwd_gen B=256, M=128, K=64     |         524.3     |    494.2
                          f16 fwd_gen B=256, M=128, K=64     |         282.9     |    249.4
                          f32 fwd_gen B=256, M=128, K=128    |        1040.4     |    795.4
                          f16 fwd_gen B=256, M=128, K=128    |         535.0     |    377.0
                          f32 fwd_gen B=256, M=128, K=256    |        2113.4     |   1412.3
                          f16 fwd_gen B=256, M=128, K=256    |        1083.1     |    623.4
                          f32 fwd_gen B=256, M=512, K=16     |        4284.8     |   4114.2
                          f16 fwd_gen B=256, M=512, K=16     |        1731.2     |   1815.1
                          f32 fwd_gen B=256, M=512, K=32     |        5179.4     |   4401.6
                          f16 fwd_gen B=256, M=512, K=32     |        1941.7     |   1939.4
                          f32 fwd_gen B=256, M=512, K=64     |        7149.9     |   5058.6
                          f16 fwd_gen B=256, M=512, K=64     |        2646.0     |   2233.7
                          f32 fwd_gen B=256, M=512, K=128    |       14437.5     |   7827.2
                          f16 fwd_gen B=256, M=512, K=128    |        5399.2     |   2784.5
                          f32 fwd_gen B=256, M=512, K=256    |       29536.3     |  13496.9
                          f16 fwd_gen B=256, M=512, K=256    |       11705.0     |   4197.9
                          f32 fwd_gen B=256, M=1024, K=16    |       16977.9     |  15841.3
                          f16 fwd_gen B=256, M=1024, K=16    |        6707.4     |   6851.2
                          f32 fwd_gen B=256, M=1024, K=32    |       20341.6     |  16666.8
                          f16 fwd_gen B=256, M=1024, K=32    |        7226.6     |   7102.8
                          f32 fwd_gen B=256, M=1024, K=64    |       27943.0     |  19065.1
                          f16 fwd_gen B=256, M=1024, K=64    |        9493.2     |   7948.6
                          f32 fwd_gen B=256, M=1024, K=128   |       56523.3     |  29593.5
                          f16 fwd_gen B=256, M=1024, K=128   |       19771.5     |   9262.3
                          f32 fwd_gen B=256, M=1024, K=256   |      117464.9     |  51119.7
                          f16 fwd_gen B=256, M=1024, K=256   |       44110.6     |  13820.6
                          f32 fwd_gen B=1024, M=128, K=16    |         982.4     |   1134.2
                          f16 fwd_gen B=1024, M=128, K=16    |         500.6     |    557.4
                          f32 fwd_gen B=1024, M=128, K=32    |        1281.9     |   1333.3
                          f16 fwd_gen B=1024, M=128, K=32    |         631.8     |    665.3
                          f32 fwd_gen B=1024, M=128, K=64    |        1884.1     |   1724.4
                          f16 fwd_gen B=1024, M=128, K=64    |         994.4     |    871.9
                          f32 fwd_gen B=1024, M=128, K=128   |        3797.2     |   2787.8
                          f16 fwd_gen B=1024, M=128, K=128   |        1940.1     |   1326.8
                          f32 fwd_gen B=1024, M=128, K=256   |        7706.6     |   4904.8
                          f16 fwd_gen B=1024, M=128, K=256   |        4044.8     |   2317.4
                          f32 fwd_gen B=1024, M=512, K=16    |       15061.6     |  16311.5
                          f16 fwd_gen B=1024, M=512, K=16    |        6060.6     |   7205.3
                          f32 fwd_gen B=1024, M=512, K=32    |       18578.5     |  17456.8
                          f16 fwd_gen B=1024, M=512, K=32    |        6860.5     |   7749.1
                          f32 fwd_gen B=1024, M=512, K=64    |       25878.6     |  19979.3
                          f16 fwd_gen B=1024, M=512, K=64    |        9685.9     |   8932.2
                          f32 fwd_gen B=1024, M=512, K=128   |       52971.9     |  31403.1
                          f16 fwd_gen B=1024, M=512, K=128   |       20122.9     |  10902.9
                          f32 fwd_gen B=1024, M=512, K=256   |      107029.4     |  56149.4
                          f16 fwd_gen B=1024, M=512, K=256   |       44880.2     |  16655.0
                          f32 fwd_gen B=1024, M=1024, K=16   |       59841.3     |         
                          f16 fwd_gen B=1024, M=1024, K=16   |       23407.4     |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       73259.2     |         
                          f16 fwd_gen B=1024, M=1024, K=32   |       25414.9     |         
                          f32 fwd_gen B=1024, M=1024, K=64   |      100981.7     |         
                          f16 fwd_gen B=1024, M=1024, K=64   |       35034.0     |         
                          f32 fwd_gen B=1024, M=1024, K=128  |      206925.1     |         
                          f16 fwd_gen B=1024, M=1024, K=128  |       73748.6     |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      414550.4     |         
                          f16 fwd_gen B=1024, M=1024, K=256  |      166475.6     |         

Times are in microseconds (us).

[------- attention backward (attn_bias=<class 'xformers.ops.LowerTriangularMask'>) -------]
                                                             |  1722b913_causal  |  vanilla
1 threads: --------------------------------------------------------------------------------
  (Quadro_GP100)          f32 fwd_gen B=256, M=128, K=16     |         491.4     |    618.0
                          f16 fwd_gen B=256, M=128, K=16     |         419.8     |    503.3
                          f32 fwd_gen B=256, M=128, K=32     |         601.3     |    695.9
                          f16 fwd_gen B=256, M=128, K=32     |         506.4     |    553.2
                          f32 fwd_gen B=256, M=128, K=64     |         845.1     |    851.0
                          f16 fwd_gen B=256, M=128, K=64     |         738.8     |    679.4
                          f32 fwd_gen B=256, M=128, K=128    |        1710.3     |   1223.8
                          f16 fwd_gen B=256, M=128, K=128    |        1419.9     |    963.5
                          f32 fwd_gen B=256, M=128, K=256    |        3620.6     |   2319.4
                          f16 fwd_gen B=256, M=128, K=256    |        2802.2     |   1742.7
                          f32 fwd_gen B=256, M=512, K=16     |        5452.8     |   8079.7
                          f16 fwd_gen B=256, M=512, K=16     |        4771.2     |   6610.7
                          f32 fwd_gen B=256, M=512, K=32     |        6379.9     |   8675.9
                          f16 fwd_gen B=256, M=512, K=32     |        5498.0     |   7048.8
                          f32 fwd_gen B=256, M=512, K=64     |        8870.1     |   9732.1
                          f16 fwd_gen B=256, M=512, K=64     |        7288.5     |   8046.7
                          f32 fwd_gen B=256, M=512, K=128    |       18207.9     |  12947.5
                          f16 fwd_gen B=256, M=512, K=128    |       14596.8     |  10571.4
                          f32 fwd_gen B=256, M=512, K=256    |       38268.6     |  22041.8
                          f16 fwd_gen B=256, M=512, K=256    |       29385.5     |  19069.8
                          f32 fwd_gen B=256, M=1024, K=16    |       20609.8     |  32155.6
                          f16 fwd_gen B=256, M=1024, K=16    |       17731.4     |  25856.0
                          f32 fwd_gen B=256, M=1024, K=32    |       23445.5     |  33556.3
                          f16 fwd_gen B=256, M=1024, K=32    |       20466.9     |  27201.7
                          f32 fwd_gen B=256, M=1024, K=64    |       31789.6     |  36569.8
                          f16 fwd_gen B=256, M=1024, K=64    |       26406.3     |  30083.7
                          f32 fwd_gen B=256, M=1024, K=128   |       67603.0     |  46107.1
                          f16 fwd_gen B=256, M=1024, K=128   |       53516.8     |  39191.7
                          f32 fwd_gen B=256, M=1024, K=256   |      140046.1     |  81443.0
                          f16 fwd_gen B=256, M=1024, K=256   |      111651.9     |  72755.9
                          f32 fwd_gen B=1024, M=128, K=16    |        1842.3     |   2279.6
                          f16 fwd_gen B=1024, M=128, K=16    |        1447.7     |   1838.8
                          f32 fwd_gen B=1024, M=128, K=32    |        2229.9     |   2549.9
                          f16 fwd_gen B=1024, M=128, K=32    |        1788.7     |   2046.9
                          f32 fwd_gen B=1024, M=128, K=64    |        3212.3     |   3190.9
                          f16 fwd_gen B=1024, M=128, K=64    |        2506.2     |   2508.3
                          f32 fwd_gen B=1024, M=128, K=128   |        6667.0     |   4740.4
                          f16 fwd_gen B=1024, M=128, K=128   |        4938.2     |   3616.4
                          f32 fwd_gen B=1024, M=128, K=256   |       14046.1     |   9166.7
                          f16 fwd_gen B=1024, M=128, K=256   |       10174.2     |   6858.5
                          f32 fwd_gen B=1024, M=512, K=16    |       20570.9     |  32068.6
                          f16 fwd_gen B=1024, M=512, K=16    |       16017.7     |  26198.8
                          f32 fwd_gen B=1024, M=512, K=32    |       23921.8     |  34859.5
                          f16 fwd_gen B=1024, M=512, K=32    |       18919.3     |  27799.3
                          f32 fwd_gen B=1024, M=512, K=64    |       33567.9     |  38711.3
                          f16 fwd_gen B=1024, M=512, K=64    |       25706.9     |  31657.2
                          f32 fwd_gen B=1024, M=512, K=128   |       71949.4     |  50359.4
                          f16 fwd_gen B=1024, M=512, K=128   |       50923.7     |  41519.5
                          f32 fwd_gen B=1024, M=512, K=256   |      148992.9     |  89574.8
                          f16 fwd_gen B=1024, M=512, K=256   |      106911.1     |  78852.2
                          f32 fwd_gen B=1024, M=1024, K=16   |       77130.9     |         
                          f16 fwd_gen B=1024, M=1024, K=16   |       59854.0     |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       88392.5     |         
                          f16 fwd_gen B=1024, M=1024, K=32   |       69524.3     |         
                          f32 fwd_gen B=1024, M=1024, K=64   |      124361.6     |         
                          f16 fwd_gen B=1024, M=1024, K=64   |       91947.0     |         
                          f32 fwd_gen B=1024, M=1024, K=128  |      254598.4     |         
                          f16 fwd_gen B=1024, M=1024, K=128  |      184382.0     |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      528736.1     |         
                          f16 fwd_gen B=1024, M=1024, K=256  |      370074.6     |         
  (Tesla_V100_SXM2_16GB)  f32 fwd_gen B=256, M=128, K=16     |         222.9     |    312.4
                          f16 fwd_gen B=256, M=128, K=16     |         190.7     |    209.3
                          f32 fwd_gen B=256, M=128, K=32     |         298.3     |    367.2
                          f16 fwd_gen B=256, M=128, K=32     |         197.1     |    207.6
                          f32 fwd_gen B=256, M=128, K=64     |         438.6     |    493.1
                          f16 fwd_gen B=256, M=128, K=64     |         252.8     |    249.1
                          f32 fwd_gen B=256, M=128, K=128    |         862.8     |    802.8
                          f16 fwd_gen B=256, M=128, K=128    |         475.6     |    375.2
                          f32 fwd_gen B=256, M=128, K=256    |        1745.0     |   1409.4
                          f16 fwd_gen B=256, M=128, K=256    |         944.3     |    625.4
                          f32 fwd_gen B=256, M=512, K=16     |        2480.5     |   4136.6
                          f16 fwd_gen B=256, M=512, K=16     |        1050.8     |   1837.8
                          f32 fwd_gen B=256, M=512, K=32     |        3069.3     |   4408.4
                          f16 fwd_gen B=256, M=512, K=32     |        1227.7     |   1957.8
                          f32 fwd_gen B=256, M=512, K=64     |        4273.6     |   5057.8
                          f16 fwd_gen B=256, M=512, K=64     |        1732.6     |   2231.9
                          f32 fwd_gen B=256, M=512, K=128    |        8623.0     |   7734.0
                          f16 fwd_gen B=256, M=512, K=128    |        3498.8     |   2785.0
                          f32 fwd_gen B=256, M=512, K=256    |       17730.7     |  13261.3
                          f16 fwd_gen B=256, M=512, K=256    |        7464.1     |   4162.1
                          f32 fwd_gen B=256, M=1024, K=16    |        9205.5     |  16058.8
                          f16 fwd_gen B=256, M=1024, K=16    |        3718.3     |   7175.6
                          f32 fwd_gen B=256, M=1024, K=32    |       11129.6     |  16761.7
                          f16 fwd_gen B=256, M=1024, K=32    |        4116.1     |   7412.0
                          f32 fwd_gen B=256, M=1024, K=64    |       15388.2     |  18802.1
                          f16 fwd_gen B=256, M=1024, K=64    |        5548.3     |   8024.5
                          f32 fwd_gen B=256, M=1024, K=128   |       31090.8     |  29165.4
                          f16 fwd_gen B=256, M=1024, K=128   |       11469.0     |   9230.8
                          f32 fwd_gen B=256, M=1024, K=256   |       63645.9     |  49782.4
                          f16 fwd_gen B=256, M=1024, K=256   |       25087.3     |  13507.9
                          f32 fwd_gen B=1024, M=128, K=16    |         783.8     |   1133.8
                          f16 fwd_gen B=1024, M=128, K=16    |         425.7     |    556.6
                          f32 fwd_gen B=1024, M=128, K=32    |        1043.6     |   1331.2
                          f16 fwd_gen B=1024, M=128, K=32    |         558.7     |    665.3
                          f32 fwd_gen B=1024, M=128, K=64    |        1565.8     |   1723.3
                          f16 fwd_gen B=1024, M=128, K=64    |         888.3     |    871.6
                          f32 fwd_gen B=1024, M=128, K=128   |        3148.6     |   2779.5
                          f16 fwd_gen B=1024, M=128, K=128   |        1723.1     |   1330.2
                          f32 fwd_gen B=1024, M=128, K=256   |        6401.0     |   4869.9
                          f16 fwd_gen B=1024, M=128, K=256   |        3545.5     |   2317.3
                          f32 fwd_gen B=1024, M=512, K=16    |        8737.5     |  16160.8
                          f16 fwd_gen B=1024, M=512, K=16    |        3654.6     |   7188.2
                          f32 fwd_gen B=1024, M=512, K=32    |       10974.3     |  17415.3
                          f16 fwd_gen B=1024, M=512, K=32    |        4350.8     |   7709.5
                          f32 fwd_gen B=1024, M=512, K=64    |       15568.7     |  19979.7
                          f16 fwd_gen B=1024, M=512, K=64    |        6354.5     |   8805.8
                          f32 fwd_gen B=1024, M=512, K=128   |       31897.7     |  30903.4
                          f16 fwd_gen B=1024, M=512, K=128   |       13103.3     |  10902.4
                          f32 fwd_gen B=1024, M=512, K=256   |       64105.8     |  55015.2
                          f16 fwd_gen B=1024, M=512, K=256   |       28615.8     |  16429.5
                          f32 fwd_gen B=1024, M=1024, K=16   |       32460.9     |         
                          f16 fwd_gen B=1024, M=1024, K=16   |       13038.6     |         
                          f32 fwd_gen B=1024, M=1024, K=32   |       39980.7     |         
                          f16 fwd_gen B=1024, M=1024, K=32   |       14593.0     |         
                          f32 fwd_gen B=1024, M=1024, K=64   |       55800.3     |         
                          f16 fwd_gen B=1024, M=1024, K=64   |       20581.8     |         
                          f32 fwd_gen B=1024, M=1024, K=128  |      114427.4     |         
                          f16 fwd_gen B=1024, M=1024, K=128  |       42954.2     |         
                          f32 fwd_gen B=1024, M=1024, K=256  |      229263.6     |         
                          f16 fwd_gen B=1024, M=1024, K=256  |       96103.1     |         

Times are in microseconds (us).
```
</details>

<details>
<summary>A100 perf fw</summary>

```
[-------------------- attention (attn_bias=<class 'NoneType'>) -------------------]
                                 |  1722b91_causal  |  7446017_outputrf  |  vanilla
1 threads: ------------------------------------------------------------------------
      f16 B=256, M=128, K=16     |        29.1      |         28.9       |     64.7
      f32 B=256, M=128, K=16     |        60.0      |         59.6       |    157.8
      f16 B=256, M=128, K=32     |        30.1      |         29.8       |     65.0
      f32 B=256, M=128, K=32     |        62.1      |         61.7       |    171.8
      f16 B=256, M=128, K=64     |        35.6      |         35.4       |     63.8
      f32 B=256, M=128, K=64     |        82.9      |         81.8       |    198.3
      f16 B=256, M=128, K=128    |        58.2      |         59.6       |     76.9
      f32 B=256, M=128, K=128    |       144.3      |        144.4       |    261.9
      f16 B=256, M=512, K=16     |       242.3      |        240.7       |    538.6
      f32 B=256, M=512, K=16     |       729.5      |        730.7       |   1892.3
      f16 B=256, M=512, K=32     |       249.7      |        247.8       |    551.5
      f32 B=256, M=512, K=32     |       739.3      |        740.9       |   2041.6
      f16 B=256, M=512, K=64     |       298.4      |        296.4       |    601.4
      f32 B=256, M=512, K=64     |       909.5      |        908.1       |   2353.3
      f16 B=256, M=512, K=128    |       490.6      |        493.7       |    666.1
      f32 B=256, M=512, K=128    |      1829.0      |       1826.8       |   2964.2
      f16 B=256, M=1024, K=16    |       907.2      |        901.5       |   1963.7
      f32 B=256, M=1024, K=16    |      2806.0      |       2811.0       |   7214.0
      f16 B=256, M=1024, K=32    |       916.2      |        909.6       |   1985.1
      f32 B=256, M=1024, K=32    |      2826.5      |       2833.5       |   7782.4
      f16 B=256, M=1024, K=64    |      1067.4      |       1061.2       |   2132.3
      f32 B=256, M=1024, K=64    |      3466.7      |       3464.9       |   8995.9
      f16 B=256, M=1024, K=128   |      1760.8      |       1790.0       |   2352.0
      f32 B=256, M=1024, K=128   |      7022.8      |       7023.7       |  11328.4
      f16 B=1024, M=128, K=16    |        78.0      |         77.2       |    185.0
      f32 B=1024, M=128, K=16    |       210.1      |        211.8       |    512.4
      f16 B=1024, M=128, K=32    |        86.2      |         85.4       |    193.9
      f32 B=1024, M=128, K=32    |       220.2      |        221.3       |    567.1
      f16 B=1024, M=128, K=64    |       118.4      |        118.1       |    236.2
      f32 B=1024, M=128, K=64    |       281.1      |        280.2       |    667.0
      f16 B=1024, M=128, K=128   |       202.3      |        207.9       |    309.8
      f32 B=1024, M=128, K=128   |       515.0      |        514.2       |    872.3
      f16 B=1024, M=512, K=16    |       940.4      |        932.7       |   1991.9
      f32 B=1024, M=512, K=16    |      2844.7      |       2846.5       |   7273.4
      f16 B=1024, M=512, K=32    |       960.2      |        952.6       |   2042.5
      f32 B=1024, M=512, K=32    |      2875.0      |       2880.4       |   7844.2
      f16 B=1024, M=512, K=64    |      1137.9      |       1130.5       |   2238.9
      f32 B=1024, M=512, K=64    |      3540.7      |       3538.9       |   9095.7
      f16 B=1024, M=512, K=128   |      1909.0      |       1922.1       |   2535.7
      f32 B=1024, M=512, K=128   |      7287.7      |       7284.4       |  11536.2
      f16 B=1024, M=1024, K=16   |      3554.8      |       3530.0       |   7687.7
      f32 B=1024, M=1024, K=16   |     11097.7      |      11106.0       |  28723.5
      f16 B=1024, M=1024, K=32   |      3585.8      |       3559.1       |   7803.3
      f32 B=1024, M=1024, K=32   |     11174.9      |      11192.2       |  30983.3
      f16 B=1024, M=1024, K=64   |      4174.2      |       4147.9       |   8432.3
      f32 B=1024, M=1024, K=64   |     13700.7      |      13694.2       |  35830.4
      f16 B=1024, M=1024, K=128  |      6937.8      |       6986.3       |   9266.4
      f32 B=1024, M=1024, K=128  |     27916.4      |      27911.8       |  45125.6

Times are in microseconds (us).

[ attention (attn_bias=<class 'xformers.ops.LowerTriangularMask'>) ]
                                 |  1722b91_causal
1 threads: ---------------------------------------
      f16 B=256, M=128, K=16     |        28.7    
      f32 B=256, M=128, K=16     |        58.0    
      f16 B=256, M=128, K=32     |        28.8    
      f32 B=256, M=128, K=32     |        60.6    
      f16 B=256, M=128, K=64     |        31.9    
      f32 B=256, M=128, K=64     |        82.1    
      f16 B=256, M=128, K=128    |        57.0    
      f32 B=256, M=128, K=128    |       134.5    
      f16 B=256, M=512, K=16     |       163.8    
      f32 B=256, M=512, K=16     |       465.4    
      f16 B=256, M=512, K=32     |       170.9    
      f32 B=256, M=512, K=32     |       473.3    
      f16 B=256, M=512, K=64     |       207.3    
      f32 B=256, M=512, K=64     |       585.5    
      f16 B=256, M=512, K=128    |       339.4    
      f32 B=256, M=512, K=128    |      1151.4    
      f16 B=256, M=1024, K=16    |       533.6    
      f32 B=256, M=1024, K=16    |      1593.6    
      f16 B=256, M=1024, K=32    |       543.7    
      f32 B=256, M=1024, K=32    |      1613.8    
      f16 B=256, M=1024, K=64    |       640.6    
      f32 B=256, M=1024, K=64    |      1982.9    
      f16 B=256, M=1024, K=128   |      1063.1    
      f32 B=256, M=1024, K=128   |      3985.0    
      f16 B=1024, M=128, K=16    |        68.9    
      f32 B=1024, M=128, K=16    |       174.3    
      f16 B=1024, M=128, K=32    |        76.1    
      f32 B=1024, M=128, K=32    |       184.0    
      f16 B=1024, M=128, K=64    |       107.7    
      f32 B=1024, M=128, K=64    |       234.5    
      f16 B=1024, M=128, K=128   |       188.7    
      f32 B=1024, M=128, K=128   |       481.4    
      f16 B=1024, M=512, K=16    |       580.2    
      f32 B=1024, M=512, K=16    |      1684.2    
      f16 B=1024, M=512, K=32    |       602.3    
      f32 B=1024, M=512, K=32    |      1714.9    
      f16 B=1024, M=512, K=64    |       731.2    
      f32 B=1024, M=512, K=64    |      2121.6    
      f16 B=1024, M=512, K=128   |      1279.2    
      f32 B=1024, M=512, K=128   |      4437.5    
      f16 B=1024, M=1024, K=16   |      1992.9    
      f32 B=1024, M=1024, K=16   |      6064.1    
      f16 B=1024, M=1024, K=32   |      2033.2    
      f32 B=1024, M=1024, K=32   |      6128.3    
      f16 B=1024, M=1024, K=64   |      2398.5    
      f32 B=1024, M=1024, K=64   |      7543.4    
      f16 B=1024, M=1024, K=128  |      4120.0    
      f32 B=1024, M=1024, K=128  |     15636.2    

Times are in microseconds (us).
```
</details>
<details>
<summary>A100 perf bw</summary>

```
[--------------- attention backward (attn_bias=<class 'NoneType'>) ---------------]
                                 |  1722b91_causal  |  7446017_outputrf  |  vanilla
1 threads: ------------------------------------------------------------------------
      f16 B=256, M=128, K=16     |       166.0      |        164.1       |    213.6
      f32 B=256, M=128, K=16     |       189.0      |        187.7       |    432.2
      f16 B=256, M=128, K=32     |       138.9      |        130.5       |    169.5
      f32 B=256, M=128, K=32     |       211.7      |        211.5       |    463.1
      f16 B=256, M=128, K=64     |       172.2      |        171.7       |    171.3
      f32 B=256, M=128, K=64     |       290.1      |        288.9       |    518.9
      f16 B=256, M=128, K=128    |       314.0      |        313.2       |    241.2
      f32 B=256, M=128, K=128    |       567.7      |        566.6       |    654.4
      f16 B=256, M=512, K=16     |       931.6      |        926.9       |   1206.6
      f32 B=256, M=512, K=16     |      2562.0      |       2570.7       |   5168.7
      f16 B=256, M=512, K=32     |      1105.1      |       1105.4       |   1267.6
      f32 B=256, M=512, K=32     |      2887.7      |       2869.0       |   5393.8
      f16 B=256, M=512, K=64     |      1600.3      |       1593.4       |   1416.5
      f32 B=256, M=512, K=64     |      3686.8      |       3673.2       |   5842.3
      f16 B=256, M=512, K=128    |      3125.2      |       3117.5       |   1729.4
      f32 B=256, M=512, K=128    |      7467.2      |       7446.6       |   6742.7
      f16 B=256, M=1024, K=16    |      3633.8      |       3638.2       |   4296.0
      f32 B=256, M=1024, K=16    |     10763.8      |      10713.5       |  19653.5
      f16 B=256, M=1024, K=32    |      4469.7      |       4425.2       |   4439.4
      f32 B=256, M=1024, K=32    |     11240.7      |      11181.8       |  20383.8
      f16 B=256, M=1024, K=64    |      5734.1      |       5708.2       |   4791.6
      f32 B=256, M=1024, K=64    |     14660.9      |      14581.7       |  21819.8
      f16 B=256, M=1024, K=128   |     11282.7      |      11275.7       |   5508.9
      f32 B=256, M=1024, K=128   |     28691.5      |      28641.4       |  24752.1
      f16 B=1024, M=128, K=16    |       288.7      |        287.1       |    419.0
      f32 B=1024, M=128, K=16    |       566.2      |        563.5       |   1413.4
      f16 B=1024, M=128, K=32    |       369.7      |        367.0       |    481.3
      f32 B=1024, M=128, K=32    |       666.8      |        666.0       |   1540.8
      f16 B=1024, M=128, K=64    |       606.4      |        606.1       |    615.1
      f32 B=1024, M=128, K=64    |       977.3      |        975.4       |   1773.8
      f16 B=1024, M=128, K=128   |      1184.3      |       1182.7       |    935.3
      f32 B=1024, M=128, K=128   |      1893.9      |       1893.8       |   2259.7
      f16 B=1024, M=512, K=16    |      3163.3      |       3129.4       |   4434.2
      f32 B=1024, M=512, K=16    |      8165.8      |       8186.9       |  19901.1
      f16 B=1024, M=512, K=32    |      4190.5      |       4141.3       |   4724.9
      f32 B=1024, M=512, K=32    |      9183.7      |       9147.3       |  20723.4
      f16 B=1024, M=512, K=64    |      5619.2      |       5596.9       |   5318.7
      f32 B=1024, M=512, K=64    |     11741.7      |      11692.7       |  22453.5
      f16 B=1024, M=512, K=128   |     11723.8      |      11730.8       |   6594.0
      f32 B=1024, M=512, K=128   |     23370.4      |      23382.8       |  26070.1
      f16 B=1024, M=1024, K=16   |     13942.3      |      13857.7       |  16975.4
      f32 B=1024, M=1024, K=16   |     33837.4      |      33705.3       |  78341.9
      f16 B=1024, M=1024, K=32   |     15575.5      |      15459.7       |  17580.0
      f32 B=1024, M=1024, K=32   |     35460.5      |      35284.3       |  81315.7
      f16 B=1024, M=1024, K=64   |     20065.6      |      20105.8       |  19038.3
      f32 B=1024, M=1024, K=64   |     44984.0      |      44948.8       |  86977.1
      f16 B=1024, M=1024, K=128  |     43563.6      |      43307.7       |  21847.3
      f32 B=1024, M=1024, K=128  |     89462.1      |      89279.8       |  98676.0

Times are in microseconds (us).

[ attention backward (attn_bias=<class 'xformers.ops.LowerTriangularMask'>) ]
                                 |  1722b91_causal
1 threads: ---------------------------------------
      f16 B=256, M=128, K=16     |       165.0    
      f32 B=256, M=128, K=16     |       154.8    
      f16 B=256, M=128, K=32     |       139.2    
      f32 B=256, M=128, K=32     |       178.9    
      f16 B=256, M=128, K=64     |       160.2    
      f32 B=256, M=128, K=64     |       248.9    
      f16 B=256, M=128, K=128    |       285.4    
      f32 B=256, M=128, K=128    |       489.4    
      f16 B=256, M=512, K=16     |       590.3    
      f32 B=256, M=512, K=16     |      1525.1    
      f16 B=256, M=512, K=32     |       698.2    
      f32 B=256, M=512, K=32     |      1727.8    
      f16 B=256, M=512, K=64     |      1084.5    
      f32 B=256, M=512, K=64     |      2284.0    
      f16 B=256, M=512, K=128    |      2098.0    
      f32 B=256, M=512, K=128    |      4520.5    
      f16 B=256, M=1024, K=16    |      2016.0    
      f32 B=256, M=1024, K=16    |      5785.1    
      f16 B=256, M=1024, K=32    |      2530.8    
      f32 B=256, M=1024, K=32    |      6227.9    
      f16 B=256, M=1024, K=64    |      3436.3    
      f32 B=256, M=1024, K=64    |      8067.0    
      f16 B=256, M=1024, K=128   |      6702.7    
      f32 B=256, M=1024, K=128   |     16014.2    
      f16 B=1024, M=128, K=16    |       253.6    
      f32 B=1024, M=128, K=16    |       467.8    
      f16 B=1024, M=128, K=32    |       339.6    
      f32 B=1024, M=128, K=32    |       572.5    
      f16 B=1024, M=128, K=64    |       574.2    
      f32 B=1024, M=128, K=64    |       846.3    
      f16 B=1024, M=128, K=128   |      1095.9    
      f32 B=1024, M=128, K=128   |      1621.4    
      f16 B=1024, M=512, K=16    |      2077.2    
      f32 B=1024, M=512, K=16    |      4831.3    
      f16 B=1024, M=512, K=32    |      2561.5    
      f32 B=1024, M=512, K=32    |      5463.2    
      f16 B=1024, M=512, K=64    |      3831.7    
      f32 B=1024, M=512, K=64    |      7312.4    
      f16 B=1024, M=512, K=128   |      7873.8    
      f32 B=1024, M=512, K=128   |     14443.3    
      f16 B=1024, M=1024, K=16   |      7161.1    
      f32 B=1024, M=1024, K=16   |     18067.9    
      f16 B=1024, M=1024, K=32   |      8902.4    
      f32 B=1024, M=1024, K=32   |     19739.6    
      f16 B=1024, M=1024, K=64   |     12102.2    
      f32 B=1024, M=1024, K=64   |     25465.6    
      f16 B=1024, M=1024, K=128  |     25830.1    
      f32 B=1024, M=1024, K=128  |     50244.6    

Times are in microseconds (us).
```
</details>

<details>
<summary>PERFORMANCE vs FLASHATTN for M=8096 (A100)</summary>

**FORWARD**
```
[----------- attention (attn_bias=<class 'NoneType'>) ----------]
                                        |  xformers  |  flashattn
1 threads: ------------------------------------------------------
      f16 fwd_gen B=160, M=8096, K=128  |   49828.0  |    88721.0
      f32 fwd_gen B=160, M=8096, K=128  |  207993.3  |           
      f16 fwd_gen B=320, M=8096, K=128  |   99573.7  |   136010.9
      f32 fwd_gen B=320, M=8096, K=128  |  415060.8  |           
      f16 fwd_gen B=384, M=192, K=88    |     121.9  |           
      f32 fwd_gen B=384, M=192, K=88    |     367.1  |           

Times are in microseconds (us).

[ attention (attn_bias=<class 'xformers.ops.LowerTriangularMask'>) ]
                                        |  xformers  |  flashattn
1 threads: ------------------------------------------------------
      f16 fwd_gen B=160, M=8096, K=128  |   25525.1  |   51004.1 
      f32 fwd_gen B=160, M=8096, K=128  |  105257.7  |           
      f16 fwd_gen B=320, M=8096, K=128  |   51014.6  |   78507.5 
      f32 fwd_gen B=320, M=8096, K=128  |  209725.8  |           
      f16 fwd_gen B=384, M=192, K=88    |      95.6  |           
      f32 fwd_gen B=384, M=192, K=88    |     258.2  |           

Times are in microseconds (us).
```
**BACKWARD**
```
[------ attention backward (attn_bias=<class 'NoneType'>) -------]
                                        |   xformers  |  flashattn
1 threads: -------------------------------------------------------
      f16 fwd_gen B=160, M=8096, K=128  |   442853.9  |   212045.3
      f32 fwd_gen B=160, M=8096, K=128  |   879855.1  |           
      f16 fwd_gen B=320, M=8096, K=128  |   614955.0  |   325223.4
      f32 fwd_gen B=320, M=8096, K=128  |  1586283.1  |           
      f16 fwd_gen B=384, M=192, K=88    |      641.0  |           
      f32 fwd_gen B=384, M=192, K=88    |     1061.8  |           

Times are in microseconds (us).

[ attention backward (attn_bias=<class 'xformers.ops.LowerTriangularMask'>) ]
                                        |  xformers  |  flashattn
1 threads: ------------------------------------------------------
      f16 fwd_gen B=160, M=8096, K=128  |  227253.7  |   120768.2
      f32 fwd_gen B=160, M=8096, K=128  |  445873.2  |           
      f16 fwd_gen B=320, M=8096, K=128  |  317960.9  |   186259.6
      f32 fwd_gen B=320, M=8096, K=128  |  805130.7  |           
      f16 fwd_gen B=384, M=192, K=88    |     537.2  |           
      f32 fwd_gen B=384, M=192, K=88    |     817.3  |           

Times are in microseconds (us).
```
</details>