### PR TITLE
causalfix: Fix causal after iteration inversion

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -63,9 +63,17 @@ mem_efficient_attention_backward_generic(
   int64_t N = key.size(1);
   int64_t K = query.size(2);
 
+  // It does not make sense to use that in practice,
+  // but let's still make sure we are correct
+  // As we iterate through keys first, we skip
+  // keys with no query associated, so they are not
+  // initialized
+  bool grad_kv_needs_init = causal && N > M;
   at::Tensor grad_q = at::empty_like(query);
-  at::Tensor grad_k = at::empty_like(key);
-  at::Tensor grad_v = at::empty_like(value);
+  at::Tensor grad_k =
+      grad_kv_needs_init ? at::zeros_like(key) : at::empty_like(key);
+  at::Tensor grad_v =
+      grad_kv_needs_init ? at::zeros_like(value) : at::empty_like(value);
 
   cudaDeviceProp* properties =
       at::cuda::getDeviceProperties(query.device().index());


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #443
* #442
* #440
* #439
* #438
* #434
* #429
* __->__ #426
* #421
* #415
* #412
* #411
* #433
* #432
* #405
* #404
* #403
* #399
* #398
* #397
* #396
* #395

**SUMMARY**

We now correctly skip the parts of the attention matrix that we shouldn't compute.