### PR TITLE
p100nvcc: Workaround a compiler bug on P100

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/iterators/predicated_tile_access_iterator_residual_last.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/iterators/predicated_tile_access_iterator_residual_last.h
@@ -228,6 +228,16 @@ class PredicatedTileAccessIteratorResidualLast<
     the_predicates.get_mask(residual_tile_mask);
     the_predicates.compute_predicates_(extent, true);
 
+    // Working around a weird compiler bug happening on P100 for the backward.
+    // I've seen together: the_predicates.predicates_[0] = 14 (instead of 15)
+    // residual_tile_mask[0] = 15 (correct)
+    //
+    // Adding prints when the value is calculated (in `compute_predicates_`)
+    // sometimes removes the bug. The consequence is that we skip the first
+    // element of a tensor, leading to wrong results. The line below should
+    // always be a no-op in theory
+    the_predicates.predicates_[0] |= residual_tile_mask[0];
+
     // update internal pointers
     Layout layout(params_.stride_);
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #443
* #442
* #440
* #439
* #438
* __->__ #434
* #429
* #426
* #421
* #415
* #412
* #411
* #433
* #432
* #405
* #404
* #403
* #399
* #398
* #397
* #396
* #395

**PERFORMANCE F16**

<details>
<summary>A100 fw</summary>

```
[--------------------------------------------------------------------------------------------- attention (attn_bias=<class 'NoneType'>) --------------------------------------------------------------------------------------------]
                                 |  prologuemma_5b7b8db  |   flash    |  vanilla  |  mma_pipeline_01fa622  |  noinit_69206e9  |  bw_preproc_e351b21  |  outputf16_64be278  |  f16_4116eb4  |  custommma_b99b79b  |  causalfix_3dbafca
1 threads: --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      f16 B=16, M=4096, K=40     |           889.5       |            |   1942.1  |           901.6        |        902.4     |          900.5       |          891.9      |       891.7   |          890.6      |          889.3    
      f16 B=16, M=16384, K=40    |         12714.4       |            |  30665.8  |         12745.1        |      12749.8     |        12742.2       |        12751.2      |     12744.1   |        12714.1      |        12711.6    
      f16 B=160, M=4096, K=128   |         13044.5       |   22651.2  |  20670.4  |         13019.2        |      13037.8     |        13038.2       |        12785.6      |     12774.6   |        13021.6      |        13044.6    
      f16 B=160, M=8192, K=128   |         51825.2       |   89923.7  |           |         51514.3        |      51568.2     |        51476.3       |        51080.8      |     51175.1   |        51745.6      |        51702.7    
      f16 B=256, M=128, K=16     |            21.6       |      42.4  |     84.4  |            29.0        |         28.3     |           28.1       |           25.8      |        25.1   |           21.6      |           21.3    
      f16 B=256, M=128, K=32     |            22.1       |      42.7  |     83.9  |            28.7        |         28.6     |           28.3       |           25.9      |        25.8   |           21.9      |           21.5    
      f16 B=256, M=128, K=64     |            22.0       |      29.3  |     62.8  |            29.2        |         28.6     |           28.4       |           25.9      |        25.5   |           22.0      |           21.8    
      f16 B=256, M=128, K=128    |            37.6       |      50.2  |     75.6  |            50.4        |         50.3     |           50.1       |           37.0      |        37.6   |           37.9      |           37.6    
      f16 B=256, M=512, K=16     |           182.9       |     113.1  |    475.1  |           189.6        |        189.2     |          189.2       |          182.8      |       182.9   |          182.9      |          182.8    
      f16 B=256, M=512, K=32     |           186.6       |     131.2  |    489.5  |           196.8        |        196.8     |          196.5       |          186.3      |       186.5   |          186.8      |          186.6    
      f16 B=256, M=512, K=64     |           215.5       |     236.5  |    536.4  |           240.8        |        241.2     |          240.6       |          215.3      |       215.2   |          215.4      |          215.3    
      f16 B=256, M=512, K=128    |           362.9       |     598.7  |    611.1  |           403.5        |        403.3     |          403.1       |          359.0      |       358.7   |          363.0      |          363.6    
      f16 B=256, M=1024, K=16    |           701.6       |     440.2  |   1786.1  |           713.2        |        713.2     |          712.9       |          702.4      |       702.4   |          701.8      |          701.5    
      f16 B=256, M=1024, K=32    |           699.4       |     489.9  |   1815.9  |           722.8        |        722.7     |          722.8       |          699.3      |       699.5   |          699.2      |          699.1    
      f16 B=256, M=1024, K=64    |           801.7       |     909.0  |   1938.9  |           849.9        |        849.8     |          849.7       |          802.3      |       802.8   |          801.9      |          801.8    
      f16 B=256, M=1024, K=128   |          1370.7       |    2253.2  |   2145.4  |          1432.6        |       1431.9     |         1432.0       |         1346.4      |      1344.5   |         1368.8      |         1370.9    
      f16 B=320, M=4096, K=128   |         25980.0       |   34696.1  |  41314.9  |         26202.4        |      26216.9     |        26166.9       |        25726.5      |     25704.2   |        25937.2      |        25978.9    
      f16 B=320, M=8192, K=128   |        103241.6       |  137685.0  |           |        103239.0        |     102853.9     |       103227.3       |       102159.8      |    102140.2   |       103096.4      |       103249.4    
      f16 B=384, M=197, K=64     |            91.6       |      69.7  |    662.0  |           103.6        |        103.5     |          103.4       |           91.2      |        91.3   |           91.4      |           91.4    
      f16 B=384, M=197, K=80     |           117.2       |            |    708.3  |           131.8        |        131.7     |          131.6       |          115.5      |       115.2   |          117.0      |          117.0    
      f16 B=384, M=197, K=88     |           126.5       |            |    815.7  |           144.5        |        144.3     |          144.1       |          124.9      |       125.0   |          126.5      |          126.4    
      f16 B=768, M=256, K=64     |           175.6       |     148.1  |    474.4  |           213.8        |        214.1     |          214.7       |          175.2      |       175.3   |          175.6      |          175.9    
      f16 B=1024, M=128, K=16    |            54.6       |      42.6  |    163.9  |            60.7        |         60.6     |           60.5       |           54.4      |        54.5   |           54.6      |           54.5    
      f16 B=1024, M=128, K=32    |            59.1       |      47.2  |    174.6  |            69.4        |         69.1     |           68.9       |           58.8      |        58.8   |           59.4      |           59.3    
      f16 B=1024, M=128, K=64    |            73.0       |      81.1  |    215.3  |           105.4        |        105.1     |          105.0       |           72.5      |        72.8   |           73.1      |           73.0    
      f16 B=1024, M=128, K=128   |           124.2       |     139.8  |    289.0  |           188.1        |        188.1     |          188.1       |          122.8      |       123.3   |          124.3      |          124.2    
      f16 B=1024, M=197, K=64    |           220.7       |     153.9  |   1731.0  |           259.5        |        259.1     |          259.4       |          220.3      |       220.4   |          220.8      |          220.6    
      f16 B=1024, M=197, K=80    |           299.5       |            |   1842.1  |           342.2        |        341.8     |          341.7       |          293.9      |       294.0   |          299.7      |          299.4    
      f16 B=1024, M=197, K=88    |           320.8       |            |   2132.8  |           368.0        |        368.1     |          368.4       |          315.3      |       315.5   |          321.1      |          320.7    
      f16 B=1024, M=512, K=16    |           719.5       |     375.2  |   1759.6  |           742.3        |        742.6     |          742.8       |          719.2      |       719.1   |          719.5      |          719.4    
      f16 B=1024, M=512, K=32    |           717.6       |     412.4  |   1831.0  |           763.7        |        763.9     |          763.8       |          716.9      |       717.0   |          717.7      |          717.3    
      f16 B=1024, M=512, K=64    |           821.3       |     677.4  |   1999.5  |           918.1        |        917.7     |          917.7       |          820.5      |       821.2   |          821.4      |          821.3    
      f16 B=1024, M=512, K=128   |          1426.5       |    1988.3  |   2326.0  |          1584.4        |       1583.5     |         1584.3       |         1403.2      |      1402.8   |         1426.2      |         1428.4    
      f16 B=1024, M=1024, K=16   |          2752.1       |    1500.1  |   7048.9  |          2802.1        |       2801.9     |         2802.8       |         2754.2      |      2754.1   |         2752.1      |         2752.4    
      f16 B=1024, M=1024, K=32   |          2742.0       |    1640.3  |   7191.8  |          2836.9        |       2836.1     |         2836.4       |         2743.6      |      2743.0   |         2742.0      |         2742.0    
      f16 B=1024, M=1024, K=64   |          3133.5       |    2721.0  |   7710.1  |          3322.9        |       3322.7     |         3322.8       |         3136.1      |      3135.3   |         3133.7      |         3133.7    
      f16 B=1024, M=1024, K=128  |          5444.2       |    7530.2  |   8483.1  |          5724.6        |       5706.8     |         5710.1       |         5400.3      |      5391.7   |         5450.9      |         5442.0    
      f16 B=2400, M=256, K=64    |           522.5       |     394.9  |   1397.3  |           632.3        |        632.7     |          633.1       |          520.4      |       520.1   |          522.5      |          522.0    
      f16 B=4096, M=4096, K=64   |        193050.6       |  167603.0  |           |        195935.1        |     195915.4     |       195925.6       |       193424.2      |    193413.5   |       193082.1      |       193051.2    
      f16 B=8192, M=82, K=64     |           466.2       |     336.9  |   1169.0  |           592.7        |        592.6     |          592.6       |          462.8      |       464.4   |          465.6      |          465.5    

Times are in microseconds (us).
```
</details>

<details>
<summary>A100 bw</summary>

