### PR TITLE
fix failing tests #464 due to windows distributed using gloo not nccl

### DIFF
--- a/xformers/helpers/test_utils.py
+++ b/xformers/helpers/test_utils.py
@@ -4,14 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import os
 import tempfile
 
 import torch
 
-import os
 is_windows = False
-if (os.environ.get('OS','') == 'Windows_NT'): #pytorch on windows uses gloo not ncll
+if (os.environ.get('OS', '') == 'Windows_NT'):  # pytorch on windows uses gloo not ncll
     is_windows = True
+
 
 def init_torch_distributed_local():
     if torch.distributed.is_initialized():

--- a/xformers/helpers/test_utils.py
+++ b/xformers/helpers/test_utils.py
@@ -10,7 +10,7 @@ import tempfile
 import torch
 
 is_windows = False
-if (os.environ.get('OS', '') == 'Windows_NT'):  # pytorch on windows uses gloo not ncll
+if os.environ.get("OS", "") == "Windows_NT":  # pytorch on windows uses gloo not ncll
     is_windows = True
 
 

--- a/xformers/helpers/test_utils.py
+++ b/xformers/helpers/test_utils.py
@@ -4,13 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import os
+import sys
 import tempfile
 
 import torch
 
 is_windows = False
-if os.environ.get("OS", "") == "Windows_NT":  # pytorch on windows uses gloo not ncll
+if sys.platform == "win32":  # pytorch on windows uses gloo not ncll
     is_windows = True
 
 

--- a/xformers/helpers/test_utils.py
+++ b/xformers/helpers/test_utils.py
@@ -8,6 +8,10 @@ import tempfile
 
 import torch
 
+import os
+is_windows = False
+if (os.environ.get('OS','') == 'Windows_NT'): #pytorch on windows uses gloo not ncll
+    is_windows = True
 
 def init_torch_distributed_local():
     if torch.distributed.is_initialized():
@@ -16,7 +20,7 @@ def init_torch_distributed_local():
     init_url = "file://" + tempfile.mkstemp()[1]
     backend = (
         torch.distributed.Backend.NCCL
-        if torch.cuda.is_available()
+        if torch.cuda.is_available() and not is_windows
         else torch.distributed.Backend.GLOO
     )
     torch.distributed.init_process_group(


### PR DESCRIPTION
Fixes fails in test_feedforward.py and test_block_factory.py

Even though windows pytorch is built with CUDA it doesn't support NCCL, only GLOO or MPI.  So needed to add a check if on windows to do the test_block_factory.py and test_block_factory.py tests without failing.

## What does this PR do?
Fixes #464 

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
