### PR TITLE
Use dedicated logger instead of the root one

### DIFF
--- a/xformers/__init__.py
+++ b/xformers/__init__.py
@@ -12,6 +12,9 @@ try:
 except ImportError:
     pass
 
+
+logger = logging.getLogger("xformers")
+
 _is_sparse_available: bool = True
 
 # Set to true to utilize functorch
@@ -66,7 +69,7 @@ if _is_sparse_available:
         _register_extensions()
     except (ImportError, OSError) as e:
         print(e)
-        logging.warning(
+        logger.warning(
             f"WARNING: {e}\nNeed to compile C++ extensions to get sparse attention suport."
             + " Please run python setup.py build develop"
         )
@@ -94,7 +97,7 @@ def _is_triton_available():
 
         return True
     except (ImportError, AttributeError) as e:
-        logging.warning(
+        logger.warning(
             f"A matching Triton is not available, some optimizations will not be enabled.\nError caught was: {e}"
         )
         return False
@@ -104,7 +107,7 @@ if _is_functorch_available:
     try:
         from xformers.components.nvfuser import NVFusedBiasActivationDropout  # noqa
     except ImportError as e:
-        logging.warning(
+        logger.warning(
             f"Functorch is not available, some optimizations will not be enabled.\nError caught was: {e}"
         )
         _is_functorch_available = False

--- a/xformers/__init__.py
+++ b/xformers/__init__.py
@@ -70,7 +70,7 @@ if _is_sparse_available:
     except (ImportError, OSError) as e:
         print(e)
         logger.warning(
-            f"WARNING: {e}\nNeed to compile C++ extensions to get sparse attention suport."
+            f"WARNING: {e}\nNeed to compile C++ extensions to get sparse attention support."
             + " Please run python setup.py build develop"
         )
         _is_sparse_available = False

--- a/xformers/components/attention/__init__.py
+++ b/xformers/components/attention/__init__.py
@@ -19,6 +19,9 @@ from ._sputnik_sparse import SparseCS
 from .attention_mask import AttentionMask
 from .base import Attention, AttentionConfig  # noqa
 
+logger = logging.getLogger("xformers")
+
+
 # CREDITS: Classy Vision registry mechanism
 
 ATTENTION_REGISTRY: Dict[str, Any] = {}
@@ -45,7 +48,7 @@ def build_attention(config: Union[Dict[str, Any], AttentionConfig]):
             )
         except KeyError as e:
             name = config["name"]
-            logging.warning(f"{name} not available among {ATTENTION_REGISTRY.keys()}")
+            logger.warning(f"{name} not available among {ATTENTION_REGISTRY.keys()}")
             raise e
     else:
         config_instance = config

--- a/xformers/components/attention/blocksparse.py
+++ b/xformers/components/attention/blocksparse.py
@@ -13,7 +13,13 @@ import torch
 from xformers import _is_triton_available
 from xformers.components.attention import Attention, AttentionConfig, register_attention
 
+
+logger = logging.getLogger("xformers")
+
+
 _is_blocksparse_available = _is_triton_available()
+
+
 if _is_blocksparse_available:
     from triton.ops.blocksparse import matmul as blocksparse_matmul  # type: ignore
     from triton.ops.blocksparse import softmax as blocksparse_softmax  # type: ignore
@@ -22,7 +28,7 @@ if _is_blocksparse_available:
 
     # Blocksparse requires Tensor cores
     if gpu_capabilities_older_than_70():
-        logging.warning(
+        logger.warning(
             "Blocksparse is not available: the current GPU does not expose Tensor cores"
         )
         _is_blocksparse_available = False
@@ -64,14 +70,14 @@ if _is_blocksparse_available:
             **kwargs,
         ):
             if layout.dim() == 2:
-                logging.warning(
+                logger.warning(
                     "The layout passed is lacking a head dimension and a batch dimension"
                 )
-                logging.warning(
+                logger.warning(
                     "Now assuming that the same layout is to be used across all heads"
                 )
                 layout = layout.unsqueeze(0).expand(num_heads, -1, -1)
-                logging.warning(f"New layout dimensions: {layout.shape}")
+                logger.warning(f"New layout dimensions: {layout.shape}")
 
             assert block_size in (
                 16,

--- a/xformers/components/attention/blocksparse.py
+++ b/xformers/components/attention/blocksparse.py
@@ -13,7 +13,6 @@ import torch
 from xformers import _is_triton_available
 from xformers.components.attention import Attention, AttentionConfig, register_attention
 
-
 logger = logging.getLogger("xformers")
 
 

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -30,6 +30,9 @@ if _is_blocksparse_available:
     from xformers.components.attention.blocksparse import BlockSparseAttention
 
 
+logger = logging.getLogger("xformers")
+
+
 def _create_random_sparsity(matrix, sparsity, divisible_by=4):
     assert matrix.ndim == 3
     keep = torch.rand_like(matrix[0], dtype=torch.float32) > sparsity
@@ -311,7 +314,7 @@ def scaled_dot_product_attention(
     )
 
     if switch_to_blocksparse:
-        logging.info("Switching causal attention to Triton blocksparse...")
+        logger.info("Switching causal attention to Triton blocksparse...")
         return blocksparse_attention(q, k, v, dropout, block_size)
 
     with torch.cuda.amp.autocast(enabled=False) if autocast_disabled else nullcontext():

--- a/xformers/components/attention/favor.py
+++ b/xformers/components/attention/favor.py
@@ -21,6 +21,8 @@ from xformers.components.attention.feature_maps import (
     SMReg,
 )
 
+logger = logging.getLogger("xformers")
+
 
 @dataclass
 class FavorAttentionConfig(AttentionConfig):
@@ -84,7 +86,7 @@ class FavorAttention(Attention):
             self.dim_features = 2 * (
                 self.dim_features // 2
             )  # needs to be even for some variants
-            logging.info(
+            logger.info(
                 f"FAVOR: Automatically setting the random mapping dimension to {self.dim_features} from {dim_head}"
             )
         else:

--- a/xformers/components/attention/nystrom.py
+++ b/xformers/components/attention/nystrom.py
@@ -22,6 +22,8 @@ from xformers.components.attention.utils import (
     reshape_key_padding_mask,
 )
 
+logger = logging.getLogger("xformers")
+
 
 @dataclass
 class NystromSelfAttentionConfig(AttentionConfig):
@@ -182,7 +184,7 @@ class NystromAttention(Attention):
 
         if key_padding_mask is not None:
             if key_padding_mask.dtype == torch.bool:
-                logging.warning(
+                logger.warning(
                     "Bool mask found, but an additive mask is expected. Converting but this is slow"
                 )
 

--- a/xformers/components/attention/ortho.py
+++ b/xformers/components/attention/ortho.py
@@ -20,6 +20,8 @@ from xformers.components.attention.core import (
     scaled_query_key_softmax,
 )
 
+logger = logging.getLogger("xformers")
+
 
 class LandmarkSelection(str, Enum):
     Orthogonal = "orthogonal"
@@ -105,7 +107,7 @@ class OrthoFormerAttention(Attention):
                     landmarks = self._cluster_landmarks(q, spherical=True)
 
             if att_mask is not None:
-                logging.warning(
+                logger.warning(
                     "Orthoformer: attention mask passed alongside with using landmarks to reduce dimensions. \
                     The two are typically not compatible"
                 )

--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -18,6 +18,8 @@ from xformers.components.attention import (
 )
 from xformers.components.attention.core import scaled_dot_product_attention
 
+logger = logging.getLogger("xformers")
+
 
 @dataclass
 class ScaledDotProductConfig(AttentionConfig):
@@ -118,7 +120,7 @@ class ScaledDotProduct(Attention):
             if isinstance(att_mask, AttentionMask):
                 att_mask = att_mask.make_crop(seq_len=q.shape[-2])
             else:
-                logging.error(
+                logger.error(
                     "Mismatching sparse attention mask and sequence length."
                     + " Please pad the inputs or adjust the attention mask"
                 )

--- a/xformers/components/feedforward/fused_mlp.py
+++ b/xformers/components/feedforward/fused_mlp.py
@@ -17,6 +17,9 @@ from xformers.components.feedforward import (
     register_feedforward,
 )
 
+logger = logging.getLogger("xformers")
+
+
 if torch.cuda.is_available():
     try:
         from xformers.triton import FusedDropoutBias
@@ -73,4 +76,4 @@ if torch.cuda.is_available():
                 return self.mlp(inputs)
 
     except ImportError:
-        logging.warning("Triton is not available, FusedMLP will not be enabled.")
+        logger.warning("Triton is not available, FusedMLP will not be enabled.")

--- a/xformers/components/feedforward/mixture_of_experts.py
+++ b/xformers/components/feedforward/mixture_of_experts.py
@@ -18,6 +18,9 @@ from xformers.components.feedforward import (
     register_feedforward,
 )
 
+logger = logging.getLogger("xformers")
+
+
 _is_fairscale_available = True
 
 try:
@@ -27,7 +30,7 @@ try:
     from xformers.components.feedforward import MLP
 
 except ImportError:
-    logging.warning(
+    logger.warning(
         "Either FairScale or torch distributed is not available, MixtureOfExperts will not be exposed."
         " Please install them if you would like to use MoE"
     )
@@ -105,8 +108,8 @@ if _is_fairscale_available:
                 assert number_of_experts >= number_of_local_experts
             else:
                 if dist.get_world_size() == 1:
-                    logging.warning("Local experts no specified but world size of 1")
-                    logging.warning("Assuming that all experts are local")
+                    logger.warning("Local experts no specified but world size of 1")
+                    logger.warning("Assuming that all experts are local")
                     number_of_local_experts = number_of_experts
                 else:
                     number_of_local_experts = 1

--- a/xformers/components/input_projection.py
+++ b/xformers/components/input_projection.py
@@ -14,6 +14,8 @@ from typing import Optional, Tuple
 import torch
 from torch import nn
 
+logger = logging.getLogger("xformers")
+
 
 @dataclass
 class InputProjectionConfig:
@@ -53,7 +55,7 @@ class InputProjection(nn.Module):
                 key_proj_params.bias,
             )
         else:
-            logging.info(
+            logger.info(
                 "No Key projection parameters were passed, assuming that the weights"
                 + " are shared with the query projection"
             )
@@ -66,7 +68,7 @@ class InputProjection(nn.Module):
                 value_proj_params.bias,
             )
         else:
-            logging.info(
+            logger.info(
                 "No Value projection parameters were passed, assuming that the weights"
                 + " are shared with the query projection"
             )

--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -16,6 +16,8 @@ from xformers.components.attention import Attention
 from xformers.components.input_projection import InputProjection, InputProjectionConfig
 from xformers.components.positional_embedding import RotaryEmbedding
 
+logger = logging.getLogger("xformers")
+
 
 @dataclass
 class MultiHeadDispatchConfig:
@@ -90,7 +92,7 @@ class MultiHeadDispatch(nn.Module):
         super().__init__()
 
         if isinstance(bias, bool):
-            logging.warning(
+            logger.warning(
                 "Single bias value provided for the MHA projections."
                 + f" Assuming the same parameter ({bias}) is to be used everywhere"
             )

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -30,6 +30,8 @@ from xformers.factory.block_configs import (
     xFormerEncoderConfig,
 )
 
+logger = logging.getLogger("xformers")
+
 
 def _get_ln_factory(
     d_model: int,
@@ -113,7 +115,7 @@ class xFormerEncoderBlock(torch.nn.Module):
             mha_dim = config.multi_head_config["dim_model"]
 
             if pos_encoding_dim != mha_dim:
-                logging.warning(
+                logger.warning(
                     f"The embedding dim and model dim do not match ({pos_encoding_dim} vs {mha_dim}), adding a projector layer."  # noqa
                 )
                 self.embedding_projector = nn.Linear(pos_encoding_dim, mha_dim)
@@ -257,7 +259,7 @@ class xFormerDecoderBlock(torch.nn.Module):
 
             if pos_encoding_dim != mha_dim:
 
-                logging.warning(
+                logger.warning(
                     f"The embedding dim and model dim do not match ({pos_encoding_dim} vs {mha_dim}), adding a projector layer."  # noqa
                 )
 

--- a/xformers/factory/hydra_helper.py
+++ b/xformers/factory/hydra_helper.py
@@ -14,7 +14,7 @@ from xformers.components.attention import ATTENTION_REGISTRY
 from xformers.components.feedforward import FEEDFORWARD_REGISTRY
 from xformers.components.positional_embedding import POSITION_EMBEDDING_REGISTRY
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger("xformers")
 
 
 def import_xformer_config_schema():
@@ -33,4 +33,4 @@ def import_xformer_config_schema():
             try:
                 cs.store(name=f"{kk}_schema", node=v[kk].config, group=f"xformers/{k}")
             except ValidationError as e:
-                log.debug(f"Error registering {kk}_schema, error: {e}")
+                logger.debug(f"Error registering {kk}_schema, error: {e}")

--- a/xformers/factory/model_factory.py
+++ b/xformers/factory/model_factory.py
@@ -20,6 +20,8 @@ from xformers.factory.block_configs import (
 from xformers.factory.block_factory import xFormerDecoderBlock, xFormerEncoderBlock
 from xformers.factory.weight_init import get_weight_init_fn, xFormerWeightInit
 
+logger = logging.getLogger("xformers")
+
 
 @dataclass(init=False)
 class xFormerConfig:
@@ -183,7 +185,7 @@ class xFormer(torch.nn.Module):
             and decoders[0].pose_encoding
             and not config.reversible
         ):
-            logging.info("Tying encoder and decoder embeddings, as requested")
+            logger.info("Tying encoder and decoder embeddings, as requested")
             encoders[0].pose_encoding = decoders[0].pose_encoding
 
         self.encoders: torch.nn.Module = (

--- a/xformers/factory/weight_init.py
+++ b/xformers/factory/weight_init.py
@@ -20,6 +20,9 @@ from torch.nn.init import (
     _no_grad_uniform_,
 )
 
+logger = logging.getLogger("xformers")
+
+
 _assert_if_not_initialized = False
 
 
@@ -125,7 +128,7 @@ def _maybe_report_no_init(module, name):
             return
 
         # This is unexpected, warn about a possible unhandled weight
-        logging.warning(
+        logger.warning(
             f"Not initializing weights in {name}, this could be a mistake.\nModule {module}"
         )
 

--- a/xformers/sparse/blocksparse_tensor.py
+++ b/xformers/sparse/blocksparse_tensor.py
@@ -3,17 +3,20 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+
 import torch
 
 from xformers.ops import masked_matmul
+
+logger = logging.getLogger("xformers")
+
 
 try:
     from triton.ops.blocksparse import matmul as blocksparse_matmul
     from triton.ops.blocksparse import softmax as blocksparse_softmax
 except ImportError as e:
-    import logging
-
-    logging.warning(
+    logger.warning(
         "Triton is not available, some optimizations will not be enabled.\n"
         + f"This is just a warning: {e}"
     )

--- a/xformers/triton/softmax.py
+++ b/xformers/triton/softmax.py
@@ -17,6 +17,9 @@ from xformers.triton.k_softmax import _softmax, _softmax_backward
 # and https://triton-lang.org/getting-started/tutorials/02-fused-softmax.html
 
 
+logger = logging.getLogger("xformers")
+
+
 _triton_softmax_fp16_enabled = False  # NOTE: PyTorch keeps softmax as fp32
 _triton_registered_warnings = False
 
@@ -182,11 +185,11 @@ def _softmax_dispatch(
         # Catch cases where the current GPU does not have enough registers to hold a full tensor line
         # fallback to PyTorch's implementation, which streams the tensor in and out
         _triton_registered_warnings = True
-        logging.warning(
+        logger.warning(
             "Triton softmax kernel register spillover or invalid image caught."
             "Deactivating this kernel, please file an issue int the xFormers repository"
         )
-        logging.warning(e)
+        logger.warning(e)
 
     if mask is not None:
         x = x + mask

--- a/xformers/triton/utils.py
+++ b/xformers/triton/utils.py
@@ -8,6 +8,9 @@ from typing import Optional
 
 import torch
 
+logger = logging.getLogger("xformers")
+
+
 _gpu_is_old: Optional[bool] = None
 
 
@@ -33,7 +36,7 @@ def get_current_cuda_device():
         if current_device.find(device_str) > 0:
             return device_str
 
-    logging.warning("Unsupported device, Triton code generation may fail")
+    logger.warning("Unsupported device, Triton code generation may fail")
     return "P100"  # default to an old GPU
 
 


### PR DESCRIPTION
## What does this PR do?

This introduces the use of a dedicated logger throughout the library instead of relying on Python's root logger.

Test Plan: CI + local ad-hoc script:

```
$ ./test_logging.py
2022-10-10 15:20:15,468 WARNING MainThread xformers WARNING:
Need to compile C++ extensions to get sparse attention support. Please run python setup.py build develop
```

## Before submitting

- [X] Did you have fun?
  - Make sure you had fun coding 🙃
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [X] N/A
- [ ] Did you make sure to update the docs?
  - [X] N/A
- [ ] Did you write any new necessary tests?
  - [X] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [X] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