```
[------------------------------------------------------------------------------------------------------------------------------- attention backward (attn_bias=<class 'NoneType'>) -------------------------------------------------------------------------------------------------------------------------------]
                                 |  prologuemma_5b7b8db[fwd_gen]  |  flash[flshatt]  |  vanilla  |  mma_pipeline_01fa622[fwd_gen]  |  noinit_69206e9[fwd_gen]  |  bw_preproc_e351b21[fwd_gen]  |  outputf16_64be278[fwd_gen]  |  f16_4116eb4[fwd_gen]  |  custommma_b99b79b[fwd_gen]  |  causalfix_3dbafca[fwd_gen]
1 threads: --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      f16 B=16, M=4096, K=40     |             21023.3            |                  |   4129.4  |              24087.5            |           23987.5         |             24031.9           |            24021.2           |         23970.8        |            21461.0           |            21410.5         
      f16 B=16, M=16384, K=40    |            383762.1            |                  |  66849.9  |             455257.4            |          454589.3         |            454280.2           |           455335.1           |        454733.6        |           414758.7           |           414633.5         
      f16 B=160, M=4096, K=128   |             56892.7            |      54414.2     |  43797.2  |              63950.3            |           63535.3         |             61703.4           |            60556.4           |         60514.7        |            60582.5           |            60356.7         
      f16 B=160, M=8192, K=128   |            222548.5            |     214597.8     |           |             244642.6            |          243884.3         |            239451.8           |           237750.5           |        237766.5        |           237916.9           |           237086.5         
      f16 B=256, M=128, K=16     |               100.5            |         84.0     |    177.4  |                178.6            |             191.7         |               133.3           |              114.2           |            92.2        |               99.6           |               98.0         
      f16 B=256, M=128, K=32     |                99.8            |         84.0     |    177.2  |                172.3            |             152.6         |               126.9           |              113.5           |            92.5        |               95.0           |               98.2         
      f16 B=256, M=128, K=64     |                96.7            |         84.6     |    175.5  |                194.3            |             173.6         |               125.0           |              112.9           |            93.3        |               95.0           |               95.1         
      f16 B=256, M=128, K=128    |               154.3            |        147.9     |    201.3  |                353.1            |             317.2         |               229.2           |              159.9           |           160.6        |              160.8           |              160.1         
      f16 B=256, M=512, K=16     |               539.6            |        297.5     |   1146.5  |                701.5            |             677.0         |               622.5           |              580.4           |           584.1        |              545.6           |              546.5         
      f16 B=256, M=512, K=32     |               643.0            |        393.3     |   1202.0  |                916.8            |             878.8         |               764.8           |              697.0           |           702.0        |              664.5           |              664.7         
      f16 B=256, M=512, K=64     |               859.7            |        695.6     |   1347.5  |               1338.5            |            1289.2         |              1091.0           |              953.2           |           953.8        |              905.4           |              905.1         
      f16 B=256, M=512, K=128    |              1607.8            |       1572.8     |   1644.9  |               2394.9            |            2310.7         |              1952.8           |             1688.1           |          1689.7        |             1690.6           |             1687.0         
      f16 B=256, M=1024, K=16    |              2181.7            |       1033.3     |   4153.2  |               2601.3            |            2552.7         |              2442.7           |             2390.0           |          2391.5        |             2238.4           |             2239.9         
      f16 B=256, M=1024, K=32    |              2460.6            |       1532.1     |   4296.9  |               3132.6            |            3077.0         |              2852.5           |             2705.4           |          2715.8        |             2589.5           |             2587.2         
      f16 B=256, M=1024, K=64    |              3035.0            |       2346.3     |   4615.0  |               4161.9            |            4065.0         |              3699.4           |             3417.0           |          3429.5        |             3221.8           |             3218.0         
      f16 B=256, M=1024, K=128   |              5808.1            |       5613.2     |   5268.9  |               7594.2            |            7443.6         |              6748.7           |             6190.0           |          6190.9        |             6195.1           |             6175.5         
      f16 B=320, M=4096, K=128   |             93362.2            |      83906.9     |           |             104946.1            |          102655.4         |            100080.1           |            97576.9           |         97551.2        |            97556.4           |            97708.8         
      f16 B=320, M=8192, K=128   |            348081.5            |     329339.2     |           |             384520.9            |          383288.2         |            375001.5           |           370542.1           |        370834.6        |           370662.6           |           369923.8         
      f16 B=384, M=197, K=64     |               397.7            |        220.0     |   1706.3  |                686.2            |             650.3         |               534.7           |              432.0           |           438.7        |              451.4           |              457.4         
      f16 B=384, M=197, K=80     |               600.0            |                  |   1790.0  |                821.7            |             783.3         |               661.6           |              552.8           |           545.5        |              571.8           |              571.2         
      f16 B=384, M=197, K=88     |               644.6            |                  |   2123.1  |                882.8            |             842.7         |               713.2           |              584.8           |           589.7        |              613.4           |              615.9         
      f16 B=768, M=256, K=64     |               749.1            |        569.2     |   1229.8  |               1354.3            |            1291.9         |              1005.6           |              798.0           |           800.3        |              771.7           |              770.3         
      f16 B=1024, M=128, K=16    |               162.1            |        143.3     |    383.6  |                292.3            |             270.0         |               215.7           |              175.7           |           176.2        |              165.4           |              164.6         
      f16 B=1024, M=128, K=32    |               197.4            |        188.9     |    440.1  |                435.9            |             398.3         |               283.1           |              214.7           |           214.7        |              203.6           |              202.4         
      f16 B=1024, M=128, K=64    |               339.2            |        302.6     |    572.6  |                747.3            |             702.0         |               498.7           |              355.9           |           355.8        |              342.9           |              342.6         
      f16 B=1024, M=128, K=128   |               588.9            |        560.1     |    874.9  |               1336.1            |            1252.2         |               883.8           |              609.7           |           611.8        |              612.8           |              611.6         
      f16 B=1024, M=197, K=64    |               914.7            |        581.7     |   4501.0  |               1583.9            |            1517.0         |              1227.4           |             1000.6           |          1002.3        |             1022.2           |             1030.9         
      f16 B=1024, M=197, K=80    |              1565.6            |                  |   4708.2  |               2039.2            |            1956.1         |              1679.6           |             1407.3           |          1399.6        |             1466.4           |             1462.1         
      f16 B=1024, M=197, K=88    |              1673.5            |                  |   5587.1  |               2170.0            |            2082.9         |              1773.6           |             1489.8           |          1488.7        |             1571.4           |             1558.1         
      f16 B=1024, M=512, K=16    |              1901.2            |       1037.7     |   4299.9  |               2495.2            |            2445.9         |              2206.7           |             2061.6           |          2067.1        |             1932.0           |             1930.3         
      f16 B=1024, M=512, K=32    |              2346.1            |       1376.9     |   4589.2  |               3423.6            |            3319.9         |              2846.4           |             2580.4           |          2586.3        |             2457.4           |             2454.1         
      f16 B=1024, M=512, K=64    |              3137.1            |       2391.8     |   5121.1  |               4873.4            |            4717.5         |              3972.6           |             3432.6           |          3450.0        |             3260.3           |             3220.3         
      f16 B=1024, M=512, K=128   |              5599.7            |       5421.9     |   6328.3  |               8620.6            |            8304.0         |              6934.5           |             5912.2           |          5910.8        |             5915.8           |             5905.8         
      f16 B=1024, M=1024, K=16   |              7885.3            |       3512.2     |  16535.5  |               9514.4            |            9430.5         |              8955.6           |             8727.1           |          8733.5        |             8242.2           |             8232.5         
      f16 B=1024, M=1024, K=32   |              8592.2            |       5335.4     |  17119.6  |              11128.8            |           10926.8         |             10035.3           |             9525.9           |          9525.4        |             9056.4           |             9033.1         
      f16 B=1024, M=1024, K=64   |             11053.3            |       8032.8     |  18413.6  |              14932.1            |           14663.6         |             13154.9           |            12167.6           |         12213.5        |            11414.4           |            11397.4         
      f16 B=1024, M=1024, K=128  |             20167.0            |      19100.7     |  20879.7  |              26709.5            |           26144.3         |             23435.3           |            21356.1           |         21334.6        |            21330.1           |            21299.6         
      f16 B=2400, M=256, K=64    |              2155.3            |       1622.5     |   3651.8  |               3954.1            |            3776.8         |              2907.1           |             2296.4           |          2295.1        |             2219.3           |             2216.9         
      f16 B=4096, M=4096, K=64   |            581472.7            |     431484.4     |           |                                 |                           |            672475.1           |           655465.5           |        656361.0        |           616553.9           |           617063.5         
      f16 B=8192, M=82, K=64     |              1944.5            |       1604.9     |   2708.4  |               3887.5            |            3692.3         |              2812.8           |             2132.4           |          2124.7        |             2285.0           |             2333.7         

Times are in microseconds (us).
```
</details>
<details>
<summary>P100/V100 fw</summary>

