### PR TITLE
fctls_bflsh: New OP that combines cutlass's fw + flash's bw

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -53,7 +53,10 @@ def generate_test_shapes_B_Mq_Mkv_H_K_Kv(op):
     # Crashes on Flash, Errors on Cutlass
     # shapes.append((1, 1, 64000, 300, 128, 128))
     # Add some random shapes
-    if op is xformers.ops.MemoryEfficientAttentionCutlassOp:
+    if op in [
+        xformers.ops.MemoryEfficientAttentionCutlassOp,
+        xformers.ops.MemoryEfficientAttentionCutlassFwdFlashBwOp,
+    ]:
         K_CHOICES = [8 * i for i in range(1, 256 // 8)]
         r = random.Random(0)
         for _ in range(20):
@@ -75,6 +78,7 @@ def _generate_op_device_dtype_B_Mq_Mkv_H_K_Kv(**kwargs):
         xformers.ops.MemoryEfficientAttentionOp,
         xformers.ops.MemoryEfficientAttentionCutlassOp,
         xformers.ops.MemoryEfficientAttentionFlashAttentionOp,
+        xformers.ops.MemoryEfficientAttentionCutlassFwdFlashBwOp,
     ]:
         for shape in generate_test_shapes_B_Mq_Mkv_H_K_Kv(op, **kwargs):
             for device in _devices:

--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -419,7 +419,10 @@ def test_logsumexp(op_device_dtype_B_Mq_Mkv_H_K_Kv):
         k,
         kv,
     ) = op_device_dtype_B_Mq_Mkv_H_K_Kv
-    if op.FORWARD_OPERATOR is None:
+    if (
+        op.FORWARD_OPERATOR is None
+        or op is xformers.ops.MemoryEfficientAttentionCutlassFwdFlashBwOp
+    ):
         return
     query, key, value, attn_bias = create_tensors(
         *op_device_dtype_B_Mq_Mkv_H_K_Kv, fmt="BMK"

--- a/xformers/ops.py
+++ b/xformers/ops.py
@@ -6,6 +6,7 @@
 
 import math
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, List, Mapping, Optional, Sequence, Set, Tuple, Type, Union
 
 import torch
@@ -427,16 +428,17 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
         )
 
     @classmethod
-    def forward(cls, ctx, query, key, value, attn_bias, p):
-        causal = isinstance(attn_bias, LowerTriangularMask)
-        return_softmax = False
-
+    def prepare_inputs(
+        cls, ctx, query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+    ):
         batch = query.shape[0]
         seqlen_q = query.shape[1]
         seqlen_k = key.shape[1]
         num_heads = query.shape[2]
         head_dim_q = query.shape[3]
         head_dim_v = value.shape[3]
+        ctx.max_seqlen_q = seqlen_q
+        ctx.max_seqlen_k = seqlen_k
 
         cu_seqlens_k = torch.arange(
             0,
@@ -458,12 +460,22 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
 
         # Initially we have `query.shape = [batch, seqlen, head_dim_q]`
         # We want format `[batch * seqlen, num_heads, head_dim_q]`
-        query_api_input_shape = query.shape
-        key_api_input_shape = key.shape
-        value_api_input_shape = value.shape
+        ctx.query_api_input_shape = query.shape
+        ctx.key_api_input_shape = key.shape
+        ctx.value_api_input_shape = value.shape
         query = query.reshape([batch * seqlen_q, num_heads, head_dim_q])
         key = key.reshape([batch * seqlen_k, num_heads, head_dim_q])
         value = value.reshape([batch * seqlen_k, num_heads, head_dim_v])
+        return query, key, value, cu_seqlens_k, cu_seqlens_q
+
+    @classmethod
+    def forward(cls, ctx, query, key, value, attn_bias, p):
+        causal = isinstance(attn_bias, LowerTriangularMask)
+        return_softmax = False
+        ctx_flash = ctx if ctx is not None else SimpleNamespace()
+        query, key, value, cu_seqlens_k, cu_seqlens_q = cls.prepare_inputs(
+            ctx_flash, query, key, value
+        )
 
         # Save rng_state because the backward pass will regenerate the dropout mask
         rng_state = torch.cuda.get_rng_state() if p > 0 else None
@@ -474,8 +486,8 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
             value,
             cu_seqlens_q,
             cu_seqlens_k,
-            seqlen_q,
-            seqlen_k,
+            ctx_flash.max_seqlen_q,
+            ctx_flash.max_seqlen_k,
             p,
             softmax_scale,
             causal=causal,
@@ -493,18 +505,17 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
                 rng_state,
             )
             ctx.dropout_p = p
-            ctx.max_seqlen_q = seqlen_q
-            ctx.max_seqlen_k = seqlen_k
             ctx.softmax_scale = softmax_scale
             ctx.causal = causal
             ctx.kernel_output_shape = out.shape
