### PR TITLE
regfix: Fix regression with cu seqlen PR

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -41,9 +41,9 @@
                       /* Run a more efficient kernel (with `isAligned=True`)  \
                       if memory is correctly aligned*/                        \
                       bool isAligned =                                        \
-                          (QUERY.stride(1) % AlignedAK::kAlignmentQ == 0 &&  \
-                           KEY.stride(1) % AlignedAK::kAlignmentK == 0 &&    \
-                           VALUE.stride(1) % AlignedAK::kAlignmentV == 0);   \
+                          (QUERY.stride(2) % AlignedAK::kAlignmentQ == 0 &&  \
+                           KEY.stride(2) % AlignedAK::kAlignmentK == 0 &&    \
+                           VALUE.stride(2) % AlignedAK::kAlignmentV == 0);   \
                       /* TODO: Should we warn or log somewhere when we use a  \
                       less efficient kernel due to wrong alignment? */        \
                       DISPATCH_BOOL(isAligned, kIsAligned, ([&]() {           \

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -41,9 +41,9 @@
                       /* Run a more efficient kernel (with `isAligned=True`)  \
                       if memory is correctly aligned*/                        \
                       bool isAligned =                                        \
-                          (QUERY.stride(-1) % AlignedAK::kAlignmentQ == 0 &&  \
-                           KEY.stride(-1) % AlignedAK::kAlignmentK == 0 &&    \
-                           VALUE.stride(-1) % AlignedAK::kAlignmentV == 0);   \
+                          (QUERY.stride(1) % AlignedAK::kAlignmentQ == 0 &&  \
+                           KEY.stride(1) % AlignedAK::kAlignmentK == 0 &&    \
+                           VALUE.stride(1) % AlignedAK::kAlignmentV == 0);   \
                       /* TODO: Should we warn or log somewhere when we use a  \
                       less efficient kernel due to wrong alignment? */        \
                       DISPATCH_BOOL(isAligned, kIsAligned, ([&]() {           \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #452
* #451
* #449
* #448
* #447
* #446
* __->__ #445
* #444

**PERFORMANCE COMPARISON**

<details>
<summary>A100 fw</summary>

```
[--------------------------------------- attention (attn_bias=<class 'NoneType'>) ---------------------------------------]
                                 |  37_regfix_85c0fb4[cutlass]  |  vanilla  |  flash[flshatt]  |  37_noqs_1b917ab[cutlass]
1 threads: ---------------------------------------------------------------------------------------------------------------
      f16 B=16, M=4096, K=40     |              873.6           |   1942.5  |                  |             882.0        
      f16 B=16, M=16384, K=40    |            12504.9           |  30670.0  |                  |           12638.1        
      f16 B=160, M=4096, K=128   |            12941.5           |  20664.9  |      22646.4     |           12985.0        
      f16 B=160, M=8192, K=128   |            51478.8           |           |      89871.2     |           51656.2        
      f16 B=256, M=128, K=16     |               32.5           |     62.3  |         29.4     |              23.0        
      f16 B=256, M=128, K=32     |               32.9           |     62.1  |         29.6     |              22.8        
      f16 B=256, M=128, K=64     |               33.0           |     61.8  |         29.5     |              22.8        
      f16 B=256, M=128, K=128    |               37.9           |     75.7  |         49.8     |              37.4        
      f16 B=256, M=512, K=16     |              180.0           |    474.8  |        113.4     |             181.1        
      f16 B=256, M=512, K=32     |              184.3           |    489.5  |        131.2     |             184.6        
      f16 B=256, M=512, K=64     |              212.0           |    538.1  |        236.5     |             213.9        
      f16 B=256, M=512, K=128    |              361.1           |    611.1  |        600.2     |             361.6        
      f16 B=256, M=1024, K=16    |              693.3           |   1787.4  |        443.0     |             695.3        
      f16 B=256, M=1024, K=32    |              691.4           |   1818.0  |        488.0     |             692.1        
      f16 B=256, M=1024, K=64    |              790.7           |   1937.9  |        908.5     |             797.4        
      f16 B=256, M=1024, K=128   |             1365.0           |   2147.8  |       2253.9     |            1361.5        
      f16 B=320, M=4096, K=128   |            25878.0           |  41196.9  |      34711.6     |           25865.5        
      f16 B=320, M=8192, K=128   |           102537.6           |           |     137676.9     |          102718.6        
      f16 B=384, M=197, K=64     |               90.2           |    659.3  |         69.7     |              90.7        
      f16 B=384, M=197, K=80     |              116.5           |    707.5  |                  |             116.1        
      f16 B=384, M=197, K=88     |              126.5           |    815.6  |                  |             125.9        
      f16 B=768, M=256, K=64     |              172.4           |    474.9  |        148.3     |             174.5        
      f16 B=1024, M=128, K=16    |               54.0           |    162.6  |         39.2     |              54.2        
      f16 B=1024, M=128, K=32    |               58.2           |    174.1  |         46.3     |              58.2        
      f16 B=1024, M=128, K=64    |               72.2           |    214.8  |         80.8     |              72.7        
      f16 B=1024, M=128, K=128   |              124.1           |    290.5  |        139.2     |             123.7        
      f16 B=1024, M=197, K=64    |              218.0           |   1723.6  |        155.0     |             219.3        
      f16 B=1024, M=197, K=80    |              297.1           |   1842.8  |                  |             296.8        
      f16 B=1024, M=197, K=88    |              318.7           |   2132.2  |                  |             319.1        
      f16 B=1024, M=512, K=16    |              708.4           |   1759.0  |        375.7     |             713.0        
      f16 B=1024, M=512, K=32    |              709.3           |   1832.0  |        416.4     |             709.7        
      f16 B=1024, M=512, K=64    |              809.8           |   2006.8  |        675.2     |             815.9        
      f16 B=1024, M=512, K=128   |             1409.5           |   2328.2  |       1990.7     |            1406.3        
      f16 B=1024, M=1024, K=16   |             2708.4           |   7057.6  |       1508.3     |            2727.9        
      f16 B=1024, M=1024, K=32   |             2711.0           |   7187.7  |       1641.6     |            2715.9        
      f16 B=1024, M=1024, K=64   |             3089.9           |   7714.8  |       2719.9     |            3116.7        
      f16 B=1024, M=1024, K=128  |             5360.9           |   8485.8  |       7524.9     |            5415.0        
      f16 B=2400, M=256, K=64    |              512.8           |   1398.2  |        396.0     |             517.8        
      f16 B=4096, M=4096, K=64   |           190373.4           |           |     167581.4     |          192210.1        
      f16 B=8192, M=82, K=64     |              459.0           |   1169.7  |        337.4     |             463.3
```
</details>

<details>
<summary>P100/V100 fw</summary>

```
[------------------------------------- attention (attn_bias=<class 'NoneType'>) ------------------------------------]
                                                     |  38_fw_forceinline_be509940  |  37_regfix_c5ea3975  |  vanilla
1 threads: ----------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f32 B=16, M=4096, K=40     |             9877.1           |         9628.4       |  17064.7
                          f16 B=16, M=4096, K=40     |            11039.4           |        10622.5       |  13597.6
                          f32 B=16, M=16384, K=40    |           149519.5           |       145354.9       |         
                          f16 B=16, M=16384, K=40    |           167359.9           |       162490.9       |         
                          f32 B=160, M=4096, K=128   |           228531.3           |       227594.4       |         
                          f16 B=160, M=4096, K=128   |           246930.4           |       239059.5       |         
                          f32 B=160, M=8192, K=128   |           947336.8           |       937086.9       |         
                          f16 B=160, M=8192, K=128   |           999301.4           |       974127.7       |         
                          f32 B=256, M=128, K=16     |              141.7           |          138.7       |    258.0
                          f16 B=256, M=128, K=16     |              149.9           |          149.3       |    221.4
                          f32 B=256, M=128, K=32     |              164.4           |          160.7       |    287.5
                          f16 B=256, M=128, K=32     |              177.7           |          173.4       |    243.2
                          f32 B=256, M=128, K=64     |              214.8           |          211.6       |    341.7
                          f16 B=256, M=128, K=64     |              229.3           |          226.6       |    292.2
                          f32 B=256, M=128, K=128    |              426.0           |          417.3       |    453.5
                          f16 B=256, M=128, K=128    |              427.1           |          423.0       |    382.5
                          f32 B=256, M=512, K=16     |             1951.5           |         1920.0       |   3459.7
                          f16 B=256, M=512, K=16     |             2130.8           |         2090.6       |   3009.7
                          f32 B=256, M=512, K=32     |             2269.4           |         2252.5       |   3728.3
                          f16 B=256, M=512, K=32     |             2514.0           |         2497.9       |   3290.3
                          f32 B=256, M=512, K=64     |             2957.7           |         2952.0       |   4361.3
                          f16 B=256, M=512, K=64     |             3275.3           |         3255.9       |   3915.4
                          f32 B=256, M=512, K=128    |             5910.1           |         5859.3       |   5605.1
                          f16 B=256, M=512, K=128    |             6349.4           |         6325.1       |   4983.1
                          f32 B=256, M=1024, K=16    |             7567.9           |         7542.5       |  13600.7
                          f16 B=256, M=1024, K=16    |             8343.9           |         8316.4       |  11988.3
                          f32 B=256, M=1024, K=32    |             8815.8           |         8909.9       |  14671.3
                          f16 B=256, M=1024, K=32    |             9890.2           |         9798.3       |  13107.4
                          f32 B=256, M=1024, K=64    |            11503.4           |        11429.2       |  16881.1
                          f16 B=256, M=1024, K=64    |            12776.6           |        12834.6       |  15358.5
                          f32 B=256, M=1024, K=128   |            23134.9           |        23114.8       |  21554.2
                          f16 B=256, M=1024, K=128   |            25036.1           |        25195.0       |  19679.0
                          f32 B=320, M=4096, K=128   |           468715.2           |       476270.4       |         
                          f16 B=320, M=4096, K=128   |           495174.9           |       495656.7       |         
                          f32 B=320, M=8192, K=128   |          1934265.2           |      1938613.4       |         
                          f16 B=320, M=8192, K=128   |          2014182.6           |      2012988.5       |         
                          f32 B=384, M=197, K=64     |             1039.1           |         1040.5       |   1376.4
                          f16 B=384, M=197, K=64     |             1142.8           |         1150.2       |   1275.1
                          f32 B=384, M=197, K=80     |             1470.7           |         1475.2       |   1504.4
                          f16 B=384, M=197, K=80     |             1519.1           |         1529.2       |   1388.0
                          f32 B=384, M=197, K=88     |             1536.6           |         1543.4       |   1567.7
                          f16 B=384, M=197, K=88     |             1592.2           |         1601.9       |   1437.2
                          f32 B=768, M=256, K=64     |             2281.4           |         2280.0       |   3420.4
                          f16 B=768, M=256, K=64     |             2513.9           |         2518.7       |   3029.2
                          f32 B=1024, M=128, K=16    |              523.0           |          525.4       |    972.1
                          f16 B=1024, M=128, K=16    |              565.1           |          563.8       |    844.3
                          f32 B=1024, M=128, K=32    |              611.5           |          615.2       |   1081.6
                          f16 B=1024, M=128, K=32    |              667.9           |          664.8       |    923.1
                          f32 B=1024, M=128, K=64    |              801.1           |          804.1       |   1283.8
                          f16 B=1024, M=128, K=64    |              862.3           |          864.2       |   1107.1
                          f32 B=1024, M=128, K=128   |             1647.0           |         1654.6       |   1720.3
                          f16 B=1024, M=128, K=128   |             1666.1           |         1668.7       |   1444.6
                          f32 B=1024, M=197, K=64    |             2715.1           |         2730.8       |   3643.9
                          f16 B=1024, M=197, K=64    |             2970.5           |         2980.9       |   3351.6
                          f32 B=1024, M=197, K=80    |             3925.5           |         3919.5       |   3932.6
                          f16 B=1024, M=197, K=80    |             4035.9           |         4068.6       |   3648.1
                          f32 B=1024, M=197, K=88    |             4052.8           |         4071.9       |   4090.5
                          f16 B=1024, M=197, K=88    |             4192.7           |         4211.9       |   3778.7
                          f32 B=1024, M=512, K=16    |             7567.1           |         7599.1       |  13818.3
                          f16 B=1024, M=512, K=16    |             8425.9           |         8413.1       |  12005.7
                          f32 B=1024, M=512, K=32    |             8946.7           |         8950.0       |  14917.2
                          f16 B=1024, M=512, K=32    |             9915.1           |         9912.6       |  13178.2
                          f32 B=1024, M=512, K=64    |            11603.1           |        11669.4       |  17390.9
                          f16 B=1024, M=512, K=64    |            13007.8           |        13025.8       |  15594.0
                          f32 B=1024, M=512, K=128   |            23677.0           |        23799.5       |  22201.9
                          f16 B=1024, M=512, K=128   |            25263.0           |        25490.7       |  20019.5
                          f32 B=1024, M=1024, K=16   |            29870.3           |        29972.0       |  54587.5
                          f16 B=1024, M=1024, K=16   |            33197.8           |        33138.4       |  48263.2
                          f32 B=1024, M=1024, K=32   |            35071.6           |        35394.1       |  58847.3
                          f16 B=1024, M=1024, K=32   |            38962.3           |        39197.8       |  53243.4
                          f32 B=1024, M=1024, K=64   |            45583.9           |        45935.3       |  68551.4
                          f16 B=1024, M=1024, K=64   |            51038.2           |        51334.0       |  62073.2
                          f32 B=1024, M=1024, K=128  |            92306.3           |        92544.9       |  86876.1
                          f16 B=1024, M=1024, K=128  |            99940.5           |       100599.8       |  79020.7
                          f32 B=2400, M=256, K=64    |             7027.3           |         7063.6       |  10626.1
                          f16 B=2400, M=256, K=64    |             7770.9           |         7800.6       |   9426.6
                          f32 B=8192, M=82, K=64     |             5310.2           |         5345.8       |   6851.0
                          f16 B=8192, M=82, K=64     |             5741.7           |         5755.5       |   6434.8
  (Tesla_V100_SXM2_16GB)  f32 B=16, M=4096, K=40     |             5850.7           |         5834.7       |   8023.8
                          f16 B=16, M=4096, K=40     |             2282.8           |         2285.1       |   4189.9
                          f32 B=16, M=16384, K=40    |            87257.8           |        86368.5       |         
                          f16 B=16, M=16384, K=40    |            33120.2           |        32868.9       |         
                          f32 B=160, M=4096, K=128   |           126679.7           |       125890.6       |         
                          f16 B=160, M=4096, K=128   |            38170.5           |        37777.4       |         
                          f32 B=160, M=8192, K=128   |           516485.9           |       516229.7       |         
                          f16 B=160, M=8192, K=128   |           155101.4           |       153617.1       |         
                          f32 B=256, M=128, K=16     |               83.7           |           83.2       |    119.9
                          f16 B=256, M=128, K=16     |               61.0           |           71.8       |    112.4
                          f32 B=256, M=128, K=32     |               95.5           |           95.9       |    142.7
                          f16 B=256, M=128, K=32     |               59.7           |           66.4       |    103.8
                          f32 B=256, M=128, K=64     |              127.1           |          126.1       |    199.4
                          f16 B=256, M=128, K=64     |               61.8           |           72.4       |    107.0
                          f32 B=256, M=128, K=128    |              234.0           |          234.5       |    327.5
                          f16 B=256, M=128, K=128    |               90.7           |           90.2       |    133.6
                          f32 B=256, M=512, K=16     |             1094.2           |         1094.5       |   1757.7
                          f16 B=256, M=512, K=16     |              478.0           |          477.0       |    793.2
                          f32 B=256, M=512, K=32     |             1283.4           |         1276.2       |   1908.9
                          f16 B=256, M=512, K=32     |              487.0           |          482.4       |    832.2
                          f32 B=256, M=512, K=64     |             1688.0           |         1678.5       |   2256.6
                          f16 B=256, M=512, K=64     |              584.3           |          583.1       |    978.0
                          f32 B=256, M=512, K=128    |             3313.9           |         3301.6       |   3640.9
                          f16 B=256, M=512, K=128    |             1074.6           |         1064.5       |   1154.7
                          f32 B=256, M=1024, K=16    |             4228.7           |         4239.5       |   7049.9
                          f16 B=256, M=1024, K=16    |             1835.5           |         1835.9       |   3279.9
                          f32 B=256, M=1024, K=32    |             5025.5           |         5021.7       |   7650.6
                          f16 B=256, M=1024, K=32    |             1865.3           |         1853.9       |   3335.2
                          f32 B=256, M=1024, K=64    |             6603.1           |         6590.5       |   9041.9
                          f16 B=256, M=1024, K=64    |             2235.9           |         2232.9       |   3798.5
                          f32 B=256, M=1024, K=128   |            12854.9           |        12893.4       |  14574.3
                          f16 B=256, M=1024, K=128   |             4069.8           |         4046.4       |   4277.9
                          f32 B=320, M=4096, K=128   |           255518.0           |       254584.4       |         
                          f16 B=320, M=4096, K=128   |            77126.0           |        77114.7       |         
                          f32 B=320, M=8192, K=128   |          1040399.2           |      1044030.5       |         
                          f16 B=320, M=8192, K=128   |           312274.0           |       311949.6       |         
                          f32 B=384, M=197, K=64     |              584.0           |          583.8       |    720.8
                          f16 B=384, M=197, K=64     |              221.7           |          221.8       |    413.4
                          f32 B=384, M=197, K=80     |              773.3           |          776.1       |    874.7
                          f16 B=384, M=197, K=80     |              309.1           |          310.1       |    516.7
                          f32 B=384, M=197, K=88     |              807.4           |          809.8       |    909.1
                          f16 B=384, M=197, K=88     |              322.7           |          322.0       |    535.6
                          f32 B=768, M=256, K=64     |             1307.3           |         1314.3       |   1885.6
                          f16 B=768, M=256, K=64     |              457.2           |          460.0       |    771.4
                          f32 B=1024, M=128, K=16    |              289.5           |          288.9       |    439.6
                          f16 B=1024, M=128, K=16    |              138.8           |          138.8       |    231.9
                          f32 B=1024, M=128, K=32    |              343.6           |          340.9       |    520.2
                          f16 B=1024, M=128, K=32    |              144.0           |          144.2       |    259.2
                          f32 B=1024, M=128, K=64    |              462.2           |          459.5       |    690.1
                          f16 B=1024, M=128, K=64    |              182.7           |          182.4       |    324.9
                          f32 B=1024, M=128, K=128   |              883.0           |          887.9       |   1133.8
                          f16 B=1024, M=128, K=128   |              334.2           |          331.8       |    451.6
                          f32 B=1024, M=197, K=64    |             1521.2           |         1532.9       |   1879.2
                          f16 B=1024, M=197, K=64    |              574.4           |          574.1       |   1064.8
                          f32 B=1024, M=197, K=80    |             2033.8           |         2036.1       |   2299.4
                          f16 B=1024, M=197, K=80    |              812.3           |          813.2       |   1345.2
                          f32 B=1024, M=197, K=88    |             2122.8           |         2128.0       |   2386.7
                          f16 B=1024, M=197, K=88    |              840.0           |          838.9       |   1400.0
                          f32 B=1024, M=512, K=16    |             4217.7           |         4222.7       |   7173.6
                          f16 B=1024, M=512, K=16    |             1845.0           |         1844.7       |   3073.8
                          f32 B=1024, M=512, K=32    |             5052.5           |         5027.6       |   7952.3
                          f16 B=1024, M=512, K=32    |             1897.0           |         1896.7       |   3268.3
                          f32 B=1024, M=512, K=64    |             6645.7           |         6695.6       |   9327.8
                          f16 B=1024, M=512, K=64    |             2272.1           |         2274.7       |   3897.7
                          f32 B=1024, M=512, K=128   |            13070.8           |        13144.3       |  14805.1
                          f16 B=1024, M=512, K=128   |             4161.1           |         4163.6       |   4527.7
                          f32 B=1024, M=1024, K=16   |            16464.4           |        16507.7       |  27456.0
                          f16 B=1024, M=1024, K=16   |             7085.7           |         7085.6       |  13481.2
                          f32 B=1024, M=1024, K=32   |            19640.1           |        19728.3       |  29735.3
                          f16 B=1024, M=1024, K=32   |             7277.9           |         7289.0       |  13752.5
                          f32 B=1024, M=1024, K=64   |            26247.3           |        26185.2       |  36672.8
                          f16 B=1024, M=1024, K=64   |             8709.7           |         8715.1       |  15543.5
                          f32 B=1024, M=1024, K=128  |            51174.0           |        51101.9       |  56685.6
                          f16 B=1024, M=1024, K=128  |            15798.1           |        15839.9       |  16910.8
                          f32 B=2400, M=256, K=64    |             4009.8           |         4040.4       |   5694.7
                          f16 B=2400, M=256, K=64    |             1433.6           |         1430.7       |   2369.0
                          f32 B=8192, M=82, K=64     |             2947.0           |         2969.3       |   3254.7
                          f16 B=8192, M=82, K=64     |             1195.0           |         1196.8       |   1695.5

Times are in microseconds (us).
```
</details>

<details>
<summary>P100/V100 bw</summary>

```
[-------------------------------- attention backward (attn_bias=<class 'NoneType'>) ---------------------------------]
                                                     |  38_fw_forceinline_be509940  |  37_regfix_c5ea3975  |  vanilla 
1 threads: -----------------------------------------------------------------------------------------------------------
  (Quadro_GP100)          f32 B=16, M=4096, K=40     |           144085.2           |       144156.8       |   36038.1
                          f16 B=16, M=4096, K=40     |           135009.6           |       134936.9       |   27876.5
                          f32 B=16, M=16384, K=40    |          2273513.9           |      2273974.8       |          
                          f16 B=16, M=16384, K=40    |          2151278.1           |      2150035.8       |          
                          f32 B=160, M=4096, K=128   |          1097718.9           |      1096700.5       |          
                          f16 B=160, M=4096, K=128   |          1072588.6           |      1051041.4       |          
                          f32 B=160, M=8192, K=128   |          4363521.4           |      4362798.8       |          
                          f16 B=160, M=8192, K=128   |          4254100.1           |      4215918.8       |          
                          f32 B=256, M=128, K=16     |              673.7           |          672.2       |     617.5
                          f16 B=256, M=128, K=16     |              510.0           |          510.2       |     503.8
                          f32 B=256, M=128, K=32     |              831.7           |          829.9       |     692.2
                          f16 B=256, M=128, K=32     |              592.6           |          592.7       |     553.9
                          f32 B=256, M=128, K=64     |             1143.7           |         1147.4       |     851.0
                          f16 B=256, M=128, K=64     |              749.3           |          746.4       |     680.6
                          f32 B=256, M=128, K=128    |             2174.7           |         2171.5       |    1225.9
                          f16 B=256, M=128, K=128    |             1609.9           |         1606.7       |     963.9
                          f32 B=256, M=512, K=16     |             9937.9           |         9938.5       |    8225.3
                          f16 B=256, M=512, K=16     |             7494.2           |         7503.2       |    6628.3
                          f32 B=256, M=512, K=32     |            11203.9           |        11258.0       |    8706.4
                          f16 B=256, M=512, K=32     |             8554.1           |         8526.2       |    7094.7
                          f32 B=256, M=512, K=64     |            15216.9           |        15142.3       |    9846.9
                          f16 B=256, M=512, K=64     |            10768.6           |        10757.7       |    8001.4
                          f32 B=256, M=512, K=128    |            29615.0           |        29685.3       |   12971.6
                          f16 B=256, M=512, K=128    |            24655.6           |        24680.7       |   10668.4
                          f32 B=256, M=1024, K=16    |            39060.0           |        39039.8       |   31830.3
                          f16 B=256, M=1024, K=16    |            29545.2           |        29554.2       |   25868.6
                          f32 B=256, M=1024, K=32    |            43761.5           |        43831.1       |   33560.6
                          f16 B=256, M=1024, K=32    |            33660.5           |        33333.3       |   27375.0
                          f32 B=256, M=1024, K=64    |            58548.1           |        58665.9       |   37259.9
                          f16 B=256, M=1024, K=64    |            43102.2           |        43349.9       |   30409.3
                          f32 B=256, M=1024, K=128   |           115915.8           |       115482.7       |   46994.3
                          f16 B=256, M=1024, K=128   |           101692.5           |       102317.9       |   39838.0
                          f32 B=320, M=4096, K=128   |          2183953.8           |      2183895.5       |          
                          f16 B=320, M=4096, K=128   |          1727324.0           |      1732745.4       |          
                          f32 B=320, M=8192, K=128   |          8705171.9           |      8717331.2       |          
                          f16 B=320, M=8192, K=128   |          6930424.1           |      6939417.4       |          
                          f32 B=384, M=197, K=64     |             6263.1           |         6264.1       |    3036.3
                          f16 B=384, M=197, K=64     |             3567.8           |         3565.8       |    2578.6
                          f32 B=384, M=197, K=80     |             9191.6           |         9192.8       |    3551.6
                          f16 B=384, M=197, K=80     |             6504.9           |         6451.7       |    3036.1
                          f32 B=384, M=197, K=88     |             9650.4           |         9667.0       |    3676.3
                          f16 B=384, M=197, K=88     |             6777.4           |         6713.6       |    3147.6
                          f32 B=768, M=256, K=64     |            11599.4           |        11573.7       |    8081.4
                          f16 B=768, M=256, K=64     |             7053.2           |         7024.3       |    6514.6
                          f32 B=1024, M=128, K=16    |             2524.5           |         2525.8       |    2302.9
                          f16 B=1024, M=128, K=16    |             1706.9           |         1707.4       |    1870.4
                          f32 B=1024, M=128, K=32    |             3134.5           |         3140.9       |    2583.2
                          f16 B=1024, M=128, K=32    |             2006.4           |         2008.7       |    2075.5
                          f32 B=1024, M=128, K=64    |             4404.5           |         4408.3       |    3232.3
                          f16 B=1024, M=128, K=64    |             2621.5           |         2624.9       |    2522.0
                          f32 B=1024, M=128, K=128   |             8331.2           |         8342.0       |    4794.7
                          f16 B=1024, M=128, K=128   |             5670.7           |         5663.4       |    3665.8
                          f32 B=1024, M=197, K=64    |            16919.9           |        16897.0       |    8079.6
                          f16 B=1024, M=197, K=64    |             9000.3           |         8978.2       |    6702.1
                          f32 B=1024, M=197, K=80    |            24775.2           |        24787.0       |    9372.4
                          f16 B=1024, M=197, K=80    |            16114.2           |        16103.0       |    7971.3
                          f32 B=1024, M=197, K=88    |            26004.2           |        26000.8       |    9707.0
                          f16 B=1024, M=197, K=88    |            16873.1           |        16898.4       |    8263.0
                          f32 B=1024, M=512, K=16    |            37312.8           |        37299.5       |   32550.2
                          f16 B=1024, M=512, K=16    |            24944.0           |        25120.6       |   26262.2
                          f32 B=1024, M=512, K=32    |            42335.8           |        42386.3       |   34772.3
                          f16 B=1024, M=512, K=32    |            29043.3           |        28991.2       |   28165.6
                          f32 B=1024, M=512, K=64    |            58077.2           |        58057.4       |   39177.4
                          f16 B=1024, M=512, K=64    |            37648.2           |        37624.3       |   31618.7
                          f32 B=1024, M=512, K=128   |           113396.8           |       113503.7       |   50989.8
                          f16 B=1024, M=512, K=128   |            87049.6           |        87517.4       |   42328.2
                          f32 B=1024, M=1024, K=16   |           146435.4           |       146764.8       |          
                          f16 B=1024, M=1024, K=16   |            99689.7           |       101909.6       |  104224.7
                          f32 B=1024, M=1024, K=32   |           165030.3           |       164861.3       |          
                          f16 B=1024, M=1024, K=32   |           114600.5           |       114607.9       |  110319.6
                          f32 B=1024, M=1024, K=64   |           225300.4           |       224976.3       |          
                          f16 B=1024, M=1024, K=64   |           149259.4           |       149296.1       |  122474.8
                          f32 B=1024, M=1024, K=128  |           439342.7           |       439278.7       |          
                          f16 B=1024, M=1024, K=128  |           342786.0           |       343221.3       |  163200.7
                          f32 B=2400, M=256, K=64    |            35715.0           |        35707.3       |   25404.3
                          f16 B=2400, M=256, K=64    |            21926.6           |        21990.3       |   20221.7
                          f32 B=8192, M=82, K=64     |            48765.5           |        48871.6       |   16988.2
                          f16 B=8192, M=82, K=64     |            22505.1           |        22317.4       |   13658.8
  (Tesla_V100_SXM2_16GB)  f32 B=16, M=4096, K=40     |           111361.8           |       111474.3       |   19246.9
                          f16 B=16, M=4096, K=40     |            47210.1           |        47213.6       |    8470.7
                          f32 B=16, M=16384, K=40    |          1779759.2           |      1776770.7       |          
                          f16 B=16, M=16384, K=40    |           751771.1           |       755331.6       |          
                          f32 B=160, M=4096, K=128   |           496759.4           |       496725.3       |          
                          f16 B=160, M=4096, K=128   |           139650.0           |       139787.5       |          
                          f32 B=160, M=8192, K=128   |          1976963.1           |      1978114.2       |          
                          f16 B=160, M=8192, K=128   |           566856.5           |       567555.9       |          
                          f32 B=256, M=128, K=16     |              295.7           |          295.1       |     311.6
                          f16 B=256, M=128, K=16     |              207.8           |          194.4       |     237.6
                          f32 B=256, M=128, K=32     |              380.7           |          379.7       |     366.6
                          f16 B=256, M=128, K=32     |              225.9           |          199.2       |     235.6
                          f32 B=256, M=128, K=64     |              548.9           |          548.0       |     492.9
                          f16 B=256, M=128, K=64     |              237.0           |          234.2       |     250.5
                          f32 B=256, M=128, K=128    |             1058.2           |         1050.3       |     808.6
                          f16 B=256, M=128, K=128    |              430.2           |          429.4       |     376.2
                          f32 B=256, M=512, K=16     |             4323.1           |         4268.7       |    4130.6
                          f16 B=256, M=512, K=16     |             1639.1           |         1655.3       |    1821.0
                          f32 B=256, M=512, K=32     |             5175.4           |         5168.3       |    4375.7
                          f16 B=256, M=512, K=32     |             1860.8           |         1864.6       |    1943.0
                          f32 B=256, M=512, K=64     |             7269.5           |         7278.4       |    5105.4
                          f16 B=256, M=512, K=64     |             2516.0           |         2524.1       |    2245.7
                          f32 B=256, M=512, K=128    |            14273.0           |        14270.2       |    8009.7
                          f16 B=256, M=512, K=128    |             4617.6           |         4613.3       |    2794.6
                          f32 B=256, M=1024, K=16    |            16679.0           |        16634.0       |   15862.6
                          f16 B=256, M=1024, K=16    |             6333.9           |         6392.1       |    6853.5
                          f32 B=256, M=1024, K=32    |            20259.2           |        20313.9       |   16651.6
                          f16 B=256, M=1024, K=32    |             6997.5           |         6982.4       |    7107.3
                          f32 B=256, M=1024, K=64    |            28417.2           |        28380.0       |   19409.1
                          f16 B=256, M=1024, K=64    |             9425.0           |         9363.1       |    7949.4
                          f32 B=256, M=1024, K=128   |            55822.7           |        55852.7       |   30489.1
                          f16 B=256, M=1024, K=128   |            17592.4           |        17101.1       |    9350.3
                          f32 B=320, M=4096, K=128   |           995535.4           |       997476.5       |          
                          f16 B=320, M=4096, K=128   |           279399.9           |       281533.4       |          
                          f32 B=320, M=8192, K=128   |          3972063.1           |      3979533.4       |          
                          f16 B=320, M=8192, K=128   |          1139498.9           |      1110779.6       |          
                          f32 B=384, M=197, K=64     |             2708.5           |         2701.7       |    1592.3
                          f16 B=384, M=197, K=64     |             1176.1           |         1172.1       |     922.1
                          f32 B=384, M=197, K=80     |             3885.1           |         3885.0       |    1990.6
                          f16 B=384, M=197, K=80     |             1668.8           |         1662.7       |    1127.2
                          f32 B=384, M=197, K=88     |             4241.0           |         4236.5       |    2062.6
                          f16 B=384, M=197, K=88     |             1738.2           |         1734.6       |    1177.2
                          f32 B=768, M=256, K=64     |             5358.6           |         5316.3       |    4293.2
                          f16 B=768, M=256, K=64     |             1953.5           |         1941.2       |    1936.7
                          f32 B=1024, M=128, K=16    |             1032.7           |         1028.2       |    1132.7
                          f16 B=1024, M=128, K=16    |              466.3           |          465.7       |     558.3
                          f32 B=1024, M=128, K=32    |             1347.8           |         1354.2       |    1332.5
                          f16 B=1024, M=128, K=32    |              574.1           |          573.5       |     662.4
                          f32 B=1024, M=128, K=64    |             2010.0           |         2012.3       |    1728.6
                          f16 B=1024, M=128, K=64    |              863.5           |          851.2       |     869.8
                          f32 B=1024, M=128, K=128   |             3915.3           |         3917.8       |    2839.2
                          f16 B=1024, M=128, K=128   |             1517.1           |         1522.0       |    1333.2
                          f32 B=1024, M=197, K=64    |             6591.6           |         6574.2       |    4090.1
                          f16 B=1024, M=197, K=64    |             2909.5           |         2904.9       |    2355.9
                          f32 B=1024, M=197, K=80    |             9382.6           |         9380.8       |    5219.3
                          f16 B=1024, M=197, K=80    |             4340.4           |         4340.0       |    2908.0
                          f32 B=1024, M=197, K=88    |            10324.8           |        10318.0       |    5385.8
                          f16 B=1024, M=197, K=88    |             4516.3           |         4515.5       |    3040.3
                          f32 B=1024, M=512, K=16    |            14995.5           |        15050.3       |   16171.1
                          f16 B=1024, M=512, K=16    |             5760.2           |         5787.3       |    7147.9
                          f32 B=1024, M=512, K=32    |            18565.3           |        18625.0       |   17418.6
                          f16 B=1024, M=512, K=32    |             6627.3           |         6633.3       |    7639.3
                          f32 B=1024, M=512, K=64    |            27111.6           |        27229.3       |   20299.8
                          f16 B=1024, M=512, K=64    |             9311.3           |         9319.8       |    8997.2
                          f32 B=1024, M=512, K=128   |            53816.7           |        54273.8       |   32373.5
                          f16 B=1024, M=512, K=128   |            16095.5           |        16073.0       |   10934.0
                          f32 B=1024, M=1024, K=16   |            59123.7           |        59549.4       |          
                          f16 B=1024, M=1024, K=16   |            22465.7           |        22463.4       |   27803.9
                          f32 B=1024, M=1024, K=32   |            72229.6           |        72161.7       |          
                          f16 B=1024, M=1024, K=32   |            24940.8           |        25095.4       |   28953.9
                          f32 B=1024, M=1024, K=64   |           105802.3           |       105901.7       |          
                          f16 B=1024, M=1024, K=64   |            34537.7           |        34727.7       |   32367.6
                          f32 B=1024, M=1024, K=128  |           210823.2           |       210418.2       |          
                          f16 B=1024, M=1024, K=128  |            60216.8           |        62215.4       |   37380.7
                          f32 B=2400, M=256, K=64    |            16564.0           |        16565.0       |   13045.4
                          f16 B=2400, M=256, K=64    |             6008.0           |         6013.9       |    5942.4
                          f32 B=8192, M=82, K=64     |            15926.3           |        15866.5       |    7705.5
                          f16 B=8192, M=82, K=64     |             9313.7           |         9261.4       |    3935.4

Times are in microseconds (us).
```
</details>