```
[----------------------------------------------------------------------------------------------------- attention (attn_bias=<class 'NoneType'>) ----------------------------------------------------------------------------------------------------]
                                                     |  prologuemma_5b7b8db0  |  mma_pipeline_01fa6224  |  vanilla   |  noinit_69206e9b  |  bw_preproc_e351b21d  |  outputf16_64be278e  |  f16_4116eb4a  |  custommma_b99b79bf  |  causalfix_3dbafcad
1 threads: ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f16 B=16, M=4096, K=40     |         10960.3        |          10663.5        |   13461.6  |       10616.8     |         10678.0       |        10648.5       |     10705.5    |        10691.9       |        10643.6     
                          f16 B=16, M=16384, K=40    |        163487.2        |         159726.0        |            |      159807.9     |        159601.5       |       159445.8       |    159607.4    |       159745.4       |       159204.8     
                          f16 B=160, M=4096, K=128   |        240891.4        |         234773.2        |  190089.3  |      236076.0     |        235228.9       |       234485.8       |    232758.3    |       235219.5       |       233831.7     
                          f16 B=160, M=8192, K=128   |        978719.2        |         955610.8        |            |      956724.1     |        957416.2       |       956789.1       |    955530.0    |       955085.2       |       957035.6     
                          f16 B=256, M=128, K=16     |           148.5        |            153.2        |     221.7  |         153.5     |           153.1       |          149.0       |       148.4    |          148.4       |          148.4     
                          f16 B=256, M=128, K=32     |           174.1        |            181.4        |     239.4  |         181.7     |           181.4       |          172.2       |       172.0    |          172.1       |          172.1     
                          f16 B=256, M=128, K=64     |           223.5        |            232.7        |     287.9  |         233.6     |           233.3       |          219.4       |       219.7    |          219.6       |          219.7     
                          f16 B=256, M=128, K=128    |           419.1        |            439.3        |     374.7  |         435.2     |           434.2       |          412.7       |       409.9    |          410.3       |          409.7     
                          f16 B=256, M=512, K=16     |          2102.4        |           2097.5        |    2924.5  |        2093.7     |          2095.1       |         2080.8       |      2082.1    |         2079.6       |         2080.0     
                          f16 B=256, M=512, K=32     |          2428.6        |           2461.2        |    3203.6  |        2454.1     |          2453.7       |         2422.9       |      2423.5    |         2424.5       |         2398.5     
                          f16 B=256, M=512, K=64     |          3203.3        |           3235.3        |    3812.6  |        3230.0     |          3226.9       |         3166.3       |      3129.8    |         3127.1       |         3147.9     
                          f16 B=256, M=512, K=128    |          6191.8        |           6198.8        |    4935.7  |        6207.7     |          6210.0       |         6091.8       |      6090.8    |         6088.9       |         6098.5     
                          f16 B=256, M=1024, K=16    |          8251.7        |           8108.2        |   11628.2  |        8124.0     |          8079.0       |         8043.4       |      8090.1    |         8061.1       |         8071.7     
                          f16 B=256, M=1024, K=32    |          9625.7        |           9595.4        |   12799.1  |        9589.4     |          9503.3       |         9544.6       |      9454.7    |         9444.8       |         9437.5     
                          f16 B=256, M=1024, K=64    |         12640.6        |          12533.1        |   15048.2  |       12487.9     |         12450.3       |        12434.0       |     12394.0    |        12376.4       |        12423.6     
                          f16 B=256, M=1024, K=128   |         24509.7        |          24652.0        |   19221.4  |       24236.1     |         24453.4       |        24181.7       |     24096.0    |        24055.8       |        24053.8     
                          f16 B=320, M=4096, K=128   |        484985.1        |         486631.6        |            |      479908.3     |        480946.2       |       478347.2       |    477300.8    |       477953.0       |       476468.0     
                          f16 B=320, M=8192, K=128   |       1978541.9        |        1964367.7        |            |     1963447.1     |       1963880.6       |      1961168.8       |   1956890.0    |      1952072.1       |      1946145.5     
                          f16 B=384, M=197, K=64     |          1118.8        |           1137.5        |    1245.7  |        1140.0     |          1135.5       |         1102.7       |      1096.9    |         1097.4       |         1097.5     
                          f16 B=384, M=197, K=80     |          1508.0        |           1529.3        |    1353.3  |        1523.1     |          1527.9       |         1488.0       |      1484.3    |         1483.1       |         1487.1     
                          f16 B=384, M=197, K=88     |          1567.6        |           1610.3        |    1419.1  |        1599.8     |          1591.2       |         1545.2       |      1544.6    |         1544.8       |         1546.1     
                          f16 B=768, M=256, K=64     |          2457.3        |           2532.1        |    2974.3  |        2504.4     |          2509.8       |         2422.7       |      2427.3    |         2428.6       |         2420.2     
                          f16 B=1024, M=128, K=16    |           551.6        |            566.4        |     831.9  |         559.1     |           559.4       |          544.4       |       544.5    |          545.8       |          544.5     
                          f16 B=1024, M=128, K=32    |           644.2        |            678.2        |     912.8  |         669.9     |           673.6       |          645.8       |       645.3    |          644.1       |          638.5     
                          f16 B=1024, M=128, K=64    |           847.3        |            894.5        |    1089.3  |         884.4     |           887.0       |          839.2       |       838.8    |          834.7       |          834.8     
                          f16 B=1024, M=128, K=128   |          1638.8        |           1744.2        |    1426.4  |        1722.0     |          1726.0       |         1619.4       |      1619.1    |         1620.1       |         1622.2     
                          f16 B=1024, M=197, K=64    |          2924.8        |           2981.2        |    3302.7  |        2977.8     |          2980.3       |         2887.1       |      2887.1    |         2887.2       |         2889.0     
                          f16 B=1024, M=197, K=80    |          3974.4        |           4080.2        |    3568.4  |        4060.0     |          4061.4       |         3956.3       |      3909.6    |         3911.0       |         3911.5     
                          f16 B=1024, M=197, K=88    |          4160.3        |           4285.1        |    3708.5  |        4213.8     |          4231.4       |         4119.0       |      4116.6    |         4117.5       |         4092.9     
                          f16 B=1024, M=512, K=16    |          8277.5        |           8318.6        |   11860.5  |        8251.2     |          8217.6       |         8156.7       |      8152.8    |         8155.3       |         8186.3     
                          f16 B=1024, M=512, K=32    |          9821.2        |           9838.4        |   13011.2  |        9780.9     |          9755.8       |         9639.0       |      9629.8    |         9650.4       |         9623.9     
                          f16 B=1024, M=512, K=64    |         12902.4        |          12949.7        |   15303.7  |       12885.6     |         12877.4       |        12678.1       |     12624.1    |        12658.1       |        12661.6     
                          f16 B=1024, M=512, K=128   |         24802.3        |          25311.5        |   19770.0  |       25339.3     |         25231.6       |        24847.2       |     24775.7    |        24751.3       |        24828.7     
                          f16 B=1024, M=1024, K=16   |         32635.2        |          32949.0        |   47853.0  |       32414.6     |         32553.8       |        32571.8       |     32241.7    |        32243.8       |        32238.6     
                          f16 B=1024, M=1024, K=32   |         38459.0        |          38513.0        |   52563.3  |       38373.8     |         38266.9       |        38034.0       |     38030.3    |        38083.7       |        38116.0     
                          f16 B=1024, M=1024, K=64   |         50009.6        |          50841.9        |   61511.2  |       50505.6     |         50478.4       |        50028.8       |     50083.4    |        50002.1       |        50008.7     
                          f16 B=1024, M=1024, K=128  |         99551.1        |         100325.7        |   78776.9  |       99628.5     |         99329.0       |        98325.2       |     98545.2    |        98329.9       |        98327.6     
                          f16 B=2400, M=256, K=64    |          7638.2        |           7873.4        |    9337.3  |        7764.6     |          7824.9       |         7566.4       |      7555.2    |         7572.5       |         7501.4     
                          f16 B=4096, M=4096, K=64   |       3202425.9        |                         |            |                   |                       |      3198336.1       |   3191382.4    |      3191169.4       |      3189070.0     
                          f16 B=8192, M=82, K=64     |          5705.2        |           5956.8        |    6390.2  |        5911.1     |          5914.2       |         5674.2       |      5666.7    |         5622.7       |         5617.3     
  (Tesla_V100_SXM2_16GB)  f16 B=16, M=4096, K=40     |          2343.5        |           2381.6        |    4161.3  |        2389.6     |          2384.8       |         2348.6       |      2348.7    |         2349.4       |         2345.8     
                          f16 B=16, M=16384, K=40    |         33589.0        |          34362.1        |            |       34318.7     |         34244.8       |        33266.4       |     33269.3    |        33266.6       |        33277.3     
                          f16 B=160, M=4096, K=128   |         38600.2        |          37651.4        |   42580.8  |       37676.1     |         37637.0       |        38124.3       |     38300.0    |        38168.1       |        38192.5     
                          f16 B=160, M=8192, K=128   |        154295.8        |         150243.8        |            |      150159.3     |        150018.1       |       152811.9       |    152789.1    |       152655.8       |       152731.5     
                          f16 B=256, M=128, K=16     |            42.9        |             68.0        |     137.2  |          60.4     |            57.1       |           44.1       |        43.1    |           42.9       |           42.9     
                          f16 B=256, M=128, K=32     |            46.4        |             67.8        |     139.7  |          60.5     |            56.4       |           46.2       |        46.5    |           46.4       |           46.5     
                          f16 B=256, M=128, K=64     |            56.2        |             72.2        |     135.3  |          73.7     |            72.8       |           56.1       |        56.3    |           56.2       |           56.2     
                          f16 B=256, M=128, K=128    |            85.0        |            112.4        |     135.3  |         111.8     |           111.9       |           84.3       |        84.4    |           84.6       |           84.3     
                          f16 B=256, M=512, K=16     |           482.2        |            516.4        |     796.8  |         516.2     |           517.0       |          482.4       |       481.4    |          481.3       |          481.3     
                          f16 B=256, M=512, K=32     |           489.4        |            532.5        |     822.5  |         533.4     |           532.6       |          485.9       |       485.6    |          485.4       |          485.5     
                          f16 B=256, M=512, K=64     |           597.2        |            651.0        |     972.3  |         649.4     |           648.7       |          591.3       |       591.7    |          592.5       |          591.5     
                          f16 B=256, M=512, K=128    |          1058.1        |           1130.8        |    1153.0  |        1129.8     |          1128.3       |         1049.6       |      1052.9    |         1048.6       |         1047.9     
                          f16 B=256, M=1024, K=16    |          1852.4        |           1971.6        |    3327.7  |        1971.7     |          1969.2       |         1854.3       |      1853.3    |         1852.7       |         1852.5     
                          f16 B=256, M=1024, K=32    |          1870.9        |           2011.2        |    3415.5  |        2011.2     |          2008.5       |         1868.8       |      1868.3    |         1867.0       |         1868.3     
                          f16 B=256, M=1024, K=64    |          2281.8        |           2411.8        |    3849.3  |        2415.6     |          2407.2       |         2272.3       |      2280.9    |         2279.7       |         2279.3     
                          f16 B=256, M=1024, K=128   |          4004.9        |           4182.3        |    4258.3  |        4166.0     |          4157.4       |         3975.0       |      3977.7    |         3984.2       |         3968.1     
                          f16 B=320, M=4096, K=128   |         77288.2        |          76297.7        |            |       76265.8     |         76209.7       |        77283.3       |     77237.7    |        77288.2       |        77302.4     
                          f16 B=320, M=8192, K=128   |        310855.9        |         306341.6        |            |      306149.3     |        304142.9       |       308931.7       |    308956.2    |       308917.7       |       308767.0     
                          f16 B=384, M=197, K=64     |           229.2        |            257.7        |     412.3  |         257.6     |           257.2       |          229.1       |       229.4    |          229.1       |          229.7     
                          f16 B=384, M=197, K=80     |           305.1        |            328.7        |     517.0  |         328.3     |           328.6       |          302.9       |       302.9    |          302.4       |          302.4     
                          f16 B=384, M=197, K=88     |           315.0        |            341.4        |     536.8  |         341.2     |           338.5       |          314.0       |       314.2    |          314.0       |          314.0     
                          f16 B=768, M=256, K=64     |           463.6        |            545.4        |     773.9  |         546.3     |           546.4       |          464.5       |       462.2    |          462.0       |          461.5     
                          f16 B=1024, M=128, K=16    |           138.5        |            156.5        |     232.1  |         156.0     |           156.3       |          138.6       |       138.7    |          138.4       |          138.8     
                          f16 B=1024, M=128, K=32    |           143.6        |            173.8        |     259.3  |         173.1     |           173.1       |          142.6       |       142.7    |          142.6       |          142.8     
                          f16 B=1024, M=128, K=64    |           179.8        |            239.3        |     325.5  |         238.6     |           239.0       |          179.0       |       179.8    |          179.4       |          179.6     
                          f16 B=1024, M=128, K=128   |           312.6        |            402.5        |     452.4  |         402.9     |           401.4       |          309.8       |       309.6    |          309.4       |          309.8     
                          f16 B=1024, M=197, K=64    |           588.5        |            652.9        |    1062.3  |         652.8     |           652.7       |          583.3       |       588.6    |          584.3       |          583.1     
                          f16 B=1024, M=197, K=80    |           798.2        |            864.9        |    1346.7  |         862.4     |           862.0       |          791.9       |       791.0    |          792.1       |          791.2     
                          f16 B=1024, M=197, K=88    |           816.9        |            896.1        |    1397.8  |         890.5     |           887.7       |          818.0       |       816.7    |          815.1       |          815.3     
                          f16 B=1024, M=512, K=16    |          1856.3        |           1995.0        |    3060.9  |        1991.3     |          1991.1       |         1857.4       |      1858.3    |         1856.8       |         1856.7     
                          f16 B=1024, M=512, K=32    |          1907.7        |           2054.7        |    3208.5  |        2051.6     |          2050.7       |         1892.6       |      1889.7    |         1890.6       |         1890.6     
                          f16 B=1024, M=512, K=64    |          2319.4        |           2538.0        |    3866.5  |        2538.1     |          2519.7       |         2323.4       |      2324.1    |         2320.7       |         2322.2     
                          f16 B=1024, M=512, K=128   |          4151.2        |           4437.7        |    4506.8  |        4414.3     |          4411.5       |         4136.2       |      4150.4    |         4108.6       |         4107.5     
                          f16 B=1024, M=1024, K=16   |          7151.2        |           7587.3        |   13649.1  |        7581.3     |          7583.8       |         7144.2       |      7145.3    |         7140.4       |         7154.7     
                          f16 B=1024, M=1024, K=32   |          7322.9        |           7724.1        |   14087.3  |        7728.2     |          7729.3       |         7256.4       |      7305.2    |         7257.3       |         7256.1     
                          f16 B=1024, M=1024, K=64   |          8885.9        |           9439.2        |   15464.8  |        9487.3     |          9404.9       |         8895.5       |      8881.9    |         8889.4       |         8829.7     
                          f16 B=1024, M=1024, K=128  |         15746.0        |          16516.6        |   16894.8  |       16471.8     |         16485.4       |        15760.9       |     15755.7    |        15748.2       |        15747.2     
                          f16 B=2400, M=256, K=64    |          1453.2        |           1678.3        |    2372.7  |        1675.3     |          1675.9       |         1443.4       |      1444.8    |         1443.5       |         1443.6     
                          f16 B=8192, M=82, K=64     |          1220.5        |           1432.3        |    1698.0  |        1432.3     |          1431.8       |         1220.8       |      1219.8    |         1218.3       |         1218.0     
                          f16 B=4096, M=4096, K=64   |        542192.0        |                         |            |                   |                       |       542462.9       |    542126.2    |       541959.6       |       542358.3     

Times are in microseconds (us).
```
</details>

<details>
<summary>P100/V100 bw</summary>

