### PR TITLE
conda packages to know their python dep

### DIFF
--- a/packaging/conda/xformers/meta.yaml
+++ b/packaging/conda/xformers/meta.yaml
@@ -16,6 +16,7 @@ requirements:
 
   run:
     # - numpy >=1.11
+    - python
     - pytorch=={{ environ.get('PYTORCH_VERSION') }}
     - cudatoolkit{{ environ['CONDA_CUDATOOLKIT_CONSTRAINT'] }}
 


### PR DESCRIPTION
Original change from @bottler 
https://github.com/facebookresearch/xformers/pull/470

I would have put the python version constraint as we do for pytorch, but I'm not an expert in those things so I trust hum