-            ctx.query_api_input_shape = query_api_input_shape
-            ctx.key_api_input_shape = key_api_input_shape
-            ctx.value_api_input_shape = value_api_input_shape
         return out
 
     @classmethod
     def backward(cls, ctx, grad):
+        return cls._backward(ctx, grad, ctx.saved_tensors)
+
+    @classmethod
+    def _backward(cls, ctx, grad, saved_tensors):
         (
             q,
             k,
@@ -514,7 +525,7 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
             cu_seqlens_q,
             cu_seqlens_k,
             rng_state,
-        ) = ctx.saved_tensors
+        ) = saved_tensors
         if rng_state is not None:
             cur_rng_state = torch.cuda.get_rng_state()
             torch.cuda.set_rng_state(rng_state)
@@ -641,6 +652,38 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
         return dq, dk, dv, softmax_d
 
 
+class MemoryEfficientAttentionCutlassFwdFlashBwOp(MemoryEfficientAttentionCutlassOp):
+    FW_OP = MemoryEfficientAttentionCutlassOp
+    BW_OP = MemoryEfficientAttentionFlashAttentionOp
+    NAME = "fctls_bflsh"
+
+    @classmethod
+    def supports(cls, d: "AttentionOpDispatch") -> bool:
+        return cls.FW_OP.supports(d) and cls.BW_OP.supports(d)
+
+    @classmethod
+    def backward(cls, ctx, grad):
+        query, key, value, lse, out = ctx.saved_tensors
+        ctx_flash = SimpleNamespace()
+
+        ctx_flash.causal = ctx.causal
+        ctx_flash.dropout_p = 0.0
+        query, key, value, cu_seqlens_k, cu_seqlens_q = cls.BW_OP.prepare_inputs(
+            ctx_flash, query, key, value
+        )
+        ctx_flash.kernel_output_shape = (query.shape[0], query.shape[1], value.shape[2])
+        ctx_flash.softmax_scale = query.shape[-1] ** (-0.5)
+        rng_state = None
+
+        out = out.reshape(ctx_flash.kernel_output_shape)
+        grad = grad.reshape(ctx_flash.kernel_output_shape)
+        return cls.BW_OP._backward(
+            ctx_flash,
+            grad,
+            [query, key, value, out, lse, cu_seqlens_q, cu_seqlens_k, rng_state],
+        )
+
+
 @dataclass
 class AttentionOpDispatch:
     dtype: torch.dtype
@@ -651,10 +694,22 @@ class AttentionOpDispatch:
     kv_len: int
     q_len: int
     kv: int = -1
+    batch_size: int = -1
+    num_heads: int = 1
 
     def __post_init__(self):
         if self.kv == -1:
             self.kv = self.k
+
+    def _is_cutlass_fwd_faster_than_flash(self) -> bool:
+        # Very small batch sizes - if batch size specified
+        if self.batch_size > 0:
+            threads_flash = self.batch_size * self.num_heads
+            threads_cutlass = threads_flash * (self.q_len // 64)
+            if threads_flash < 60 and (threads_cutlass // 2) >= threads_flash:
+                return True
+        # Large values of K
+        return max(self.k, self.kv) == 128
 
     @property
     def op(self) -> Type[AttentionOpBase]:
@@ -663,6 +718,8 @@ class AttentionOpDispatch:
             MemoryEfficientAttentionCutlassOp,
             MemoryEfficientAttentionOp,
         ]
+        if self._is_cutlass_fwd_faster_than_flash():
+            priority_list_ops.insert(0, MemoryEfficientAttentionCutlassFwdFlashBwOp)
         for op in priority_list_ops:
             if op.supports(self):
                 return op
@@ -677,6 +734,9 @@ class AttentionOpDispatch:
         attn_bias: Optional[Union[torch.Tensor, AttentionMask]] = None,
         p: float = 0.0,
     ) -> "AttentionOpDispatch":
+        B, H = query.shape[0], 1
+        if query.ndim == 4:
+            H = query.shape[2]
         return AttentionOpDispatch(
             dtype=query.dtype,
             device=query.device,
@@ -684,8 +744,10 @@ class AttentionOpDispatch:
             kv=value.shape[-1],
             has_dropout=p > 0.0,
             attn_bias_type=type(attn_bias),
-            kv_len=value.shape[-2],
-            q_len=query.shape[-2],
+            kv_len=value.shape[1],
+            q_len=query.shape[1],
+            batch_size=B,
+            num_heads=H,
         )
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #469

**PERFORMANCE**

<details>
<summary>A100 bw</summary>