```
[------------------------------------------------------------------------------------------------ attention backward (attn_bias=<class 'NoneType'>) ------------------------------------------------------------------------------------------------]
                                                     |  prologuemma_5b7b8db0  |  mma_pipeline_01fa6224  |  vanilla   |  noinit_69206e9b  |  bw_preproc_e351b21d  |  outputf16_64be278e  |  f16_4116eb4a  |  custommma_b99b79bf  |  causalfix_3dbafcad
1 threads: ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f16 B=16, M=4096, K=40     |        142483.3        |         137362.3        |   29010.8  |      137561.4     |        137519.0       |       137232.6       |    137343.8    |       137126.3       |       135757.0     
                          f16 B=16, M=16384, K=40    |       2272261.1        |        2181354.0        |            |     2181528.0     |       2185337.1       |      2186645.9       |   2187463.2    |      2186971.3       |      2163006.2     
                          f16 B=160, M=4096, K=128   |       1072521.5        |        1098046.0        |            |     1095272.4     |       1091653.2       |      1088101.0       |   1084261.8    |      1088366.8       |      1087131.6     
                          f16 B=160, M=8192, K=128   |       4274453.6        |        4358173.9        |            |     4353036.5     |       4344974.6       |      4347698.1       |   4336783.9    |      4352458.5       |      4330207.6     
                          f16 B=256, M=128, K=16     |           513.0        |            601.0        |     502.8  |         591.4     |           541.7       |          511.5       |       512.0    |          512.0       |          507.0     
                          f16 B=256, M=128, K=32     |           598.5        |            766.4        |     558.6  |         752.8     |           651.4       |          595.3       |       595.2    |          594.8       |          589.0     
                          f16 B=256, M=128, K=64     |           780.0        |           1025.8        |     680.5  |         999.6     |           867.4       |          766.5       |       769.7    |          771.5       |          746.8     
                          f16 B=256, M=128, K=128    |          1607.1        |           2094.3        |     965.7  |        2050.7     |          1814.5       |         1632.7       |      1632.7    |         1631.5       |         1630.0     
                          f16 B=256, M=512, K=16     |          7670.5        |           7798.3        |    6694.3  |        7772.5     |          7622.7       |         7529.3       |      7538.2    |         7533.7       |         7444.5     
                          f16 B=256, M=512, K=32     |          8702.7        |           9089.5        |    7126.3  |        9052.5     |          8719.5       |         8538.5       |      8539.4    |         8534.8       |         8436.8     
                          f16 B=256, M=512, K=64     |         11101.2        |          11820.0        |    8052.0  |       11679.3     |         11316.9       |        10938.8       |     10949.0    |        10948.3       |        10734.4     
                          f16 B=256, M=512, K=128    |         24809.0        |          27036.5        |   10643.1  |       26673.5     |         25658.9       |        25114.0       |     25018.6    |        24986.1       |        25004.9     
                          f16 B=256, M=1024, K=16    |         30455.8        |          30048.5        |   25949.0  |       30054.5     |         29897.5       |        29686.3       |     29704.8    |        29702.3       |        29404.9     
                          f16 B=256, M=1024, K=32    |         34453.1        |          34847.9        |   27301.0  |       34542.6     |         34038.7       |        33615.5       |     33640.6    |        33695.3       |        33133.3     
                          f16 B=256, M=1024, K=64    |         44732.5        |          45625.2        |   30445.6  |       45162.0     |         44827.5       |        44177.4       |     44309.9    |        44243.9       |        42942.1     
                          f16 B=256, M=1024, K=128   |        101380.0        |         105469.8        |   39724.3  |      105322.5     |        104108.6       |       103185.8       |    102727.0    |       104558.9       |       102550.2     
                          f16 B=320, M=4096, K=128   |       1726382.8        |        1761592.9        |            |     1746625.6     |       1750922.5       |      1741059.3       |   1744287.3    |      1745400.7       |      1747610.5     
                          f16 B=320, M=8192, K=128   |       6892781.0        |        7004021.7        |            |     6973618.8     |       6952586.3       |      6971498.5       |   6961703.2    |      6938487.0       |      6968746.7     
                          f16 B=384, M=197, K=64     |          3592.8        |           4153.8        |    2576.6  |        4115.2     |          3807.0       |         3570.6       |      3568.6    |         3571.0       |         3565.3     
                          f16 B=384, M=197, K=80     |          6471.9        |           7225.0        |    3040.3  |        7160.4     |          6794.3       |         6521.3       |      6513.7    |         6547.1       |         6525.3     
                          f16 B=384, M=197, K=88     |          6759.5        |           7540.0        |    3161.1  |        7476.6     |          7102.1       |         6796.8       |      6810.0    |         6816.4       |         6814.0     
                          f16 B=768, M=256, K=64     |          7329.6        |           8516.3        |    6534.9  |        8414.0     |          7699.1       |         7175.7       |      7182.0    |         7153.8       |         7000.0     
                          f16 B=1024, M=128, K=16    |          1725.2        |           2019.8        |    1865.6  |        1999.3     |          1809.9       |         1712.0       |      1711.1    |         1711.0       |         1694.1     
                          f16 B=1024, M=128, K=32    |          2025.0        |           2601.5        |    2073.9  |        2560.3     |          2182.1       |         2001.5       |      2001.2    |         2014.8       |         1990.7     
                          f16 B=1024, M=128, K=64    |          2689.7        |           3600.2        |    2528.5  |        3508.8     |          2996.5       |         2668.7       |      2661.9    |         2664.0       |         2618.0     
                          f16 B=1024, M=128, K=128   |          5663.8        |           7479.7        |    3661.7  |        7330.9     |          6417.2       |         5750.6       |      5755.6    |         5731.4       |         5758.8     
                          f16 B=1024, M=197, K=64    |          8897.3        |          10420.7        |    6772.7  |       10325.5     |          9404.9       |         8927.4       |      8873.7    |         8889.8       |         8980.9     
                          f16 B=1024, M=197, K=80    |         16129.6        |          18056.2        |    7988.5  |       17893.3     |         16926.6       |        16291.8       |     16296.5    |        16274.0       |        16292.2     
                          f16 B=1024, M=197, K=88    |         16893.5        |          18964.0        |    8238.2  |       18760.0     |         17674.5       |        16983.0       |     17062.7    |        16958.0       |        17056.0     
                          f16 B=1024, M=512, K=16    |         25826.5        |          26155.6        |   26340.5  |       26122.0     |         25491.2       |        25231.4       |     25182.6    |        25109.6       |        25007.8     
                          f16 B=1024, M=512, K=32    |         29666.8        |          31374.0        |   28154.2  |       31080.5     |         29814.5       |        29192.7       |     29167.2    |        29122.9       |        28766.7     
                          f16 B=1024, M=512, K=64    |         39050.2        |          41466.6        |   31670.1  |       41140.8     |         39634.5       |        38233.8       |     38327.0    |        38384.5       |        37582.2     
                          f16 B=1024, M=512, K=128   |         87161.7        |          95139.0        |   42416.3  |       94596.5     |         90787.5       |        88516.3       |     87816.6    |        88687.1       |        87968.0     
                          f16 B=1024, M=1024, K=16   |        103075.8        |         102361.0        |  104081.8  |      101650.3     |        101193.8       |       100655.9       |    100544.0    |       100508.8       |        99583.0     
                          f16 B=1024, M=1024, K=32   |        117993.3        |         119207.3        |  110198.8  |      118782.2     |        116652.1       |       115991.8       |    115799.1    |       115721.0       |       114678.2     
                          f16 B=1024, M=1024, K=64   |        154413.3        |         158852.3        |  122803.3  |      157318.3     |        153920.3       |       153290.8       |    152304.6    |       152764.3       |       148607.8     
                          f16 B=1024, M=1024, K=128  |        345453.3        |         363410.9        |  163346.7  |      360159.9     |        353040.4       |       347600.9       |    348481.8    |       348529.4       |       348932.7     
                          f16 B=2400, M=256, K=64    |         22862.5        |          26499.9        |   20292.2  |       26250.5     |         23902.9       |        22353.4       |     22286.9    |        22367.2       |        21905.6     
                          f16 B=8192, M=82, K=64     |         22460.4        |          27036.9        |   13648.9  |       26878.2     |         24118.5       |        22426.0       |     22595.5    |        22587.0       |        22347.6     
  (Tesla_V100_SXM2_16GB)  f16 B=16, M=4096, K=40     |         47166.8        |          48023.5        |    8441.1  |       47947.6     |         47821.8       |        47586.9       |     47603.4    |        47584.3       |        47676.7     
                          f16 B=16, M=16384, K=40    |        753003.5        |         762569.6        |            |      762771.6     |        758410.5       |       760353.4       |    760940.6    |       760544.1       |       761575.7     
                          f16 B=160, M=4096, K=128   |        136755.5        |         147209.2        |            |      146874.1     |        144219.8       |       142414.9       |    142174.3    |       142175.3       |       138133.4     
                          f16 B=160, M=8192, K=128   |        549803.7        |         577194.1        |            |      571631.5     |        567173.1       |       570909.5       |    570116.1    |       570142.0       |       557495.1     
                          f16 B=256, M=128, K=16     |           146.2        |            394.9        |     392.0  |         345.3     |           287.7       |          196.1       |       212.6    |          142.4       |          145.4     
                          f16 B=256, M=128, K=32     |           157.5        |            445.3        |     414.9  |         301.8     |           314.7       |          211.0       |       176.3    |          155.8       |          156.1     
                          f16 B=256, M=128, K=64     |           235.4        |            433.4        |     407.1  |         378.2     |           297.1       |          237.9       |       236.8    |          236.4       |          236.9     
                          f16 B=256, M=128, K=128    |           424.9        |            726.2        |     380.8  |         685.7     |           547.3       |          439.4       |       440.7    |          438.8       |          427.7     
                          f16 B=256, M=512, K=16     |          1652.6        |           1826.7        |    1817.8  |        1805.7     |          1721.6       |         1666.5       |      1666.7    |         1665.3       |         1662.7     
                          f16 B=256, M=512, K=32     |          1856.8        |           2189.3        |    1937.7  |        2155.5     |          1992.5       |         1881.5       |      1880.1    |         1877.3       |         1865.3     
                          f16 B=256, M=512, K=64     |          2500.2        |           3113.1        |    2247.4  |        3016.9     |          2753.1       |         2559.3       |      2544.5    |         2544.0       |         2522.0     
                          f16 B=256, M=512, K=128    |          4563.3        |           5760.4        |    2799.3  |        5609.5     |          5108.1       |         4737.3       |      4695.2    |         4696.3       |         4564.3     
                          f16 B=256, M=1024, K=16    |          6365.3        |           6689.5        |    6839.6  |        6622.0     |          6474.5       |         6436.4       |      6416.1    |         6400.7       |         6456.0     
                          f16 B=256, M=1024, K=32    |          6987.7        |           7669.3        |    7100.0  |        7550.5     |          7254.7       |         7078.1       |      7072.8    |         7084.8       |         7023.4     
                          f16 B=256, M=1024, K=64    |          9378.7        |          10654.5        |    7928.9  |       10443.5     |          9913.1       |         9572.6       |      9536.6    |         9553.3       |         9447.6     
                          f16 B=256, M=1024, K=128   |         16940.3        |          19698.4        |    9365.6  |       19756.0     |         18825.5       |        17913.4       |     17853.4    |        17772.3       |        17407.2     
                          f16 B=320, M=4096, K=128   |        272921.2        |         300641.7        |            |      302416.2     |        298778.5       |       285305.9       |    285764.2    |       285664.5       |       277529.9     
                          f16 B=320, M=8192, K=128   |       1131872.9        |        1149972.6        |            |     1157017.9     |       1152996.6       |      1162352.9       |   1170555.3    |      1164948.7       |      1141451.5     
                          f16 B=384, M=197, K=64     |          1182.1        |           1524.4        |     926.0  |        1474.0     |          1318.5       |         1181.0       |      1182.2    |         1178.7       |         1182.3     
                          f16 B=384, M=197, K=80     |          1664.3        |           2092.0        |    1129.7  |        2031.9     |          1852.9       |         1695.2       |      1697.5    |         1693.9       |         1675.5     
                          f16 B=384, M=197, K=88     |          1731.5        |           2191.9        |    1180.9  |        2125.8     |          1933.6       |         1761.1       |      1764.8    |         1760.5       |         1742.4     
                          f16 B=768, M=256, K=64     |          1944.0        |           2780.4        |    1940.8  |        2670.6     |          2268.0       |         1969.9       |      1964.4    |         1962.0       |         1951.3     
                          f16 B=1024, M=128, K=16    |           466.4        |            641.3        |     558.7  |         614.5     |           522.3       |          462.6       |       463.0    |          462.6       |          465.1     
                          f16 B=1024, M=128, K=32    |           572.2        |            898.2        |     663.2  |         852.0     |           679.9       |          572.9       |       572.5    |          571.9       |          571.3     
                          f16 B=1024, M=128, K=64    |           857.6        |           1412.7        |     872.6  |        1338.0     |          1058.0       |          857.2       |       858.6    |          858.8       |          859.7     
                          f16 B=1024, M=128, K=128   |          1502.9        |           2591.8        |    1330.7  |        2449.4     |          1945.7       |         1553.1       |      1556.7    |         1550.1       |         1508.9     
                          f16 B=1024, M=197, K=64    |          2920.9        |           3743.8        |    2357.0  |        3630.8     |          3232.9       |         2911.2       |      2906.5    |         2910.6       |         2921.6     
                          f16 B=1024, M=197, K=80    |          4330.6        |           5389.0        |    2916.2  |        5241.9     |          4799.2       |         4413.1       |      4420.2    |         4417.6       |         4364.7     
                          f16 B=1024, M=197, K=88    |          4509.0        |           5656.0        |    3041.8  |        5503.3     |          5014.2       |         4592.3       |      4598.0    |         4589.3       |         4543.9     
                          f16 B=1024, M=512, K=16    |          5802.1        |           6390.9        |    7153.3  |        6320.5     |          6019.8       |         5831.8       |      5843.5    |         5834.3       |         5796.7     
                          f16 B=1024, M=512, K=32    |          6620.8        |           7826.0        |    7679.6  |        7750.8     |          7063.9       |         6702.3       |      6713.2    |         6702.3       |         6635.7     
                          f16 B=1024, M=512, K=64    |          9258.3        |          11483.9        |    8961.5  |       11217.4     |         10150.4       |         9413.6       |      9418.4    |         9409.3       |         9308.3     
                          f16 B=1024, M=512, K=128   |         15922.0        |          20567.3        |   10949.8  |       20019.9     |         18032.2       |        16516.2       |     16502.7    |        16474.5       |        16020.5     
                          f16 B=1024, M=1024, K=16   |         22313.1        |          23586.8        |   27808.5  |       23351.6     |         22801.1       |        22515.4       |     22494.6    |        22448.1       |        22381.0     
                          f16 B=1024, M=1024, K=32   |         25068.8        |          27621.9        |   28917.7  |       27310.4     |         26112.6       |        25389.2       |     25397.5    |        25353.4       |        25081.4     
                          f16 B=1024, M=1024, K=64   |         34493.4        |          39151.6        |   32442.1  |       38890.3     |         36545.1       |        35107.9       |     35189.7    |        35045.6       |        34673.4     
                          f16 B=1024, M=1024, K=128  |         61377.2        |          72100.8        |   37242.8  |       68658.2     |         64959.4       |        62388.3       |     61668.5    |        61600.4       |        59972.6     
                          f16 B=2400, M=256, K=64    |          6007.6        |           8562.6        |    5941.1  |        8210.9     |          7005.8       |         6078.0       |      6092.6    |         6088.7       |         6042.2     
                          f16 B=8192, M=82, K=64     |          9327.1        |          11836.2        |    3928.7  |       11555.3     |         10247.4       |         9247.6       |      9285.1    |         9273.2       |         9310.6     

Times are in microseconds (us).
```
</details>


