### PR TITLE
seqlen: Support variable sequence lengths

### DIFF
--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -4,7 +4,7 @@ TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention(Tensor query, Tensor key, Tensor value, bool compute_logsumexp, Tensor? attn_bias, float p) -> (Tensor, Tensor, int, int)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention_forward_cutlass(Tensor query, Tensor key, Tensor value, bool compute_logsumexp, bool causal) -> (Tensor, Tensor)"));
+      "xformers::efficient_attention_forward_cutlass(Tensor query, Tensor key, Tensor value, Tensor? cu_seqlens_q, Tensor? cu_seqlens_k, int? max_seqlen_q, int? max_seqlen_k, bool compute_logsumexp, bool causal) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, Tensor? attn_bias, float p, int rng_seed, int rng_offset) -> (Tensor, Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -24,7 +24,7 @@
         at::cuda::getDeviceProperties(QUERY.device().index());                \
     const int computeCapability = properties->major * 10 + properties->minor; \
     DISPATCH_BLOCKSIZE(                                                       \
-        VALUE.size(2), ([&]() {                                               \
+        VALUE.size(-1), ([&]() {                                              \
           static constexpr int64_t kQueriesPerBlock = kIs64x64 ? 64 : 32;     \
           static constexpr int64_t kKeysPerBlock = kIs64x64 ? 64 : 128;       \
           DISPATCH_TYPES(                                                     \
@@ -41,9 +41,9 @@
                       /* Run a more efficient kernel (with `isAligned=True`)  \
                       if memory is correctly aligned*/                        \
                       bool isAligned =                                        \
-                          (QUERY.stride(1) % AlignedAK::kAlignmentQ == 0 &&   \
-                           KEY.stride(1) % AlignedAK::kAlignmentK == 0 &&     \
-                           VALUE.stride(1) % AlignedAK::kAlignmentV == 0);    \
+                          (QUERY.stride(-1) % AlignedAK::kAlignmentQ == 0 &&  \
+                           KEY.stride(-1) % AlignedAK::kAlignmentK == 0 &&    \
+                           VALUE.stride(-1) % AlignedAK::kAlignmentV == 0);   \
                       /* TODO: Should we warn or log somewhere when we use a  \
                       less efficient kernel due to wrong alignment? */        \
                       DISPATCH_BOOL(isAligned, kIsAligned, ([&]() {           \
@@ -62,18 +62,48 @@
   }
 
 namespace {
+/*
+  There are 2 modes for using this function.
+  (Mode BMK) `num_heads=1` with the heads coalesced into the batch dimension
+  (Mode MKH) `batch=1` with all tokens across batches concatenated
+*/
 std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
-    const at::Tensor& query,
-    const at::Tensor& key,
-    const at::Tensor& value,
+    const at::Tensor& query, // [b, seqlen, num_heads, K]
+    const at::Tensor& key, // [b, seqlen, num_heads, K]
+    const at::Tensor& value, // [b, seqlen, num_heads, Kv]
+    // (Mode MKH only) [b+1]: cu_seqlens_q[b] contains the
+    // position of the first query token for batch $b
+    const c10::optional<at::Tensor>& cu_seqlens_q,
+    // (Mode MKH only) [b+1]: cu_seqlens_k[b] contains the
+    // position of the first key token for batch $b
+    const c10::optional<at::Tensor>& cu_seqlens_k,
+    // (Mode MKH only) Maximum sequence length across batches
+    const c10::optional<int64_t> max_seqlen_q_,
+    // (Mode MKH only) Maximum sequence length across batches
+    const c10::optional<int64_t> max_seqlen_k_,
     bool compute_logsumexp,
     bool causal) {
-  TORCH_CHECK(query.dim() == 3);
-  TORCH_CHECK(key.dim() == 3);
-  TORCH_CHECK(value.dim() == 3);
+  TORCH_CHECK(query.dim() == 4);
+  TORCH_CHECK(key.dim() == 4);
+  TORCH_CHECK(value.dim() == 4);
 
-  TORCH_CHECK(query.size(2) == key.size(2));
+  TORCH_CHECK(query.size(-1) == key.size(-1));
   TORCH_CHECK(query.size(0) == key.size(0));
+
+  int64_t max_seqlen_q, max_seqlen_k;
+  TORCH_CHECK(cu_seqlens_q.has_value() == cu_seqlens_k.has_value());
+  if (cu_seqlens_q.has_value()) {
+    TORCH_CHECK(cu_seqlens_q->scalar_type() == at::ScalarType::Int);
+    TORCH_CHECK(cu_seqlens_k->scalar_type() == at::ScalarType::Int);
+    CHECK_NOSPARSE_CONTIGUOUS_CUDA((*cu_seqlens_q));
+    CHECK_NOSPARSE_CONTIGUOUS_CUDA((*cu_seqlens_k));
+    TORCH_CHECK(max_seqlen_q_.has_value() && max_seqlen_k_.has_value());
+    max_seqlen_q = *max_seqlen_q_;
+    max_seqlen_k = *max_seqlen_k_;
+  } else {
+    max_seqlen_q = query.size(1);
+    max_seqlen_k = key.size(1);
+  }
 
   CHECK_NOSPARSE_CONTIGUOUS_CUDA(query);
   CHECK_NOSPARSE_CONTIGUOUS_CUDA(key);
@@ -85,7 +115,8 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
   int64_t B = query.size(0);
   int64_t M = query.size(1);
   int64_t N = key.size(1);
-  int64_t K = query.size(2);
+  int64_t num_heads = query.size(-2);
+  int64_t K = query.size(-1);
 
   at::Tensor res;
   at::Tensor logsumexp;
@@ -96,7 +127,7 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
     (void)_k;
 
     res = at::empty(
-        {B, M, K},
+        {B, M, num_heads, K},
         query.options().dtype(
             TypeTraits<typename Kernel::output_t>::atScalarType()));
 
@@ -104,7 +135,9 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
     // not a good number for loading during backward
     constexpr decltype(M) kAlignLSE = Kernel::kAlignLSE;
     logsumexp = at::empty(
-        {B, compute_logsumexp ? ceil_div(M, kAlignLSE) * kAlignLSE : 0},
+        {B,
+         num_heads,
+         compute_logsumexp ? ceil_div(max_seqlen_q, kAlignLSE) * kAlignLSE : 0},
         query.options().dtype(at::ScalarType::Float));
 
     typename Kernel::Params p;
@@ -117,7 +150,7 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
     at::Tensor output_accum;
     if (Kernel::kNeedsOutputAccumulatorBuffer) {
       output_accum = at::empty(
-          {B, M, K},
+          {B, M, num_heads, K},
           query.options().dtype(
               TypeTraits<typename Kernel::output_accum_t>::atScalarType()));
       p.output_accum_ptr =
@@ -126,10 +159,17 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
       p.output_accum_ptr = nullptr;
     }
     p.output_ptr = (typename Kernel::output_t*)res.data_ptr();
-    p.head_dim = query.size(2);
-    p.head_dim_value = value.size(2);
-    p.num_queries = query.size(1);
-    p.num_keys = key.size(1);
+
+    if (cu_seqlens_q.has_value()) {
+      p.cu_seqlens_q_ptr = (int32_t*)cu_seqlens_q->data_ptr();
+      p.cu_seqlens_k_ptr = (int32_t*)cu_seqlens_k->data_ptr();
+    }
+
+    p.num_heads = num_heads;
+    p.head_dim = query.size(3);
+    p.head_dim_value = value.size(3);
+    p.num_queries = max_seqlen_q;
+    p.num_keys = max_seqlen_k;
     p.num_batches = B;
     p.causal = causal;
 

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_forward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_forward.h
@@ -92,14 +92,17 @@ struct AttentionKernel {
 
   struct Params {
     // Input tensors
-    scalar_t* query_ptr; // [num_queries, head_dim]
-    scalar_t* key_ptr; // [num_keys, head_dim]
-    scalar_t* value_ptr; // [num_keys, head_dim_value]
+    scalar_t* query_ptr; // [num_queries, num_heads, head_dim]
+    scalar_t* key_ptr; // [num_keys, num_heads, head_dim]
+    scalar_t* value_ptr; // [num_keys, num_heads, head_dim_value]
+    int32_t* cu_seqlens_q_ptr = nullptr;
+    int32_t* cu_seqlens_k_ptr = nullptr;
 
     // Output tensors
-    output_t* output_ptr; // [num_queries, head_dim_value]
-    output_accum_t* output_accum_ptr; // [num_queries, head_dim_value]
-    lse_scalar_t* logsumexp_ptr; // [num_queries] - can be 0
+    output_t* output_ptr; // [num_queries, num_heads, head_dim_value]
+    output_accum_t*
+        output_accum_ptr; // [num_queries, num_heads, head_dim_value]
+    lse_scalar_t* logsumexp_ptr; // [num_heads, num_queries] - can be null
 
     // Dimensions/strides
     int32_t head_dim;
@@ -107,37 +110,66 @@ struct AttentionKernel {
     int32_t num_queries;
     int32_t num_keys;
     int32_t num_batches;
+    int32_t num_heads = 1;
 
     bool causal;
 
+    CUTLASS_DEVICE int32_t qk_stride() const {
+      return head_dim * num_heads;
+    }
+    CUTLASS_DEVICE int32_t v_stride() const {
+      return head_dim_value * num_heads;
+    }
     // Moves pointers to what we should process
     // Returns "false" if there is no work to do
-    CUTLASS_DEVICE void advance_to_block() {
+    CUTLASS_DEVICE bool advance_to_block() {
       auto batch_id = blockIdx.z;
-      auto query_start = blockIdx.y * kQueriesPerBlock;
+      auto head_id = blockIdx.y;
+      auto query_start = blockIdx.x * kQueriesPerBlock;
 
       auto lse_dim = ceil_div((int32_t)num_queries, kAlignLSE) * kAlignLSE;
 
-      // query[batch_id, query_start, 0]
-      query_ptr += batch_id * head_dim * num_queries + query_start * head_dim;
-      // key[batch_id, 0, 0]
-      key_ptr += batch_id * head_dim * num_keys;
-      // value[batch_id, 0, 0]
-      value_ptr += batch_id * head_dim_value * num_keys;
-      // output[batch_id, query_start, 0]
-      output_ptr += batch_id * head_dim_value * num_queries +
-          query_start * head_dim_value;
+      int32_t q_start, k_start;
+      // Advance to current batch - in case of different sequence lengths
+      if (cu_seqlens_q_ptr != nullptr) {
+        assert(cu_seqlens_k_ptr != nullptr);
+        cu_seqlens_q_ptr += batch_id;
+        cu_seqlens_k_ptr += batch_id;
+        q_start = cu_seqlens_q_ptr[0];
+        k_start = cu_seqlens_k_ptr[0];
+        int32_t q_next_start = cu_seqlens_q_ptr[1];
+        int32_t k_next_start = cu_seqlens_k_ptr[1];
+        num_queries = q_next_start - q_start;
+        num_keys = k_next_start - k_start;
 
-      if (output_accum_ptr == nullptr) {
+        if (query_start >= num_queries) {
+          return false;
+        }
+      } else {
+        q_start = batch_id * num_queries;
+        k_start = batch_id * num_keys;
+      }
+
+      // Advance to the current batch / head / query_start
+      query_ptr += (q_start + query_start) * qk_stride() + head_id * head_dim;
+      key_ptr += k_start * qk_stride() + head_id * head_dim;
+      value_ptr += k_start * v_stride() + head_id * head_dim_value;
+      output_ptr +=
+          (q_start + query_start) * v_stride() + head_id * head_dim_value;
+
+      if (output_accum_ptr != nullptr) {
+        output_accum_ptr +=
+            (q_start + query_start) * v_stride() + head_id * head_dim_value;
+      } else {
         // Accumulate directly in the destination buffer (eg for f32)
         output_accum_ptr = (accum_t*)output_ptr;
-      } else {
-        output_accum_ptr += batch_id * head_dim_value * num_queries +
-            query_start * head_dim_value;
       }
       if (logsumexp_ptr != nullptr) {
-        logsumexp_ptr += batch_id * lse_dim + query_start;
+        // lse[batch_id, head_id, query_start]
+        logsumexp_ptr +=
+            batch_id * lse_dim * num_heads + head_id * lse_dim + query_start;
       }
+
       num_queries -= query_start;
       if (causal) {
         num_keys = std::min(int32_t(query_start + kQueriesPerBlock), num_keys);
@@ -156,11 +188,14 @@ struct AttentionKernel {
       num_keys = warp_uniform(num_keys);
       head_dim = warp_uniform(head_dim);
       head_dim_value = warp_uniform(head_dim_value);
+      return true;
     }
 
     __host__ dim3 getBlocksGrid() const {
       return dim3(
-          1, ceil_div(num_queries, (int32_t)kQueriesPerBlock), num_batches);
+          ceil_div(num_queries, (int32_t)kQueriesPerBlock),
+          num_heads,
+          num_batches);
     }
     __host__ dim3 getThreadsGrid() const {
       return dim3(kWarpSize, kNumWarpsPerBlock, 1);
@@ -397,21 +432,23 @@ struct AttentionKernel {
     auto createOutputIter = [&](auto col) {
       using OutputTileIterator = typename MM1::OutputTileIterator;
       return OutputTileIterator(
-          typename OutputTileIterator::Params{(int32_t)p.head_dim_value},
-          p.output_ptr + col,
+          typename OutputTileIterator::Params{(int32_t)p.v_stride()},
+          p.output_ptr,
           typename OutputTileIterator::TensorCoord{
-              p.num_queries, p.head_dim_value - col},
-          thread_id());
+              p.num_queries, p.head_dim_value},
+          thread_id(),
+          {0, col});
     };
 
     auto createOutputAccumIter = [&](auto col) {
       using OutputTileIteratorAccum = typename MM1::OutputTileIteratorAccum;
       return OutputTileIteratorAccum(
-          typename OutputTileIteratorAccum::Params{(int32_t)p.head_dim_value},
-          p.output_accum_ptr + col,
+          typename OutputTileIteratorAccum::Params{(int32_t)p.v_stride()},
+          p.output_accum_ptr,
           typename OutputTileIteratorAccum::TensorCoord{
-              p.num_queries, p.head_dim_value - col},
-          thread_id());
+              p.num_queries, p.head_dim_value},
+          thread_id(),
+          {0, col});
     };
 
     // Iterate through keys
@@ -428,11 +465,11 @@ struct AttentionKernel {
 
       auto prologueV = [&](int blockN) {
         typename MM1::Mma::IteratorB iterator_V(
-            typename MM1::IteratorB::Params{MM1::LayoutB(p.head_dim_value)},
-            p.value_ptr + iter_key_start * p.head_dim_value,
-            {problem_size_1_k, problem_size_1_n},
+            typename MM1::IteratorB::Params{MM1::LayoutB(p.v_stride())},
+            p.value_ptr,
+            {p.num_keys, problem_size_1_n},
             thread_id(),
-            cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
+            cutlass::MatrixCoord{iter_key_start, blockN * MM1::Mma::Shape::kN});
         MM1::Mma::prologue(
             shared_storage.after_mm0.mm1.mm,
             iterator_V,
@@ -459,12 +496,13 @@ struct AttentionKernel {
           tb_tile_offset.m() * MM0::Mma::Shape::kM, tb_tile_offset.k()};
 
       cutlass::MatrixCoord tb_offset_B{
-          tb_tile_offset.k(), tb_tile_offset.n() * MM0::Mma::Shape::kN};
+          tb_tile_offset.k(),
+          iter_key_start + tb_tile_offset.n() * MM0::Mma::Shape::kN};
 
       // Construct iterators to A and B operands
       typename MM0::IteratorA iterator_A(
           typename MM0::IteratorA::Params(
-              typename MM0::MmaCore::LayoutA(p.head_dim)),
+              typename MM0::MmaCore::LayoutA(p.qk_stride())),
           p.query_ptr,
           {problem_size_0_m, problem_size_0_k},
           thread_id(),
@@ -472,9 +510,9 @@ struct AttentionKernel {
 
       typename MM0::IteratorB iterator_B(
           typename MM0::IteratorB::Params(
-              typename MM0::MmaCore::LayoutB(p.head_dim)),
-          p.key_ptr + iter_key_start * p.head_dim,
-          {problem_size_0_k, problem_size_0_n},
+              typename MM0::MmaCore::LayoutB(p.qk_stride())),
+          p.key_ptr,
+          {problem_size_0_k, p.num_keys},
           thread_id(),
           tb_offset_B);
 
@@ -509,7 +547,7 @@ struct AttentionKernel {
 
       // Mask out last if causal
       if (p.causal && p.num_keys - iter_key_start <= kKeysPerBlock) {
-        auto query_start = blockIdx.y * kQueriesPerBlock;
+        auto query_start = blockIdx.x * kQueriesPerBlock;
         auto lane_offset = MM0::ScalingCoefsUpdater::get_lane_offset(
             lane_id(), warp_id(), iteratorC_tile_offset);
         int32_t last_col;
@@ -587,11 +625,11 @@ struct AttentionKernel {
         }
 
         typename MM1::Mma::IteratorB iterator_V(
-            typename MM1::IteratorB::Params{MM1::LayoutB(p.head_dim_value)},
-            p.value_ptr + iter_key_start * p.head_dim_value,
-            {problem_size_1_k, problem_size_1_n},
+            typename MM1::IteratorB::Params{MM1::LayoutB(p.v_stride())},
+            p.value_ptr,
+            {p.num_keys, problem_size_1_n},
             thread_id(),
-            cutlass::MatrixCoord{0, blockN * MM1::Mma::Shape::kN});
+            cutlass::MatrixCoord{iter_key_start, blockN * MM1::Mma::Shape::kN});
         typename MM1::Mma mma_pv(
             shared_storage.after_mm0.mm1.mm,
             shared_storage.after_mm0.si,
@@ -778,7 +816,9 @@ __global__ void __launch_bounds__(AK::kNumThreads, AK::kMinBlocksPerSm)
                                   QUERIES_PER_BLOCK,       \
                                   KEYS_PER_BLOCK,          \
                                   SINGLE_VALUE_ITER>)      \
-  p.advance_to_block();                                    \
+  if (!p.advance_to_block()) {                             \
+    return;                                                \
+  }                                                        \
   Kernel::attention_kernel(p);                             \
   _ATTENTION_KERNEL_FORWARD_END();
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #443
* #442
* __->__ #440
* #439
* #438
* #434
* #429
* #426
* #421
* #415
* #412
* #411
* #433
* #432
* #405
* #404
* #403
* #399
* #398
* #397
* #396
* #395

**SUMMARY**

Will make it possible to support Nested Tensors in pytorch.
This is not currently exposed to end-users, as we need to figure
out how we pass the cumulative sequence lengths to the kernels