### PR TITLE
bf16: Add support in fw/bw

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -71,40 +71,6 @@ mem_efficient_attention_backward_generic(
       at::cuda::getDeviceProperties(query.device().index());
   const int computeCapability = properties->major * 10 + properties->minor;
 
-#define DISPATCH_ARCHTAG(func)                                            \
-  {                                                                       \
-    if (computeCapability >= 80) {                                        \
-      using ArchTag = cutlass::arch::Sm80;                                \
-      func();                                                             \
-    } else if (computeCapability >= 75) {                                 \
-      using ArchTag = cutlass::arch::Sm75;                                \
-      func();                                                             \
-    } else if (computeCapability >= 70) {                                 \
-      using ArchTag = cutlass::arch::Sm70;                                \
-      func();                                                             \
-    } else if (computeCapability >= 50) {                                 \
-      using ArchTag = cutlass::arch::Sm50;                                \
-      func();                                                             \
-    } else {                                                              \
-      TORCH_CHECK(                                                        \
-          false,                                                          \
-          "Your device is too old. We require compute capability >= 50"); \
-    }                                                                     \
-  }
-
-#define DISPATCH_TYPES(func)                                          \
-  {                                                                   \
-    if (query.scalar_type() == at::ScalarType::Float) {               \
-      using scalar_t = float;                                         \
-      func();                                                         \
-    } else if (query.scalar_type() == at::ScalarType::Half) {         \
-      using scalar_t = cutlass::half_t;                               \
-      func();                                                         \
-    } else {                                                          \
-      TORCH_CHECK(false, "Only fp32 & half supported at the moment"); \
-    }                                                                 \
-  }
-
 #define DISPATCH_MAXK(func)                                          \
   {                                                                  \
     const auto maxK = std::max(query.size(2), value.size(2));        \
@@ -121,90 +87,99 @@ mem_efficient_attention_backward_generic(
   }
 
   DISPATCH_MAXK(([&] {
-    DISPATCH_TYPES(([&]() {
-      bool isAligned;
-      DISPATCH_ARCHTAG(([&]() {
-        using AlignedAK =
-            AttentionBackwardKernel<ArchTag, scalar_t, true, kMaxK>;
-        isAligned =
-            (query.stride(1) % AlignedAK::kOptimalAlignement == 0 &&
-             key.stride(1) % AlignedAK::kOptimalAlignement == 0 &&
-             value.stride(1) % AlignedAK::kOptimalAlignement == 0);
-        // TODO: Should we warn or log somewhere when we use a less efficient
-        // kernel due to wrong alignment?
+    DISPATCH_TYPES(
+        query, ([&]() {
+          bool isAligned;
+          DISPATCH_ARCHTAG(
+              computeCapability, ([&]() {
+                using AlignedAK =
+                    AttentionBackwardKernel<ArchTag, scalar_t, true, kMaxK>;
+                isAligned =
+                    (query.stride(1) % AlignedAK::kOptimalAlignement == 0 &&
+                     key.stride(1) % AlignedAK::kOptimalAlignement == 0 &&
+                     value.stride(1) % AlignedAK::kOptimalAlignement == 0);
+                // TODO: Should we warn or log somewhere when we use a less
+                // efficient kernel due to wrong alignment?
 
-        DISPATCH_BOOL(
-            isAligned, kIsAligned, ([&]() {
-              using AK =
-                  AttentionBackwardKernel<ArchTag, scalar_t, kIsAligned, kMaxK>;
-              size_t smem_bytes = sizeof(typename AK::SharedStorage);
-              // Might happen on Sm80/half, where the minimum alignment is
-              // 32bits
-              TORCH_CHECK(
-                  query.stride(1) % AK::kMinimumAlignment == 0,
-                  "query is not correctly aligned");
-              TORCH_CHECK(
-                  key.stride(1) % AK::kMinimumAlignment == 0,
-                  "key is not correctly aligned");
-              TORCH_CHECK(
-                  value.stride(1) % AK::kMinimumAlignment == 0,
-                  "value is not correctly aligned");
+                DISPATCH_BOOL(
+                    isAligned, kIsAligned, ([&]() {
+                      using AK = AttentionBackwardKernel<
+                          ArchTag,
+                          scalar_t,
+                          kIsAligned,
+                          kMaxK>;
+                      size_t smem_bytes = sizeof(typename AK::SharedStorage);
+                      // Might happen on Sm80/half, where the minimum alignment
+                      // is 32bits
+                      TORCH_CHECK(
+                          query.stride(1) % AK::kMinimumAlignment == 0,
+                          "query is not correctly aligned");
+                      TORCH_CHECK(
+                          key.stride(1) % AK::kMinimumAlignment == 0,
+                          "key is not correctly aligned");
+                      TORCH_CHECK(
+                          value.stride(1) % AK::kMinimumAlignment == 0,
+                          "value is not correctly aligned");
 
-              // TODO: Fuse this into a kernel?
-              // This is a bottleneck for smaller sequences (M <= 128)
-              auto delta = AK::kKernelComputesDelta
-                  ? at::empty(
-                        {B, M}, query.options().dtype(at::ScalarType::Float))
-                  : (grad_out.to(at::kFloat) * out.to(at::kFloat)).sum(-1);
+                      // TODO: Fuse this into a kernel?
+                      // This is a bottleneck for smaller sequences (M <= 128)
+                      auto delta = AK::kKernelComputesDelta
+                          ? at::empty(
+                                {B, M},
+                                query.options().dtype(at::ScalarType::Float))
+                          : (grad_out.to(at::kFloat) * out.to(at::kFloat))
+                                .sum(-1);
 
-              AK::Params params;
-              params.query_ptr = (scalar_t*)query.data_ptr();
-              params.key_ptr = (scalar_t*)key.data_ptr();
-              params.value_ptr = (scalar_t*)value.data_ptr();
-              params.logsumexp_ptr =
-                  (typename AK::lse_scalar_t*)logsumexp.data_ptr();
-              params.output_ptr = (scalar_t*)out.data_ptr();
-              params.grad_output_ptr = (scalar_t*)grad_out.data_ptr();
-              params.grad_query_ptr = (scalar_t*)grad_q.data_ptr();
-              params.grad_key_ptr = (scalar_t*)grad_k.data_ptr();
-              params.grad_value_ptr = (scalar_t*)grad_v.data_ptr();
-              params.delta_ptr = (float*)delta.data_ptr();
-              params.head_dim = query.size(2);
-              params.head_dim_value = value.size(2);
-              params.num_queries = query.size(1);
-              params.num_keys = key.size(1);
-              params.num_batches = B;
-              params.causal = causal;
+                      AK::Params params;
+                      params.query_ptr = (scalar_t*)query.data_ptr();
+                      params.key_ptr = (scalar_t*)key.data_ptr();
+                      params.value_ptr = (scalar_t*)value.data_ptr();
+                      params.logsumexp_ptr =
+                          (typename AK::lse_scalar_t*)logsumexp.data_ptr();
+                      params.output_ptr = (scalar_t*)out.data_ptr();
+                      params.grad_output_ptr = (scalar_t*)grad_out.data_ptr();
+                      params.grad_query_ptr = (scalar_t*)grad_q.data_ptr();
+                      params.grad_key_ptr = (scalar_t*)grad_k.data_ptr();
+                      params.grad_value_ptr = (scalar_t*)grad_v.data_ptr();
+                      params.delta_ptr = (float*)delta.data_ptr();
+                      params.head_dim = query.size(2);
+                      params.head_dim_value = value.size(2);
+                      params.num_queries = query.size(1);
+                      params.num_keys = key.size(1);
+                      params.num_batches = B;
+                      params.causal = causal;
 
-              constexpr auto kernel_fn = attention_kernel_backward_batched<AK>;
+                      constexpr auto kernel_fn =
+                          attention_kernel_backward_batched<AK>;
 
-              if (smem_bytes > 0xc000) {
-                TORCH_INTERNAL_ASSERT(
-                    computeCapability >= 70,
-                    "This kernel requires too much shared memory on this machine!");
-                cudaFuncSetAttribute(
-                    kernel_fn,
-                    cudaFuncAttributeMaxDynamicSharedMemorySize,
-                    smem_bytes);
-              }
+                      if (smem_bytes > 0xc000) {
+                        TORCH_INTERNAL_ASSERT(
+                            computeCapability >= 70,
+                            "This kernel requires too much shared memory on this machine!");
+                        cudaFuncSetAttribute(
+                            kernel_fn,
+                            cudaFuncAttributeMaxDynamicSharedMemorySize,
+                            smem_bytes);
+                      }
 
-              auto checkBinaryArchMatches = [&]() {
-                cudaFuncAttributes attr;
-                AT_CUDA_CHECK(cudaFuncGetAttributes(&attr, kernel_fn));
-                return attr.binaryVersion >= ArchTag::kMinComputeCapability;
-              };
-              TORCH_INTERNAL_ASSERT(
-                  checkBinaryArchMatches(),
-                  "Something went wrong in the build process");
+                      auto checkBinaryArchMatches = [&]() {
+                        cudaFuncAttributes attr;
+                        AT_CUDA_CHECK(cudaFuncGetAttributes(&attr, kernel_fn));
+                        return attr.binaryVersion >=
+                            ArchTag::kMinComputeCapability;
+                      };
+                      TORCH_INTERNAL_ASSERT(
+                          checkBinaryArchMatches(),
+                          "Something went wrong in the build process");
 
-              kernel_fn<<<
-                  params.getBlocksGrid(),
-                  params.getThreadsGrid(),
-                  smem_bytes>>>(params);
-              AT_CUDA_CHECK(cudaGetLastError());
-            }));
-      }));
-    }));
+                      kernel_fn<<<
+                          params.getBlocksGrid(),
+                          params.getThreadsGrid(),
+                          smem_bytes>>>(params);
+                      AT_CUDA_CHECK(cudaGetLastError());
+                    }));
+              }));
+        }));
   }));
   return std::make_tuple(grad_q, grad_k, grad_v);
 } // namespace

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_forward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_forward.h
@@ -8,6 +8,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 
+#include "cutlass/bfloat16.h"
 #include "cutlass/gemm/gemm.h"
 #include "cutlass/layout/matrix.h"
 #include "cutlass/layout/vector.h"

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16.cu
@@ -1,0 +1,6 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_backward.h"
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, false);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, false);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, false);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, false);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned.cu
@@ -1,0 +1,6 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_backward.h"
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, true);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, true);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, true);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, true);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k128.cu
@@ -1,0 +1,6 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_backward.h"
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, true, 128);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, true, 128);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, true, 128);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, true, 128);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k64.cu
@@ -1,0 +1,6 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_backward.h"
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, true, 64);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, true, 64);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, true, 64);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, true, 64);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k128.cu
@@ -1,0 +1,6 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_backward.h"
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, false, 128);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, false, 128);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, false, 128);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, false, 128);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k64.cu
@@ -1,0 +1,6 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_backward.h"
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, false, 64);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, false, 64);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, false, 64);
+INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, false, 64);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16.cu
@@ -1,0 +1,74 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_forward.h"
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
+    cutlass::bfloat16_t,
+    false,
+    64,
+    64,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(
+    cutlass::bfloat16_t,
+    false,
+    64,
+    64,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(
+    cutlass::bfloat16_t,
+    false,
+    64,
+    64,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
+    cutlass::bfloat16_t,
+    false,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
+    cutlass::bfloat16_t,
+    false,
+    64,
+    64,
+    true);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16_aligned.cu
@@ -1,0 +1,74 @@
+// This file is auto-generated. See "generate_kernels.sh"
+#include "../kernel_forward.h"
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
+    cutlass::bfloat16_t,
+    true,
+    64,
+    64,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM70(
+    cutlass::bfloat16_t,
+    true,
+    64,
+    64,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(
+    cutlass::bfloat16_t,
+    true,
+    64,
+    64,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    true);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
+    cutlass::bfloat16_t,
+    true,
+    32,
+    128,
+    false);
+INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
+    cutlass::bfloat16_t,
+    true,
+    64,
+    64,
+    true);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/generate_kernels.sh
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/generate_kernels.sh
@@ -8,10 +8,11 @@ kernel="BACKWARD"
 kernel_lower=`echo "\$kernel" | awk '{print tolower($0)}'`
 for aligned in "false" "true"; do
     for maxk in 64 128 ""; do