**PERFORMANCE F32**
<details>
<summary>P100/V100 fw</summary>

```
[---------------------------------------------------------------------------------------------------- attention (attn_bias=<class 'NoneType'>) ----------------------------------------------------------------------------------------------------]
                                                     |  prologuemma_5b7b8db0  |  mma_pipeline_01fa6224  |  vanilla  |  noinit_69206e9b  |  bw_preproc_e351b21d  |  outputf16_64be278e  |  f16_4116eb4a  |  custommma_b99b79bf  |  causalfix_3dbafcad
1 threads: -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f32 B=16, M=4096, K=40     |          9898.7        |           9653.5        |  17370.3  |        9913.8     |          9869.6       |         9820.4       |      9865.7    |         9901.7       |         9867.0     
                          f32 B=16, M=16384, K=40    |        150096.7        |         145916.8        |           |      150564.0     |        150577.0       |       150051.5       |    150230.4    |       150698.4       |       150593.0     
                          f32 B=160, M=4096, K=128   |        225357.2        |         227119.8        |           |      229961.3     |        230630.5       |       229917.1       |    226251.1    |       228945.8       |       227947.1     
                          f32 B=160, M=8192, K=128   |        947058.6        |         932282.7        |           |      945546.8     |        938399.3       |       940146.4       |    939358.1    |       939315.9       |       953977.0     
                          f32 B=256, M=128, K=16     |           141.2        |            140.5        |    257.9  |         141.7     |           142.8       |          140.4       |       140.4    |          140.3       |          141.1     
                          f32 B=256, M=128, K=32     |           163.3        |            167.7        |    288.7  |         169.2     |           169.0       |          164.3       |       163.3    |          162.7       |          163.4     
                          f32 B=256, M=128, K=64     |           213.7        |            224.3        |    340.8  |         226.4     |           227.3       |          214.2       |       213.5    |          214.8       |          213.5     
                          f32 B=256, M=128, K=128    |           424.0        |            441.2        |    452.3  |         446.9     |           445.3       |          424.6       |       423.5    |          423.4       |          422.8     
                          f32 B=256, M=512, K=16     |          1934.8        |           1900.8        |   3473.7  |        1927.7     |          1927.8       |         1913.7       |      1912.0    |         1911.7       |         1938.0     
                          f32 B=256, M=512, K=32     |          2255.8        |           2257.3        |   3693.3  |        2271.8     |          2260.6       |         2256.2       |      2255.7    |         2256.0       |         2255.4     
                          f32 B=256, M=512, K=64     |          2929.7        |           2940.8        |   4329.1  |        2993.3     |          2986.5       |         2925.3       |      2928.5    |         2929.2       |         2927.2     
                          f32 B=256, M=512, K=128    |          5839.9        |           5910.4        |   5550.8  |        5948.9     |          5953.6       |         5843.0       |      5836.7    |         5842.5       |         5843.8     
                          f32 B=256, M=1024, K=16    |          7502.3        |           7474.8        |  13427.2  |        7565.2     |          7589.4       |         7543.0       |      7571.1    |         7535.6       |         7421.2     
                          f32 B=256, M=1024, K=32    |          8823.4        |           8794.9        |  14479.5  |        9018.9     |          8843.8       |         8879.0       |      8988.1    |         8870.3       |         8877.7     
                          f32 B=256, M=1024, K=64    |         11400.4        |          11473.4        |  16735.4  |       11485.0     |         11489.9       |        11379.5       |     11375.3    |        11380.0       |        11352.7     
                          f32 B=256, M=1024, K=128   |         22684.9        |          22931.0        |  21228.3  |       22904.1     |         22902.2       |        22860.0       |     22836.1    |        22695.0       |        23055.0     
                          f32 B=320, M=4096, K=128   |        473291.2        |         470555.6        |           |      472695.5     |        472487.4       |       471413.8       |    472016.0    |       473035.4       |       471742.0     
                          f32 B=320, M=8192, K=128   |       1913200.1        |        1939532.0        |           |     1907098.7     |       1938646.0       |      1933730.0       |   1918949.6    |      1911618.8       |      1909216.7     
                          f32 B=384, M=197, K=64     |          1033.6        |           1058.5        |   1378.5  |        1067.5     |          1065.2       |         1032.0       |      1032.2    |         1034.9       |         1033.7     
                          f32 B=384, M=197, K=80     |          1472.2        |           1483.0        |   1482.8  |        1506.8     |          1509.2       |         1470.8       |      1467.3    |         1468.1       |         1472.2     
                          f32 B=384, M=197, K=88     |          1538.7        |           1567.9        |   1555.4  |        1561.2     |          1563.3       |         1533.9       |      1536.5    |         1534.9       |         1517.9     
                          f32 B=768, M=256, K=64     |          2266.5        |           2334.6        |   3409.8  |        2339.1     |          2337.1       |         2266.8       |      2265.6    |         2283.1       |         2268.8     
                          f32 B=1024, M=128, K=16    |           513.7        |            525.8        |    971.8  |         527.6     |           525.0       |          520.0       |       519.7    |          520.0       |          513.7     
                          f32 B=1024, M=128, K=32    |           610.2        |            633.7        |   1071.0  |         636.1     |           636.6       |          604.2       |       608.0    |          609.0       |          604.5     
                          f32 B=1024, M=128, K=64    |           796.7        |            846.1        |   1272.4  |         841.8     |           846.4       |          797.1       |       796.3    |          797.1       |          797.2     
                          f32 B=1024, M=128, K=128   |          1644.4        |           1726.3        |   1710.0  |        1734.4     |          1726.8       |         1631.0       |      1641.9    |         1644.1       |         1636.3     
                          f32 B=1024, M=197, K=64    |          2711.7        |           2747.3        |   3599.2  |        2753.1     |          2746.8       |         2711.7       |      2709.6    |         2713.0       |         2705.6     
                          f32 B=1024, M=197, K=80    |          3871.7        |           3980.9        |   3931.4  |        3979.0     |          3986.6       |         3873.8       |      3869.7    |         3873.7       |         3874.2     
                          f32 B=1024, M=197, K=88    |          4056.7        |           4158.6        |   4091.0  |        4168.5     |          4157.1       |         4051.0       |      4057.3    |         4061.9       |         4051.7     
                          f32 B=1024, M=512, K=16    |          7562.0        |           7633.8        |  13816.3  |        7589.9     |          7596.8       |         7575.8       |      7570.4    |         7587.0       |         7564.4     
                          f32 B=1024, M=512, K=32    |          9031.8        |           8929.9        |  14850.9  |        9013.5     |          8972.3       |         8902.6       |      8978.1    |         8970.7       |         8863.5     
                          f32 B=1024, M=512, K=64    |         11623.4        |          11836.5        |  17379.8  |       11849.6     |         11831.3       |        11616.6       |     11610.2    |        11615.6       |        11617.7     
                          f32 B=1024, M=512, K=128   |         23698.1        |          23984.9        |  22285.8  |       24024.0     |         24102.7       |        23720.0       |     23693.2    |        23728.8       |        23727.2     
                          f32 B=1024, M=1024, K=16   |         29761.0        |          29804.6        |  54333.9  |       29773.2     |         29883.4       |        29863.4       |     29697.6    |        29787.9       |        29642.4     
                          f32 B=1024, M=1024, K=32   |         34875.2        |          35390.8        |  59224.7  |       35358.6     |         35137.3       |        35111.9       |     35398.7    |        34879.6       |        35144.0     
                          f32 B=1024, M=1024, K=64   |         45764.2        |          46190.4        |  68449.9  |       46057.4     |         46095.5       |        45702.5       |     45689.8    |        45718.8       |        45641.9     
                          f32 B=1024, M=1024, K=128  |         92054.5        |          93108.3        |  86647.4  |       93233.4     |         93240.1       |        92356.6       |     92350.7    |        92210.6       |        92248.8     
                          f32 B=2400, M=256, K=64    |          7036.4        |           7286.8        |  10615.2  |        7289.7     |          7244.9       |         7029.9       |      7024.2    |         7029.2       |         7028.9     
                          f32 B=8192, M=82, K=64     |          5292.0        |           5550.0        |   6855.6  |        5543.5     |          5546.8       |         5306.1       |      5255.5    |         5309.5       |         5291.2     
  (Tesla_V100_SXM2_16GB)  f32 B=16, M=4096, K=40     |          5849.6        |           5836.7        |   8035.7  |        5843.8     |          5855.4       |         5854.4       |      5855.1    |         5857.5       |         5844.5     
                          f32 B=16, M=16384, K=40    |         86526.8        |          85904.5        |           |       86656.9     |         86806.0       |        86968.7       |     86779.5    |        86965.3       |        86396.0     
                          f32 B=160, M=4096, K=128   |        128351.5        |         127113.9        |           |      129100.9     |        128958.7       |       128424.2       |    128647.2    |       128709.9       |       128726.2     
                          f32 B=160, M=8192, K=128   |        522432.4        |         518809.5        |           |      521314.9     |        521947.4       |       522044.0       |    521264.1    |       521157.3       |       521758.8     
                          f32 B=256, M=128, K=16     |            82.6        |             86.4        |    120.5  |          85.6     |            85.5       |           82.4       |        82.1    |           82.1       |           83.0     
                          f32 B=256, M=128, K=32     |            94.9        |             99.8        |    142.9  |         100.1     |            99.8       |           95.0       |        95.0    |           94.7       |           95.0     
                          f32 B=256, M=128, K=64     |           126.1        |            132.4        |    199.0  |         133.0     |           133.7       |          125.9       |       125.9    |          125.5       |          125.3     
                          f32 B=256, M=128, K=128    |           235.3        |            250.1        |    325.2  |         252.3     |           252.7       |          234.9       |       235.2    |          235.2       |          234.8     
                          f32 B=256, M=512, K=16     |          1091.5        |           1100.5        |   1782.5  |        1101.7     |          1101.7       |         1092.3       |      1090.7    |         1090.6       |         1092.3     
                          f32 B=256, M=512, K=32     |          1279.0        |           1286.9        |   1920.9  |        1298.9     |          1298.1       |         1278.7       |      1278.6    |         1278.7       |         1278.8     
                          f32 B=256, M=512, K=64     |          1679.4        |           1692.2        |   2261.9  |        1711.0     |          1705.6       |         1679.2       |      1675.8    |         1683.5       |         1675.5     
                          f32 B=256, M=512, K=128    |          3324.9        |           3369.0        |   3628.0  |        3396.9     |          3398.2       |         3333.9       |      3335.0    |         3333.7       |         3326.6     
                          f32 B=256, M=1024, K=16    |          4216.9        |           4240.0        |   7034.7  |        4236.3     |          4237.6       |         4216.6       |      4215.7    |         4216.7       |         4217.4     
                          f32 B=256, M=1024, K=32    |          5003.8        |           5034.8        |   7745.1  |        5044.7     |          5047.8       |         5001.0       |      5004.3    |         5001.3       |         5002.8     
                          f32 B=256, M=1024, K=64    |          6565.8        |           6608.1        |   9003.4  |        6628.4     |          6645.5       |         6582.6       |      6590.0    |         6583.1       |         6576.1     
                          f32 B=256, M=1024, K=128   |         12939.5        |          13082.8        |  14510.7  |       13104.1     |         13080.9       |        12932.7       |     12929.9    |        12989.5       |        12966.7     
                          f32 B=320, M=4096, K=128   |        257588.9        |         258335.5        |           |      258341.7     |        258362.1       |       257396.5       |    257636.8    |       257440.4       |       257449.2     
                          f32 B=320, M=8192, K=128   |       1048577.8        |        1050262.9        |           |     1050623.9     |       1052824.1       |      1050739.2       |   1049965.7    |      1051291.4       |      1050888.3     
                          f32 B=384, M=197, K=64     |           579.6        |            599.0        |    721.5  |         599.3     |           601.7       |          580.0       |       580.1    |          580.3       |          580.9     
                          f32 B=384, M=197, K=80     |           776.6        |            799.5        |    872.2  |         805.9     |           801.0       |          777.9       |       777.5    |          777.9       |          777.5     
                          f32 B=384, M=197, K=88     |           812.6        |            837.6        |    906.0  |         840.2     |           840.7       |          812.0       |       811.8    |          812.2       |          815.6     
                          f32 B=768, M=256, K=64     |          1298.3        |           1332.4        |   1886.8  |        1342.3     |          1342.8       |         1297.8       |      1297.8    |         1297.3       |         1298.1     
                          f32 B=1024, M=128, K=16    |           286.3        |            298.3        |    442.3  |         297.7     |           297.5       |          286.2       |       286.3    |          286.2       |          286.3     
                          f32 B=1024, M=128, K=32    |           339.3        |            355.3        |    523.0  |         356.0     |           356.0       |          338.0       |       338.1    |          338.0       |          338.2     
                          f32 B=1024, M=128, K=64    |           459.0        |            486.3        |    688.4  |         488.2     |           488.6       |          455.1       |       458.6    |          454.7       |          455.9     
                          f32 B=1024, M=128, K=128   |           895.2        |            955.3        |   1127.6  |         955.4     |           954.8       |          896.4       |       894.8    |          894.9       |          894.5     
                          f32 B=1024, M=197, K=64    |          1514.5        |           1571.2        |   1880.3  |        1572.1     |          1572.3       |         1510.6       |      1510.9    |         1510.9       |         1510.6     
                          f32 B=1024, M=197, K=80    |          2050.9        |           2110.9        |   2287.5  |        2110.1     |          2109.8       |         2052.7       |      2051.8    |         2052.4       |         2052.3     
                          f32 B=1024, M=197, K=88    |          2135.9        |           2203.3        |   2378.9  |        2200.7     |          2201.4       |         2136.3       |      2135.7    |         2134.7       |         2135.0     
                          f32 B=1024, M=512, K=16    |          4204.9        |           4245.0        |   7205.1  |        4244.3     |          4243.1       |         4204.9       |      4204.6    |         4205.9       |         4205.1     
                          f32 B=1024, M=512, K=32    |          5002.6        |           5071.1        |   8060.1  |        5075.5     |          5077.5       |         5000.4       |      5000.2    |         5000.6       |         5000.7     
                          f32 B=1024, M=512, K=64    |          6668.9        |           6758.8        |   9306.8  |        6751.3     |          6750.9       |         6672.0       |      6662.6    |         6633.0       |         6660.6     
                          f32 B=1024, M=512, K=128   |         13097.5        |          13410.8        |  14793.2  |       13400.1     |         13399.4       |        13100.5       |     13099.1    |        13237.9       |        13211.7     
                          f32 B=1024, M=1024, K=16   |         16439.5        |          16517.4        |  27368.1  |       16518.8     |         16516.2       |        16432.6       |     16429.6    |        16436.9       |        16438.2     
                          f32 B=1024, M=1024, K=32   |         19634.0        |          19794.8        |  30041.1  |       19793.8     |         19789.6       |        19640.7       |     19634.4    |        19640.1       |        19636.3     
                          f32 B=1024, M=1024, K=64   |         26034.1        |          26340.4        |  36618.4  |       26338.0     |         26337.3       |        26034.6       |     26039.4    |        26041.6       |        26037.5     
                          f32 B=1024, M=1024, K=128  |         51617.0        |          52175.9        |  56735.0  |       52198.8     |         52190.3       |        51592.4       |     51587.6    |        51607.3       |        51599.5     
                          f32 B=2400, M=256, K=64    |          4017.6        |           4152.5        |   5655.6  |        4154.1     |          4158.6       |         4016.8       |      4017.7    |         4017.7       |         4017.7     
                          f32 B=8192, M=82, K=64     |          2915.0        |           3078.9        |   3237.4  |        3078.1     |          3087.2       |         2914.7       |      2914.3    |         2915.0       |         2914.2     

Times are in microseconds (us).
```
</details>

