### PR TITLE
mmafix: Fix matmul out-of-bounds for small dimensions with preloading

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_from_smem.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/mma_from_smem.h
@@ -841,8 +841,8 @@ class MmaMultistageFromSharedMemory : public MmaBaseFromSharedMemory<
         iterator_B1.add_tile_offset({1, 0});
         this->smem_iterator_B1_.add_tile_offset({1, 0});
       }
-      iterator_B1.set_residual_tile(gemm_k_iterations_1 == 1);
-      iterator_B1.clear_mask(gemm_k_iterations_1 == 0);
+      iterator_B1.set_residual_tile(gemm_k_iterations_1 <= 1);
+      iterator_B1.clear_mask(gemm_k_iterations_1 <= 0);
     }
 
     // DEPBAR+SYNC


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #443
* #442
* #440
* #439
* #438
* #434
* #429
* #426
* __->__ #421
* #415
* #412
* #411
* #433
* #432
* #405
* #404
* #403
* #399
* #398
* #397
* #396
* #395

