### PR TITLE
v100nvcc: work around a compiler bug in V100

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
@@ -147,7 +147,12 @@ struct AttentionBackwardKernel {
   // Compute delta for the f16 kernels
   // TODO: Figure out why it's slower on the f32 kernels
   // (something due to RF pressure?)
-  static constexpr bool kKernelComputesDelta = kIsHalf;
+  // TODO: Remove condition on `kOutputInRF` - this is needed to work
+  // around a compiler bug on V100, not exactly sure why but I spent
+  // too much time on this already. Reproducible with
+  // (B, Mq, Mkv, K) = (1, 1, 1, 136) for instance
+  static constexpr bool kKernelComputesDelta =
+      kIsHalf && (kOutputInRF || ArchTag::kMinComputeCapability != 70);
 
   // Launch bounds
   static constexpr int64_t kNumThreads = kWarpSize * kNumWarpsPerBlock;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #443
* #442
* #440
* #439
* #438
* #434
* #429
* #426
* #421
* #415
* #412
* #411
* #433
* #432
* #405
* #404
* #403
* #399
* #398
* #397
* #396
* #395