<details>
<summary>P100/V100 bw</summary>

```
[----------------------------------------------------------------------------------------------- attention backward (attn_bias=<class 'NoneType'>) ------------------------------------------------------------------------------------------------]
                                                     |  prologuemma_5b7b8db0  |  mma_pipeline_01fa6224  |  vanilla  |  noinit_69206e9b  |  bw_preproc_e351b21d  |  outputf16_64be278e  |  f16_4116eb4a  |  custommma_b99b79bf  |  causalfix_3dbafcad
1 threads: -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f32 B=16, M=4096, K=40     |        142601.6        |         141540.7        |  36545.6  |      141916.9     |        141948.1       |       142073.7       |    142215.2    |       143327.3       |       143797.0     
                          f32 B=16, M=16384, K=40    |       2270630.0        |        2257624.8        |           |     2259597.2     |       2261465.1       |      2266830.2       |   2265786.1    |      2267069.3       |      2273765.7     
                          f32 B=160, M=4096, K=128   |       1094512.6        |        1091513.9        |           |     1089529.6     |       1089903.3       |      1092289.9       |   1089778.5    |      1091651.7       |      1096715.4     
                          f32 B=160, M=8192, K=128   |       4360624.1        |        4346091.0        |           |     4346091.4     |       4346939.7       |      4342655.2       |   4346965.5    |      4344039.3       |      4369272.6     
                          f32 B=256, M=128, K=16     |           671.3        |            681.3        |    616.6  |         668.1     |           666.5       |          667.4       |       667.2    |          665.6       |          671.1     
                          f32 B=256, M=128, K=32     |           829.3        |            852.8        |    694.8  |         828.5     |           827.7       |          828.0       |       828.6    |          828.6       |          830.0     
                          f32 B=256, M=128, K=64     |          1145.1        |           1185.7        |    854.7  |        1139.9     |          1139.7       |         1138.3       |      1139.7    |         1140.6       |         1143.3     
                          f32 B=256, M=128, K=128    |          2173.8        |           2250.4        |   1228.8  |        2162.8     |          2162.6       |         2165.5       |      2163.2    |         2164.6       |         2172.9     
                          f32 B=256, M=512, K=16     |          9913.8        |           9853.3        |   8276.5  |        9817.0     |          9814.6       |         9814.7       |      9813.0    |         9816.6       |         9905.7     
                          f32 B=256, M=512, K=32     |         11185.1        |          11255.1        |   8730.7  |       11144.8     |         11160.3       |        11168.0       |     11223.0    |        11131.5       |        11223.2     
                          f32 B=256, M=512, K=64     |         15160.5        |          15275.9        |   9906.5  |       15128.6     |         15162.0       |        15133.6       |     15135.7    |        15101.7       |        15167.7     
                          f32 B=256, M=512, K=128    |         29620.8        |          29804.0        |  13063.7  |       29529.9     |         29531.3       |        29565.0       |     29473.6    |        29525.9       |        29658.9     
                          f32 B=256, M=1024, K=16    |         38965.8        |          38624.5        |  31932.6  |       38570.9     |         38537.9       |        38544.2       |     38530.3    |        38579.9       |        38924.1     
                          f32 B=256, M=1024, K=32    |         43604.3        |          43744.9        |  33858.5  |       43440.5     |         43401.2       |        43488.1       |     43455.9    |        43425.7       |        43684.9     
                          f32 B=256, M=1024, K=64    |         59687.8        |          58522.9        |  37434.4  |       58820.5     |         58481.7       |        58300.1       |     59094.2    |        58382.8       |        58510.0     
                          f32 B=256, M=1024, K=128   |        116762.3        |         115758.8        |  46867.8  |      115200.9     |        115251.0       |       115661.1       |    115538.9    |       115529.4       |       115574.3     
                          f32 B=320, M=4096, K=128   |       2188368.6        |        2175231.0        |           |     2175581.4     |       2175182.0       |      2176664.1       |   2177171.2    |      2177477.9       |      2184673.5     
                          f32 B=320, M=8192, K=128   |       8711613.1        |        8682373.0        |           |     8662832.0     |       8685256.9       |      8680843.9       |   8667612.0    |      8672964.9       |      8710785.5     
                          f32 B=384, M=197, K=64     |          6236.1        |           6215.8        |   3046.4  |        6127.5     |          6137.6       |         6151.4       |      6158.8    |         6134.5       |         6182.8     
                          f32 B=384, M=197, K=80     |          9218.7        |           9160.2        |   3551.8  |        9022.4     |          9046.8       |         9033.7       |      9051.6    |         9071.3       |         9100.8     
                          f32 B=384, M=197, K=88     |          9654.2        |           9606.8        |   3673.9  |        9476.6     |          9486.9       |         9496.0       |      9479.7    |         9520.3       |         9546.0     
                          f32 B=768, M=256, K=64     |         11725.9        |          11750.7        |   8078.4  |       11662.2     |         11653.3       |        11652.1       |     11668.2    |        11644.8       |        11685.2     
                          f32 B=1024, M=128, K=16    |          2523.3        |           2552.5        |   2301.1  |        2508.7     |          2509.6       |         2506.6       |      2503.3    |         2503.5       |         2522.5     
                          f32 B=1024, M=128, K=32    |          3131.1        |           3223.0        |   2576.5  |        3134.5     |          3131.8       |         3134.5       |      3134.6    |         3133.7       |         3140.6     
                          f32 B=1024, M=128, K=64    |          4379.0        |           4559.4        |   3223.8  |        4365.0     |          4366.3       |         4371.4       |      4364.9    |         4366.8       |         4384.4     
                          f32 B=1024, M=128, K=128   |          8301.2        |           8632.4        |   4784.2  |        8288.7     |          8281.5       |         8301.3       |      8294.3    |         8286.5       |         8338.7     
                          f32 B=1024, M=197, K=64    |         16875.0        |          16815.3        |   8112.4  |       16528.4     |         16565.0       |        16594.6       |     16599.4    |        16564.2       |        16739.2     
                          f32 B=1024, M=197, K=80    |         24728.4        |          24592.3        |   9340.9  |       24282.9     |         24285.4       |        24306.1       |     24295.1    |        24327.1       |        24508.0     
                          f32 B=1024, M=197, K=88    |         25983.0        |          25903.1        |   9673.5  |       25557.0     |         25548.2       |        25527.3       |     25535.0    |        25550.3       |        25724.8     
                          f32 B=1024, M=512, K=16    |         37095.1        |          36964.1        |  32494.4  |       36795.5     |         36764.7       |        36758.6       |     36820.3    |        36790.2       |        37184.5     
                          f32 B=1024, M=512, K=32    |         42229.8        |          42536.9        |  34662.2  |       42144.0     |         42168.5       |        42152.1       |     42163.7    |        42078.4       |        42342.8     
                          f32 B=1024, M=512, K=64    |         57923.3        |          58320.1        |  39317.9  |       58707.7     |         58199.6       |        57688.1       |     57835.9    |        57786.4       |        57914.1     
                          f32 B=1024, M=512, K=128   |        113506.3        |         113882.5        |  52024.4  |      113319.1     |        113273.0       |       113294.3       |    112827.2    |       113502.6       |       113605.5     
                          f32 B=1024, M=1024, K=16   |        145740.7        |         144969.2        |           |      145212.7     |        144697.9       |       145081.5       |    145187.4    |       144949.0       |       146333.3     
                          f32 B=1024, M=1024, K=32   |        165392.7        |         164892.1        |           |      164373.7     |        164200.0       |       163995.9       |    164441.5    |       164557.6       |       165191.0     
                          f32 B=1024, M=1024, K=64   |        224860.4        |         225462.4        |           |      223947.6     |        224107.3       |       224510.4       |    224258.8    |       224283.1       |       225349.8     
                          f32 B=1024, M=1024, K=128  |        439734.3        |         439857.6        |           |      437621.6     |        437496.1       |       438290.0       |    437528.1    |       438398.6       |       439291.4     
                          f32 B=2400, M=256, K=64    |         35630.3        |          36360.4        |  25441.6  |       35569.1     |         35596.5       |        35572.9       |     35579.9    |        35558.0       |        35674.7     
                          f32 B=8192, M=82, K=64     |         48879.6        |          48639.4        |  16849.6  |       47777.4     |         47803.7       |        47728.9       |     47803.5    |        47672.6       |        48513.6     
  (Tesla_V100_SXM2_16GB)  f32 B=16, M=4096, K=40     |        111160.1        |         110768.1        |  19257.5  |      110730.9     |        110753.6       |       110726.5       |    110714.8    |       110720.1       |       110402.4     
                          f32 B=16, M=16384, K=40    |       1774320.7        |        1769233.2        |           |     1769345.4     |       1769271.5       |      1769366.1       |   1768801.2    |      1768983.4       |      1764301.3     
                          f32 B=160, M=4096, K=128   |        495858.6        |         500147.5        |           |      497931.1     |        498690.5       |       498835.2       |    498544.1    |       498743.2       |       495956.2     
                          f32 B=160, M=8192, K=128   |       1980039.3        |        1987129.4        |           |     1992747.6     |       1988719.3       |      1988125.2       |   1983742.0    |      1983696.6       |      1979061.0     
                          f32 B=256, M=128, K=16     |           294.3        |            303.0        |    310.8  |         293.0     |           292.8       |          292.9       |       292.9    |          293.1       |          293.7     
                          f32 B=256, M=128, K=32     |           380.5        |            399.0        |    365.8  |         380.1     |           380.4       |          379.7       |       379.6    |          379.8       |          379.9     
                          f32 B=256, M=128, K=64     |           549.0        |            584.3        |    494.5  |         549.2     |           549.0       |          548.9       |       549.6    |          549.0       |          547.8     
                          f32 B=256, M=128, K=128    |          1053.5        |           1120.9        |    814.3  |        1060.4     |          1059.6       |         1058.7       |      1060.5    |         1058.1       |         1055.3     
                          f32 B=256, M=512, K=16     |          4263.7        |           4244.8        |   4111.2  |        4306.9     |          4216.4       |         4303.7       |      4207.6    |         4220.1       |         4217.2     
                          f32 B=256, M=512, K=32     |          5151.3        |           5220.6        |   4390.1  |        5160.9     |          5180.2       |         5159.9       |      5201.3    |         5198.7       |         5191.6     
                          f32 B=256, M=512, K=64     |          7297.9        |           7445.2        |   5125.9  |        7314.4     |          7317.0       |         7317.7       |      7302.0    |         7328.1       |         7252.0     
                          f32 B=256, M=512, K=128    |         14315.7        |          14633.7        |   8024.3  |       14418.5     |         14349.9       |        14408.4       |     14381.8    |        14380.5       |        14300.9     
                          f32 B=256, M=1024, K=16    |         16820.4        |          16719.3        |  15971.6  |       16795.1     |         16687.0       |        16782.7       |     16670.0    |        16640.1       |        16610.5     
                          f32 B=256, M=1024, K=32    |         20289.0        |          20336.3        |  16655.5  |       20274.1     |         20189.0       |        20256.4       |     20206.2    |        20192.0       |        20218.2     
                          f32 B=256, M=1024, K=64    |         28267.4        |          28654.7        |  19439.0  |       28499.4     |         28460.3       |        28482.6       |     28466.5    |        28465.3       |        28313.6     
                          f32 B=256, M=1024, K=128   |         55671.8        |          56782.0        |  30334.7  |       56124.3     |         56114.2       |        56114.8       |     56165.7    |        56173.4       |        55803.6     
                          f32 B=320, M=4096, K=128   |        993296.8        |         999950.8        |           |      999097.1     |        998408.6       |       998902.1       |    998793.7    |       997743.8       |       994515.2     
                          f32 B=320, M=8192, K=128   |       3956636.3        |        3977128.4        |           |     3975949.9     |       3975881.6       |      3974009.1       |   3978183.2    |      3978751.5       |      3964485.1     
                          f32 B=384, M=197, K=64     |          2699.8        |           2744.3        |   1579.7  |        2670.8     |          2680.2       |         2678.4       |      2678.9    |         2674.5       |         2691.7     
                          f32 B=384, M=197, K=80     |          3870.8        |           3922.8        |   1986.6  |        3839.7     |          3844.4       |         3839.0       |      3841.7    |         3837.9       |         3854.2     
                          f32 B=384, M=197, K=88     |          4222.4        |           4285.5        |   2056.0  |        4190.3     |          4191.8       |         4195.6       |      4195.0    |         4194.1       |         4199.9     
                          f32 B=768, M=256, K=64     |          5340.3        |           5491.7        |   4291.7  |        5344.5     |          5346.5       |         5342.1       |      5350.6    |         5346.7       |         5329.8     
                          f32 B=1024, M=128, K=16    |          1033.1        |           1062.2        |   1130.5  |        1028.7     |          1029.3       |         1028.1       |      1029.2    |         1029.3       |         1030.5     
                          f32 B=1024, M=128, K=32    |          1351.0        |           1417.7        |   1330.4  |        1352.7     |          1350.4       |         1352.0       |      1349.3    |         1350.6       |         1349.5     
                          f32 B=1024, M=128, K=64    |          2010.4        |           2135.9        |   1730.7  |        2013.5     |          2011.0       |         2012.5       |      2010.8    |         2011.9       |         2007.1     
                          f32 B=1024, M=128, K=128   |          3941.9        |           4145.3        |   2841.2  |        3949.6     |          3946.9       |         3948.5       |      3945.7    |         3948.7       |         3938.9     
                          f32 B=1024, M=197, K=64    |          6566.7        |           6684.3        |   4098.4  |        6518.9     |          6517.7       |         6533.7       |      6518.2    |         6503.6       |         6551.0     
                          f32 B=1024, M=197, K=80    |          9337.6        |           9511.8        |   5206.6  |        9278.3     |          9281.8       |         9280.6       |      9278.8    |         9278.7       |         9309.7     
                          f32 B=1024, M=197, K=88    |         10290.9        |          10488.3        |   5382.8  |       10261.7     |         10263.8       |        10253.3       |     10257.6    |        10258.8       |        10274.9     
                          f32 B=1024, M=512, K=16    |         15057.5        |          15202.2        |  16258.4  |       15031.3     |         14972.1       |        15001.9       |     14982.6    |        14996.4       |        14989.0     
                          f32 B=1024, M=512, K=32    |         18555.7        |          18815.0        |  17422.9  |       18639.9     |         18633.4       |        18631.5       |     18637.4    |        18648.0       |        18620.5     
                          f32 B=1024, M=512, K=64    |         27045.6        |          27595.1        |  20308.1  |       27123.0     |         27119.8       |        27142.4       |     27116.9    |        27147.3       |        27017.1     
                          f32 B=1024, M=512, K=128   |         53811.5        |          55058.9        |  32115.9  |       53995.3     |         54104.3       |        53995.4       |     54011.8    |        53934.4       |        53830.5     
                          f32 B=1024, M=1024, K=16   |         59349.0        |          59331.7        |           |       59047.4     |         59044.9       |        59039.2       |     59042.4    |        59160.4       |        59056.3     
                          f32 B=1024, M=1024, K=32   |         71851.7        |          72705.8        |           |       72162.1     |         72033.8       |        72113.5       |     72269.6    |        72226.5       |        72214.3     
                          f32 B=1024, M=1024, K=64   |        105678.2        |         106738.4        |           |      105730.2     |        106260.7       |       105478.0       |    105494.6    |       105842.5       |       105489.5     
                          f32 B=1024, M=1024, K=128  |        209874.6        |         212254.5        |           |      210852.0     |        211505.6       |       211378.7       |    211283.1    |       210975.7       |       210848.6     
                          f32 B=2400, M=256, K=64    |         16553.6        |          17096.3        |  13036.8  |       16570.0     |         16565.5       |        16558.8       |     16551.7    |        16551.3       |        16542.0     
                          f32 B=8192, M=82, K=64     |         15806.3        |          16175.4        |   7696.7  |       15558.2     |         15600.2       |        15582.7       |     15568.6    |        15552.0       |        15714.2     

Times are in microseconds (us).
```
</details>