-        for dtype_name in "f32" "f16"; do
+        for dtype_name in "f32" "f16" "bf16"; do
             case "$dtype_name" in
                 "f32") dtype="float" ;;
                 "f16") dtype="cutlass::half_t" ;;
+                "bf16") dtype="cutlass::bfloat16_t" ;;
             esac
             [[ $aligned = "true" ]] && s="_aligned" || s=""
             [[ $maxk = "" ]] && s="${s}" || s="${s}_k$maxk"
@@ -34,10 +35,11 @@ kernel="FORWARD"
 kernel_lower=`echo "\$kernel" | awk '{print tolower($0)}'`
 for aligned in "false" "true"; do
     [[ $aligned = "true" ]] && aligned_suffix="_aligned" || aligned_suffix=""
-    for dtype_name in "f32" "f16"; do
+    for dtype_name in "f32" "f16" "bf16"; do
         case "$dtype_name" in
             "f32") dtype="float" ;;
             "f16") dtype="cutlass::half_t" ;;
+            "bf16") dtype="cutlass::bfloat16_t" ;;
         esac
         FNAME="${kernel_lower}_${dtype_name}${aligned_suffix}.cu"
         echo $FNAME

--- a/xformers/ops.py
+++ b/xformers/ops.py
@@ -88,12 +88,12 @@ class AttentionOpBase(torch.autograd.Function):
     FORWARD_ERROR_ATOL: Mapping[torch.dtype, float] = {
         torch.float: 3e-4,
         torch.half: 4e-3,
-        torch.bfloat16: 2e-3,
+        torch.bfloat16: 2e-2,
     }
     FORWARD_ERROR_RTOL: Mapping[torch.dtype, float] = {
         torch.float: 2e-5,
-        torch.half: 2e-4,
-        torch.bfloat16: 2e-5,
+        torch.half: 4e-4,
+        torch.bfloat16: 5e-3,
     }
     SUPPORTED_DEVICES: Set[str]
     SUPPORTED_DTYPES: Set[torch.dtype]
