### PR TITLE
Enable selective build for mem-efficient kernels

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -54,6 +54,11 @@ mem_efficient_attention_backward_cutlass(
     const at::Tensor& logsumexp,
     const at::Tensor& out,
     bool causal) {
+#ifdef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
+  TORCH_CHECK(
+      false,
+      "MemoryEfficient build has been disabled at build time with -DXFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD");
+#else
   // ndim
   TORCH_CHECK(query.dim() == grad_out_.dim());
   TORCH_CHECK(query.dim() == key.dim());
@@ -225,6 +230,7 @@ mem_efficient_attention_backward_cutlass(
       query, key, value, ([&] { launchKernel(Kernel{}, computeCapability); }));
   AT_CUDA_CHECK(cudaGetLastError());
   return std::make_tuple(grad_q, grad_k, grad_v);
+#endif
 } // namespace
 
 } // namespace

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -81,6 +81,11 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
     const c10::optional<int64_t> max_seqlen_q_,
     bool compute_logsumexp,
     bool causal) {
+#ifdef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
+  TORCH_CHECK(
+      false,
+      "MemoryEfficient build has been disabled at build time with -DXFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD");
+#else
   TORCH_CHECK(query.dim() == 4);
   TORCH_CHECK(key.dim() == 4);
   TORCH_CHECK(value.dim() == 4);
@@ -215,6 +220,7 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
 
   AT_CUDA_CHECK(cudaGetLastError());
   return std::make_tuple(res, logsumexp);
+#endif
 }
 } // namespace
 

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, false);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k128.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, true, 128);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_aligned_k64.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, true, 64);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k128.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, false, 128);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_bf16_k64.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::bfloat16_t, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::bfloat16_t, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::bfloat16_t, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::bfloat16_t, false, 64);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::half_t, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::half_t, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::half_t, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::half_t, false);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_aligned.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::half_t, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::half_t, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::half_t, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::half_t, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_aligned_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_aligned_k128.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::half_t, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::half_t, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::half_t, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::half_t, true, 128);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_aligned_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_aligned_k64.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::half_t, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::half_t, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::half_t, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::half_t, true, 64);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_k128.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::half_t, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::half_t, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::half_t, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::half_t, false, 128);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f16_k64.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(cutlass::half_t, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(cutlass::half_t, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(cutlass::half_t, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(cutlass::half_t, false, 64);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(float, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(float, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(float, false);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(float, false);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_aligned.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(float, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(float, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(float, true);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(float, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_aligned_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_aligned_k128.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(float, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(float, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(float, true, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(float, true, 128);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_aligned_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_aligned_k64.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(float, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(float, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(float, true, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(float, true, 64);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_k128.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_k128.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(float, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(float, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(float, false, 128);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(float, false, 128);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_k64.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/backward_f32_k64.cu
@@ -1,6 +1,8 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM50(float, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM70(float, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM75(float, false, 64);
 INSTANTIATE_ATTENTION_KERNEL_BACKWARD_SM80(float, false, 64);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16.cu
@@ -1,4 +1,5 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
     cutlass::bfloat16_t,
@@ -72,3 +73,4 @@ INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
     64,
     64,
     true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_bf16_aligned.cu
@@ -1,4 +1,5 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
     cutlass::bfloat16_t,
@@ -72,3 +73,4 @@ INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
     64,
     64,
     true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f16.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f16.cu
@@ -1,4 +1,5 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
     cutlass::half_t,
@@ -52,3 +53,4 @@ INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
     128,
     false);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(cutlass::half_t, false, 64, 64, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f16_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f16_aligned.cu
@@ -1,4 +1,5 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(cutlass::half_t, true, 32, 128, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(
@@ -32,3 +33,4 @@ INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(
     128,
     false);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(cutlass::half_t, true, 64, 64, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f32.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f32.cu
@@ -1,4 +1,5 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(float, false, 32, 128, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(float, false, 32, 128, false);
@@ -12,3 +13,4 @@ INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(float, false, 64, 64, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(float, false, 32, 128, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(float, false, 32, 128, false);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(float, false, 64, 64, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f32_aligned.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/forward_f32_aligned.cu
@@ -1,4 +1,5 @@
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(float, true, 32, 128, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM50(float, true, 32, 128, false);
@@ -12,3 +13,4 @@ INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM75(float, true, 64, 64, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(float, true, 32, 128, true);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(float, true, 32, 128, false);
 INSTANTIATE_ATTENTION_KERNEL_FORWARD_SM80(float, true, 64, 64, true);
+#endif

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/generate_kernels.sh
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernels/generate_kernels.sh
@@ -21,11 +21,15 @@ for aligned in "false" "true"; do
             echo $FNAME
             cat <<EOF > $FNAME
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
 #include "../kernel_backward.h"
 EOF
             for sm in 50 70 75 80; do
                 echo "INSTANTIATE_ATTENTION_KERNEL_${kernel}_SM${sm}($dtype, $aligned$maxk_code);" >> $FNAME
             done;
+            cat <<EOF >> $FNAME
+#endif
+EOF
         done;
     done;
 done
@@ -45,6 +49,7 @@ for aligned in "false" "true"; do
         echo $FNAME
         cat <<EOF > $FNAME
 // This file is auto-generated. See "generate_kernels.sh"
+#ifndef XFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD
 #include "../kernel_forward.h"
 EOF
         for sm in 50 70 75 80; do
@@ -52,5 +57,8 @@ EOF
             echo "INSTANTIATE_ATTENTION_KERNEL_${kernel}_SM${sm}($dtype, $aligned, 32, 128, false);" >> $FNAME
             echo "INSTANTIATE_ATTENTION_KERNEL_${kernel}_SM${sm}($dtype, $aligned, 64, 64, true);" >> $FNAME
         done;
+            cat <<EOF >> $FNAME
+#endif
+EOF
     done;
 done


### PR DESCRIPTION
Users who only need the forward should not have to wait until the forward is built

```
# With selective built: 1m43
XFORMERS_DISABLE_FLASH_ATTN=1 NVCC_FLAGS="--use_fast_math -DXFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD" MAX_JOBS=4 time python -m pip install -e .
# Without selective built: 5m16
XFORMERS_DISABLE_FLASH_ATTN=1 NVCC_FLAGS="--use_fast_math" MAX_JOBS=4 time python -m pip install -e .
```