<details>
<summary>A100 fw</summary>

```
[--------------------------------------------------------------------------------------- attention (attn_bias=<class 'NoneType'>) --------------------------------------------------------------------------------------]
                                 |  prologuemma_5b7b8db  |  mma_pipeline_01fa622  |  vanilla   |  noinit_69206e9  |  bw_preproc_e351b21  |  outputf16_64be278  |  f16_4116eb4  |  custommma_b99b79b  |  causalfix_3dbafca
1 threads: --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      f32 B=16, M=4096, K=40     |          2860.8       |          2829.2        |    6907.6  |       2826.7     |         2836.2       |         2819.9      |      2820.3   |         2862.9      |         2864.5    
      f32 B=16, M=16384, K=40    |         41928.3       |         41390.6        |  123364.3  |      41383.7     |        41384.1       |        41362.5      |     41351.3   |        41928.8      |        41935.6    
      f32 B=160, M=4096, K=128   |         55462.0       |         53578.9        |   91346.6  |      53567.2     |        53573.0       |        53358.5      |     53350.4   |        55472.1      |        55466.5    
      f32 B=160, M=8192, K=128   |        221096.9       |        212876.3        |            |     212983.2     |       212957.2       |       212545.2      |    212541.4   |       221204.3      |       221272.8    
      f32 B=256, M=128, K=16     |            44.7       |            46.6        |     127.7  |         46.4     |           46.5       |           43.1      |        43.0   |           44.6      |           44.8    
      f32 B=256, M=128, K=32     |            45.3       |            48.1        |     140.6  |         47.9     |           48.0       |           43.8      |        43.7   |           45.3      |           45.4    
      f32 B=256, M=128, K=64     |            64.4       |            67.0        |     164.1  |         66.2     |           66.7       |           61.4      |        62.0   |           64.4      |           64.4    
      f32 B=256, M=128, K=128    |           115.3       |           115.8        |     216.5  |        115.7     |          116.0       |          104.6      |       104.3   |          115.4      |          115.4    
      f32 B=256, M=512, K=16     |           572.1       |           565.4        |    1575.1  |        565.0     |          565.5       |          559.5      |       559.4   |          572.0      |          572.1    
      f32 B=256, M=512, K=32     |           575.9       |           573.4        |    1687.8  |        573.1     |          573.5       |          562.8      |       562.8   |          575.7      |          575.9    
      f32 B=256, M=512, K=64     |           698.6       |           709.4        |    1932.3  |        709.1     |          709.2       |          687.0      |       686.8   |          698.6      |          698.7    
      f32 B=256, M=512, K=128    |          1480.2       |          1446.8        |    2428.3  |       1446.9     |         1447.3       |         1403.3      |      1402.4   |         1480.8      |         1480.4    
      f32 B=256, M=1024, K=16    |          2207.7       |          2171.5        |    6002.2  |       2171.2     |         2171.6       |         2161.0      |      2161.2   |         2207.7      |         2207.4    
      f32 B=256, M=1024, K=32    |          2215.1       |          2191.0        |    6426.1  |       2190.3     |         2190.7       |         2168.1      |      2167.9   |         2215.3      |         2215.2    
      f32 B=256, M=1024, K=64    |          2690.1       |          2691.6        |    7375.1  |       2691.6     |         2692.6       |         2647.2      |      2646.9   |         2690.5      |         2690.4    
      f32 B=256, M=1024, K=128   |          5678.9       |          5518.0        |    9245.3  |       5516.0     |         5517.3       |         5428.5      |      5427.9   |         5679.7      |         5679.9    
      f32 B=320, M=4096, K=128   |        110732.8       |        106972.2        |            |     106951.6     |       106959.6       |       106507.7      |    106507.4   |       110751.3      |       110754.6    
      f32 B=320, M=8192, K=128   |        441427.4       |        425580.1        |            |     425579.1     |       425537.1       |       424569.9      |    424675.2   |       441660.4      |       441680.5    
      f32 B=384, M=197, K=64     |           277.7       |           283.1        |     636.4  |        285.1     |          284.6       |          270.7      |       270.5   |          277.6      |          277.6    
      f32 B=384, M=197, K=80     |           447.2       |           439.5        |     686.6  |        441.7     |          441.6       |          423.4      |       423.0   |          447.7      |          447.5    
      f32 B=384, M=197, K=88     |           451.8       |           446.0        |     711.8  |        447.3     |          447.5       |          428.0      |       427.7   |          452.1      |          452.2    
      f32 B=768, M=256, K=64     |           552.4       |           571.7        |    1502.4  |        574.5     |          574.0       |          538.6      |       538.0   |          552.4      |          552.5    
      f32 B=1024, M=128, K=16    |           164.9       |           165.2        |     433.8  |        165.9     |          165.8       |          159.0      |       159.1   |          164.8      |          164.9    
      f32 B=1024, M=128, K=32    |           168.5       |           173.4        |     476.9  |        175.1     |          175.0       |          163.0      |       162.7   |          168.2      |          168.6    
      f32 B=1024, M=128, K=64    |           208.2       |           227.6        |     561.1  |        228.5     |          228.8       |          203.7      |       203.9   |          208.2      |          208.3    
      f32 B=1024, M=128, K=128   |           428.3       |           419.5        |     732.1  |        420.5     |          420.7       |          373.1      |       372.6   |          428.6      |          428.6    
      f32 B=1024, M=197, K=64    |           688.5       |           700.4        |    1565.5  |        701.4     |          701.3       |          664.9      |       664.8   |          688.5      |          688.6    
      f32 B=1024, M=197, K=80    |          1178.5       |          1159.1        |    1696.4  |       1161.5     |         1158.7       |         1114.3      |      1114.5   |         1178.8      |         1178.9    
      f32 B=1024, M=197, K=88    |          1187.7       |          1175.2        |    1756.9  |       1176.8     |         1171.9       |         1123.6      |      1123.3   |         1188.3      |         1187.9    
      f32 B=1024, M=512, K=16    |          2235.6       |          2208.8        |    6088.4  |       2209.7     |         2210.7       |         2186.8      |      2186.4   |         2235.8      |         2235.5    
      f32 B=1024, M=512, K=32    |          2245.2       |          2238.3        |    6491.5  |       2239.6     |         2240.1       |         2194.5      |      2193.9   |         2245.4      |         2245.6    
      f32 B=1024, M=512, K=64    |          2727.4       |          2765.1        |    7464.8  |       2766.2     |         2766.9       |         2676.7      |      2676.3   |         2727.8      |         2727.9    
      f32 B=1024, M=512, K=128   |          5873.0       |          5758.7        |    9459.1  |       5758.4     |         5758.8       |         5580.7      |      5579.3   |         5875.3      |         5874.7    
      f32 B=1024, M=1024, K=16   |          8734.5       |          8603.7        |   23943.8  |       8603.5     |         8605.9       |         8559.3      |      8558.6   |         8735.7      |         8734.7    
      f32 B=1024, M=1024, K=32   |          8760.7       |          8672.5        |   25636.4  |       8674.4     |         8675.6       |         8584.5      |      8584.6   |         8761.8      |         8761.5    
      f32 B=1024, M=1024, K=64   |         10638.6       |         10659.2        |   29404.3  |      10657.2     |        10656.5       |        10480.7      |     10477.1   |        10638.5      |        10641.2    
      f32 B=1024, M=1024, K=128  |         22539.9       |         21926.2        |   36831.4  |      21928.8     |        21927.7       |        21574.4      |     21573.1   |        22540.7      |        22543.7    
      f32 B=2400, M=256, K=64    |          1664.7       |          1729.0        |    4531.3  |       1729.7     |         1730.4       |         1624.6      |      1623.9   |         1664.5      |         1664.5    
      f32 B=4096, M=4096, K=64   |        668215.3       |        661853.0        |            |     661923.8     |       661826.5       |       659102.2      |    659062.0   |       668260.3      |       668376.9    
      f32 B=8192, M=82, K=64     |          1347.6       |          1459.3        |    2920.1  |       1459.2     |         1458.7       |         1339.4      |      1340.0   |         1347.7      |         1351.8    

Times are in microseconds (us).
```
</details>