```
[--------------------------------- attention backward (attn_bias=<class 'NoneType'>) ---------------------------------]
                                     |  flash[flshatt]  |  vanilla  |  fwbw[fctls_bflsh]  |  48_chunk3_31735f9[cutlass]
1 threads: ------------------------------------------------------------------------------------------------------------
      f16 B=384, M=197, H=1, K=64    |        232.7     |   1813.9  |          240.3      |              391.7         
      f16 B=1024, M=197, H=1, K=64   |        577.0     |   4746.9  |          582.8      |              876.9         
      f16 B=32, M=197, H=16, K=64    |        296.2     |   2434.6  |          303.2      |              459.9         
      f16 B=32, M=197, H=16, K=128   |        682.8     |   4504.9  |          688.6      |              792.5         
      f16 B=16, M=197, H=16, K=64    |        164.9     |   1246.6  |          172.4      |              235.4         
      f16 B=16, M=197, H=16, K=128   |        385.9     |   2272.5  |          394.1      |              455.4         
      f16 B=1, M=4096, H=160, K=128  |      54810.6     |  45967.1  |        54876.8      |            62454.4         
      f16 B=2, M=4096, H=160, K=128  |      84422.1     |           |        84371.5      |            98791.3         
      f16 B=1, M=8192, H=160, K=128  |     216095.0     |           |       216170.6      |           248498.9         
      f16 B=2, M=8192, H=160, K=128  |     330754.4     |           |       331201.2      |           389207.8         
      f16 B=1024, M=82, H=8, K=64    |       1621.7     |   3820.0  |         1625.6      |             1872.4         
      f16 B=150, M=256, H=16, K=64   |       1625.7     |   4551.9  |         1629.7      |             2126.4         
      f16 B=64, M=256, H=12, K=64    |        567.7     |   1493.7  |          569.7      |              741.2         
      f16 B=256, M=4096, H=16, K=64  |     441302.3     |           |       441526.8      |           597391.6         
      f16 B=16, M=128, H=16, K=16    |        114.4     |    266.0  |          148.1      |               93.1         
      f16 B=16, M=128, H=16, K=32    |        112.6     |    269.7  |          243.3      |              127.9         
      f16 B=16, M=128, H=16, K=64    |        113.6     |    267.8  |          149.5      |              131.4         
      f16 B=16, M=128, H=16, K=128   |        158.6     |    298.0  |          160.3      |              175.6         
      f16 B=16, M=512, H=16, K=16    |        323.5     |   1203.4  |          325.9      |              558.2         
      f16 B=16, M=512, H=16, K=32    |        435.2     |   1305.2  |          436.8      |              653.5         
      f16 B=16, M=512, H=16, K=64    |        703.1     |   1543.5  |          706.4      |              848.8         
      f16 B=16, M=512, H=16, K=128   |       1586.5     |   1982.6  |         1588.1      |             1735.4         
      f16 B=16, M=1024, H=16, K=16   |       1252.2     |   4273.8  |         1251.6      |             2236.4         
      f16 B=16, M=1024, H=16, K=32   |       1621.6     |   4494.4  |         1623.8      |             2430.8         
      f16 B=16, M=1024, H=16, K=64   |       2376.6     |   5007.3  |         2381.7      |             3007.2         
      f16 B=16, M=1024, H=16, K=128  |       5647.1     |   5956.1  |         5650.4      |             6296.2         
      f16 B=64, M=128, H=16, K=16    |        145.6     |    439.2  |          148.6      |              165.5         
      f16 B=64, M=128, H=16, K=32    |        212.1     |    544.4  |          214.4      |              210.4         
      f16 B=64, M=128, H=16, K=64    |        310.1     |    767.3  |          312.5      |              330.4         
      f16 B=64, M=128, H=16, K=128   |        562.3     |   1226.6  |          564.7      |              605.5         
      f16 B=64, M=512, H=16, K=16    |       1202.3     |   4481.6  |         1203.0      |             2004.7         
      f16 B=64, M=512, H=16, K=32    |       1543.5     |   4966.9  |         1548.2      |             2379.3         
      f16 B=64, M=512, H=16, K=64    |       2421.7     |   5886.7  |         2424.0      |             3129.6         
      f16 B=64, M=512, H=16, K=128   |       5446.6     |   7713.8  |         5452.7      |             6054.1         
      f16 B=64, M=1024, H=16, K=16   |       4725.5     |  16880.0  |         4719.8      |             7929.4         
      f16 B=64, M=1024, H=16, K=32   |       5716.0     |  17869.0  |         5722.7      |             8876.8         
      f16 B=64, M=1024, H=16, K=64   |       8155.3     |  19924.2  |         8163.5      |            11198.7         
      f16 B=64, M=1024, H=16, K=128  |      19213.5     |  23735.2  |        19228.8      |            21618.9  

Times are in microseconds (us).
```
</details>