@@ -212,7 +212,7 @@ class MemoryEfficientAttentionOp(AttentionOpBase):
 class MemoryEfficientAttentionGenericForwardOp(AttentionOpBase):
     FORWARD_OPERATOR = _get_xformers_operator("efficient_attention_forward_generic")
     SUPPORTED_DEVICES = {"cuda"}
-    SUPPORTED_DTYPES = {torch.float, torch.half}
+    SUPPORTED_DTYPES = {torch.float, torch.half, torch.bfloat16}
     SUPPORTED_MAX_K = math.inf
     SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {type(None), LowerTriangularMask}
     SUPPORTS_DROPOUT = False
@@ -323,14 +323,6 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
     """
 
     FORWARD_OPERATOR = None
-    FORWARD_ERROR_ATOL: Mapping[torch.dtype, float] = {
-        torch.half: 5e-2,
-        torch.bfloat16: 5e-2,
-    }
-    FORWARD_ERROR_RTOL: Mapping[torch.dtype, float] = {
-        torch.half: 1e-2,
-        torch.bfloat16: 1e-2,
-    }
     SUPPORTED_DEVICES = {"cuda"}
     SUPPORTED_DTYPES = {torch.half, torch.bfloat16}
     SUPPORTED_MAX_K = 128


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #443
* #442
* #440
* #439
* #438
* #434
* #429
* #426
* #421
* #415
* __->__ #412
* #411
* #433
* #432
* #405
* #404
* #403
* #399
* #398
* #397
* #396
* #395

**SUMMARY**

Performance is similar to f16

**PERFORMANCE**
*(bf16 is only available on A100)*

<details><summary>A100 fw</summary>

```
[------------- attention (attn_bias=<class 'NoneType'>) -------------]
                                 |  optimized  |  vanilla  |   flash
1 threads: -----------------------------------------------------------
      f16 B=16, M=4096, K=40     |      891.3  |   1940.7  |
      b16 B=16, M=4096, K=40     |      891.1  |   1991.0  |
      f16 B=16, M=16384, K=40    |    12748.1  |  30657.1  |
      b16 B=16, M=16384, K=40    |    12745.9  |  31955.2  |
      f16 B=160, M=4096, K=128   |    12897.9  |  20670.4  |   22651.2
      b16 B=160, M=4096, K=128   |    12756.7  |  21155.3  |
      f16 B=160, M=8192, K=128   |    51152.8  |           |   89923.7
      b16 B=160, M=8192, K=128   |    50521.9  |           |
      f16 B=256, M=128, K=16     |       25.7  |     84.4  |      42.4
      b16 B=256, M=128, K=16     |       25.8  |     82.9  |
      f16 B=256, M=128, K=32     |       26.1  |     83.9  |      42.7
      b16 B=256, M=128, K=32     |       25.9  |     83.4  |
      f16 B=256, M=128, K=64     |       26.2  |     62.8  |      29.3
      b16 B=256, M=128, K=64     |       25.9  |     83.2  |
      f16 B=256, M=128, K=128    |       37.5  |     75.6  |      50.2
      b16 B=256, M=128, K=128    |       37.2  |     82.8  |
      f16 B=256, M=512, K=16     |      182.8  |    475.1  |     113.1
      b16 B=256, M=512, K=16     |      182.7  |    487.4  |
      f16 B=256, M=512, K=32     |      186.3  |    489.5  |     131.2
      b16 B=256, M=512, K=32     |      186.3  |    501.5  |
      f16 B=256, M=512, K=64     |      215.3  |    536.4  |     236.5
      b16 B=256, M=512, K=64     |      215.0  |    549.2  |
      f16 B=256, M=512, K=128    |      359.7  |    611.1  |     598.7
      b16 B=256, M=512, K=128    |      355.6  |    623.0  |
      f16 B=256, M=1024, K=16    |      702.0  |   1786.1  |     440.2
      b16 B=256, M=1024, K=16    |      702.6  |   1757.3  |
      f16 B=256, M=1024, K=32    |      699.6  |   1815.9  |     489.9
      b16 B=256, M=1024, K=32    |      699.2  |   1788.2  |
      f16 B=256, M=1024, K=64    |      802.6  |   1938.9  |     909.0
      b16 B=256, M=1024, K=64    |      802.5  |   1908.6  |
      f16 B=256, M=1024, K=128   |     1348.7  |   2145.4  |    2253.2
      b16 B=256, M=1024, K=128   |     1334.9  |   2117.1  |
      f16 B=320, M=4096, K=128   |    25716.6  |  41314.9  |   34696.1
      b16 B=320, M=4096, K=128   |    25421.1  |  42204.4  |
      f16 B=320, M=8192, K=128   |   102092.9  |           |  137685.0
      b16 B=320, M=8192, K=128   |   101021.0  |           |
      f16 B=384, M=197, K=64     |       91.1  |    662.0  |      69.7
      b16 B=384, M=197, K=64     |       91.2  |    286.2  |
      f16 B=384, M=197, K=80     |      115.0  |    706.3  |
      b16 B=384, M=197, K=80     |      115.0  |    356.7  |
      f16 B=384, M=197, K=88     |      125.0  |    814.5  |
      b16 B=384, M=197, K=88     |      124.9  |    378.9  |
      f16 B=768, M=256, K=64     |      174.5  |    474.4  |     148.1
      b16 B=768, M=256, K=64     |      174.4  |    476.1  |
      f16 B=1024, M=128, K=16    |       54.4  |    163.9  |      42.6
      b16 B=1024, M=128, K=16    |       54.4  |    163.8  |
      f16 B=1024, M=128, K=32    |       58.6  |    174.6  |      47.2
      b16 B=1024, M=128, K=32    |       58.5  |    175.6  |
      f16 B=1024, M=128, K=64    |       73.1  |    215.3  |      81.1
      b16 B=1024, M=128, K=64    |       73.1  |    217.6  |
      f16 B=1024, M=128, K=128   |      123.3  |    289.0  |     139.8
      b16 B=1024, M=128, K=128   |      122.6  |    292.5  |
      f16 B=1024, M=197, K=64    |      220.2  |   1731.0  |     153.9
      b16 B=1024, M=197, K=64    |      220.2  |    714.2  |
      f16 B=1024, M=197, K=80    |      293.8  |   1844.1  |
      b16 B=1024, M=197, K=80    |      293.7  |    911.5  |
      f16 B=1024, M=197, K=88    |      316.5  |   2136.0  |
      b16 B=1024, M=197, K=88    |      315.0  |    970.4  |
      f16 B=1024, M=512, K=16    |      719.1  |   1759.6  |     375.2
      b16 B=1024, M=512, K=16    |      719.0  |   1804.3  |
      f16 B=1024, M=512, K=32    |      717.1  |   1831.0  |     412.4
      b16 B=1024, M=512, K=32    |      717.2  |   1875.3  |
      f16 B=1024, M=512, K=64    |      820.9  |   1999.5  |     677.4
      b16 B=1024, M=512, K=64    |      820.6  |   2053.8  |
      f16 B=1024, M=512, K=128   |     1400.9  |   2326.0  |    1988.3
      b16 B=1024, M=512, K=128   |     1387.6  |   2374.8  |
      f16 B=1024, M=1024, K=16   |     2755.0  |   7048.9  |    1500.1
      b16 B=1024, M=1024, K=16   |     2754.7  |   6931.2  |
      f16 B=1024, M=1024, K=32   |     2743.5  |   7191.8  |    1640.3
      b16 B=1024, M=1024, K=32   |     2743.7  |   7059.3  |
      f16 B=1024, M=1024, K=64   |     3135.4  |   7710.1  |    2721.0
      b16 B=1024, M=1024, K=64   |     3135.3  |   7585.4  |
      f16 B=1024, M=1024, K=128  |     5363.7  |   8483.1  |    7530.2
      b16 B=1024, M=1024, K=128  |     5363.3  |   8357.4  |
      f16 B=2400, M=256, K=64    |      521.3  |   1397.3  |     394.9
      b16 B=2400, M=256, K=64    |      515.8  |   1399.6  |
      f16 B=4096, M=4096, K=64   |   193372.8  |           |  167603.0
      b16 B=4096, M=4096, K=64   |   193347.3  |           |
      f16 B=8192, M=82, K=64     |      464.0  |   1169.0  |     336.9
      b16 B=8192, M=82, K=64     |      463.2  |   1199.9  |

Times are in microseconds (us).
```
</details>

<details><summary>A100 bw</summary>

```
[---------------- attention backward (attn_bias=<class 'NoneType'>) ----------------]
                                 |  optimized[fwd_gen]  |  vanilla  |  flash[flshatt]
1 threads: --------------------------------------------------------------------------
      f16 B=16, M=4096, K=40     |        23983.4       |   4128.9  |
      b16 B=16, M=4096, K=40     |        24100.9       |   4122.1  |
      f16 B=16, M=16384, K=40    |       454479.8       |  66858.0  |
      b16 B=16, M=16384, K=40    |       455298.8       |  66854.2  |
      f16 B=160, M=4096, K=128   |        60412.2       |  43797.2  |      54414.2
      b16 B=160, M=4096, K=128   |        60541.6       |  43645.6  |
      f16 B=160, M=8192, K=128   |       237667.8       |           |     214597.8
      b16 B=160, M=8192, K=128   |       238351.0       |           |
      f16 B=256, M=128, K=16     |           94.3       |    177.4  |         84.0
      b16 B=256, M=128, K=16     |           94.6       |    172.9  |
      f16 B=256, M=128, K=32     |           95.1       |    177.2  |         84.0
      b16 B=256, M=128, K=32     |           95.4       |    172.1  |
      f16 B=256, M=128, K=64     |           94.9       |    175.5  |         84.6
      b16 B=256, M=128, K=64     |           96.4       |    168.4  |
      f16 B=256, M=128, K=128    |          159.5       |    201.3  |        147.9
      b16 B=256, M=128, K=128    |          164.9       |    202.7  |
      f16 B=256, M=512, K=16     |          583.1       |   1146.5  |        297.5
      b16 B=256, M=512, K=16     |          596.2       |   1147.0  |
      f16 B=256, M=512, K=32     |          701.1       |   1202.0  |        393.3
      b16 B=256, M=512, K=32     |          707.9       |   1204.6  |
      f16 B=256, M=512, K=64     |          953.3       |   1347.5  |        695.6
      b16 B=256, M=512, K=64     |          957.0       |   1351.8  |
      f16 B=256, M=512, K=128    |         1689.0       |   1644.9  |       1572.8
      b16 B=256, M=512, K=128    |         1705.3       |   1643.1  |
      f16 B=256, M=1024, K=16    |         2391.8       |   4153.2  |       1033.3
      b16 B=256, M=1024, K=16    |         2412.3       |   4183.6  |
      f16 B=256, M=1024, K=32    |         2714.8       |   4296.9  |       1532.1
      b16 B=256, M=1024, K=32    |         2730.8       |   4321.9  |
      f16 B=256, M=1024, K=64    |         3426.1       |   4615.0  |       2346.3
      b16 B=256, M=1024, K=64    |         3436.0       |   4642.6  |
      f16 B=256, M=1024, K=128   |         6194.8       |   5268.9  |       5613.2
      b16 B=256, M=1024, K=128   |         6237.1       |   5291.8  |
      f16 B=320, M=4096, K=128   |        95940.6       |           |      83906.9
      b16 B=320, M=4096, K=128   |        96015.9       |           |
      f16 B=320, M=8192, K=128   |       370444.1       |           |     329339.2
      b16 B=320, M=8192, K=128   |       371007.4       |           |
      f16 B=384, M=197, K=64     |          430.8       |   1706.3  |        220.0
      b16 B=384, M=197, K=64     |          434.0       |    573.7  |
      f16 B=384, M=197, K=80     |          549.8       |   1787.8  |
      b16 B=384, M=197, K=80     |          552.7       |    764.5  |
      f16 B=384, M=197, K=88     |          585.1       |   2121.6  |
      b16 B=384, M=197, K=88     |          584.0       |    808.0  |
      f16 B=768, M=256, K=64     |          799.8       |   1229.8  |        569.2
      b16 B=768, M=256, K=64     |          797.6       |   1227.3  |
      f16 B=1024, M=128, K=16    |          175.2       |    383.6  |        143.3
      b16 B=1024, M=128, K=16    |          180.1       |    384.0  |
      f16 B=1024, M=128, K=32    |          214.0       |    440.1  |        188.9
      b16 B=1024, M=128, K=32    |          219.2       |    441.3  |
      f16 B=1024, M=128, K=64    |          357.9       |    572.6  |        302.6
      b16 B=1024, M=128, K=64    |          356.6       |    576.9  |
      f16 B=1024, M=128, K=128   |          611.2       |    874.9  |        560.1
      b16 B=1024, M=128, K=128   |          624.3       |    877.9  |
      f16 B=1024, M=197, K=64    |         1003.7       |   4501.0  |        581.7
      b16 B=1024, M=197, K=64    |         1007.6       |   1469.3  |
      f16 B=1024, M=197, K=80    |         1401.6       |   4705.6  |
      b16 B=1024, M=197, K=80    |         1394.3       |   1975.6  |
      f16 B=1024, M=197, K=88    |         1483.8       |   5585.2  |
      b16 B=1024, M=197, K=88    |         1468.6       |   2081.6  |
      f16 B=1024, M=512, K=16    |         2058.7       |   4299.9  |       1037.7
      b16 B=1024, M=512, K=16    |         2097.5       |   4298.5  |
      f16 B=1024, M=512, K=32    |         2585.8       |   4589.2  |       1376.9
      b16 B=1024, M=512, K=32    |         2600.9       |   4589.7  |
      f16 B=1024, M=512, K=64    |         3450.4       |   5121.1  |       2391.8
      b16 B=1024, M=512, K=64    |         3442.9       |   5121.5  |
      f16 B=1024, M=512, K=128   |         5920.5       |   6328.3  |       5421.9
      b16 B=1024, M=512, K=128   |         5964.6       |   6332.4  |
      f16 B=1024, M=1024, K=16   |         8709.4       |  16535.5  |       3512.2
      b16 B=1024, M=1024, K=16   |         8762.9       |  16646.8  |
      f16 B=1024, M=1024, K=32   |         9518.6       |  17119.6  |       5335.4
      b16 B=1024, M=1024, K=32   |         9543.7       |  17224.2  |
      f16 B=1024, M=1024, K=64   |        12330.7       |  18413.6  |       8032.8
      b16 B=1024, M=1024, K=64   |        12170.3       |  18508.5  |
      f16 B=1024, M=1024, K=128  |        21375.3       |  20879.7  |      19100.7
      b16 B=1024, M=1024, K=128  |        21364.6       |  20960.0  |
      f16 B=2400, M=256, K=64    |         2298.6       |   3651.8  |       1622.5
      b16 B=2400, M=256, K=64    |         2292.4       |   3649.9  |
      f16 B=4096, M=4096, K=64   |       655671.2       |           |     431484.4
      b16 B=4096, M=4096, K=64   |       652207.1       |           |
      f16 B=8192, M=82, K=64     |         2132.8       |   2708.4  |       1604.9
      b16 B=8192, M=82, K=64     |         2176.8       |   2728.3  |

Times are in microseconds (us).
```
</defails>