<details>
<summary>A100 bw</summary>

```
[--------------------------------------------------------------------------------- attention backward (attn_bias=<class 'NoneType'>) ----------------------------------------------------------------------------------]
                                 |  prologuemma_5b7b8db  |  mma_pipeline_01fa622  |  vanilla  |  noinit_69206e9  |  bw_preproc_e351b21  |  outputf16_64be278  |  f16_4116eb4  |  custommma_b99b79b  |  causalfix_3dbafca
1 threads: -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      f32 B=16, M=4096, K=40     |         67138.9       |         68255.4        |  17656.5  |      68596.7     |        68667.4       |        68610.7      |     68393.6   |        67669.2      |        67852.9    
      f32 B=16, M=16384, K=40    |       1078327.4       |       1099224.2        |           |    1099694.1     |      1099973.1       |      1098935.0      |   1099107.7   |      1085689.3      |      1088917.6    
      f32 B=160, M=4096, K=128   |        249835.2       |        236734.2        |           |     236324.3     |       236475.0       |       236018.4      |    236343.4   |       254485.2      |       249594.8    
      f32 B=160, M=8192, K=128   |        988303.8       |        936050.5        |           |     936255.7     |       935478.9       |       935017.7      |    935174.4   |      1008244.1      |       987777.0    
      f32 B=256, M=128, K=16     |           149.5       |           162.1        |    355.0  |        155.3     |          153.5       |          151.8      |       154.7   |          150.5      |          151.4    
      f32 B=256, M=128, K=32     |           183.1       |           200.3        |    380.4  |        185.2     |          186.2       |          185.5      |       184.9   |          184.1      |          185.3    
      f32 B=256, M=128, K=64     |           259.0       |           280.1        |    423.7  |        258.6     |          258.8       |          258.5      |       259.0   |          257.9      |          259.0    
      f32 B=256, M=128, K=128    |           546.4       |           561.6        |    548.3  |        520.0     |          520.9       |          522.5      |       521.8   |          551.7      |          542.3    
      f32 B=256, M=512, K=16     |          2000.5       |          2076.9        |   4335.6  |       2054.1     |         2056.1       |         2051.5      |      2037.1   |         2027.7      |         2033.3    
      f32 B=256, M=512, K=32     |          2212.3       |          2289.7        |   4512.9  |       2248.4     |         2251.3       |         2248.7      |      2240.1   |         2236.6      |         2243.0    
      f32 B=256, M=512, K=64     |          2890.3       |          3004.4        |   4884.6  |       2940.8     |         2940.9       |         2938.4      |      2933.8   |         2919.9      |         2930.1    
      f32 B=256, M=512, K=128    |          6509.2       |          6316.0        |   5640.0  |       6180.7     |         6183.8       |         6185.8      |      6189.5   |         6626.6      |         6499.9    
      f32 B=256, M=1024, K=16    |          8051.2       |          8177.3        |  16501.8  |       8131.2     |         8131.0       |         8134.2      |      8126.4   |         8118.8      |         8144.7    
      f32 B=256, M=1024, K=32    |          8401.3       |          8630.9        |  17052.1  |       8546.1     |         8548.9       |         8550.5      |      8531.1   |         8495.7      |         8515.4    
      f32 B=256, M=1024, K=64    |         10979.3       |         11294.9        |  18229.2  |      11139.7     |        11151.5       |        11137.0      |     11155.1   |        11077.9      |        11127.9    
      f32 B=256, M=1024, K=128   |         24560.8       |         23588.3        |  20617.3  |      23289.2     |        23304.2       |        23303.0      |     23303.4   |        25056.9      |        24539.9    
      f32 B=320, M=4096, K=128   |        394305.4       |        371550.4        |           |     370492.0     |       370643.9       |       370700.1      |    370652.0   |       404314.4      |       393806.5    
      f32 B=320, M=8192, K=128   |       1560705.0       |       1471981.9        |           |    1467375.4     |      1468058.1       |      1468350.2      |   1467485.1   |      1602633.9      |      1559981.6    
      f32 B=384, M=197, K=64     |          1245.7       |          1312.6        |   1566.1  |       1269.7     |         1265.1       |         1266.4      |      1270.2   |         1249.3      |         1260.1    
      f32 B=384, M=197, K=80     |          2421.6       |          2344.6        |   1656.6  |       2311.4     |         2316.0       |         2309.4      |      2299.6   |         2434.3      |         2423.4    
      f32 B=384, M=197, K=88     |          2527.1       |          2472.8        |   1698.3  |       2418.6     |         2432.8       |         2419.5      |      2414.4   |         2535.1      |         2524.1    
      f32 B=768, M=256, K=64     |          2093.0       |          2217.0        |   3912.6  |       2125.2     |         2124.9       |         2125.9      |      2125.8   |         2113.6      |         2116.2    
      f32 B=1024, M=128, K=16    |           471.5       |           505.8        |   1187.4  |        482.3     |          483.4       |          482.9      |       482.3   |          474.9      |          476.5    
      f32 B=1024, M=128, K=32    |           586.8       |           637.0        |   1298.4  |        597.2     |          598.1       |          597.3      |       596.5   |          590.7      |          591.1    
      f32 B=1024, M=128, K=64    |           881.6       |           963.6        |   1509.3  |        888.6     |          889.2       |          888.5      |       889.1   |          884.6      |          885.2    
      f32 B=1024, M=128, K=128   |          1925.4       |          1980.4        |   1934.5  |       1839.0     |         1839.9       |         1840.4      |      1840.6   |         1949.6      |         1920.3    
      f32 B=1024, M=197, K=64    |          3314.3       |          3471.4        |   3842.1  |       3349.0     |         3351.3       |         3360.8      |      3348.2   |         3305.4      |         3330.4    
      f32 B=1024, M=197, K=80    |          6292.4       |          6096.2        |   4051.2  |       5984.6     |         5994.5       |         6021.1      |      5991.5   |         6289.3      |         6289.5    
      f32 B=1024, M=197, K=88    |          6564.9       |          6412.4        |   4156.4  |       6261.8     |         6303.1       |         6293.9      |      6277.8   |         6569.1      |         6563.1    
      f32 B=1024, M=512, K=16    |          6351.1       |          6609.3        |  16733.5  |       6537.4     |         6547.5       |         6554.6      |      6545.4   |         6412.8      |         6440.2    
      f32 B=1024, M=512, K=32    |          7119.5       |          7397.4        |  17383.0  |       7260.7     |         7261.2       |         7261.9      |      7265.4   |         7176.9      |         7187.5    
      f32 B=1024, M=512, K=64    |          9234.6       |          9667.7        |  18810.2  |       9395.8     |         9398.9       |         9400.9      |      9402.4   |         9348.2      |         9363.0    
      f32 B=1024, M=512, K=128   |         22532.4       |         21888.6        |  21835.6  |      21338.7     |        21353.0       |        21346.3      |     21339.6   |        23015.8      |        22522.9    
      f32 B=1024, M=1024, K=16   |         25271.8       |         25827.2        |  65849.8  |      25738.1     |        25725.6       |        25777.1      |     25792.4   |        25621.1      |        25691.5    
      f32 B=1024, M=1024, K=32   |         26577.4       |         27335.7        |  68036.1  |      27082.2     |        27112.4       |        27094.6      |     27102.0   |        26860.1      |        26882.7    
      f32 B=1024, M=1024, K=64   |         34099.9       |         35304.8        |  72706.2  |      34762.6     |        34747.9       |        34747.6      |     34775.2   |        34588.3      |        34642.8    
      f32 B=1024, M=1024, K=128  |         84985.0       |         81294.4        |  82345.0  |      80333.1     |        80284.0       |        80312.9      |     80279.0   |        86867.2      |        84873.2    
      f32 B=2400, M=256, K=64    |          6068.1       |          6481.5        |  11817.7  |       6162.5     |         6162.4       |         6162.5      |      6157.8   |         6133.6      |         6138.3    
      f32 B=8192, M=82, K=64     |          8871.4       |          9301.6        |   7409.6  |       8960.9     |         8933.4       |         8943.1      |      8932.4   |         8870.9      |         8915.7    

Times are in microseconds (us).
```
</details>