### PR TITLE
Fix CI by updating torchvision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ install_dep: &install_dep
         conda install ninja
         echo "Ninja version $(ninja --version)"
 
-        conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch -q
+        conda install pytorch "torchvision>=0.13" torchaudio cudatoolkit=11.3 -c pytorch -q
         $CONDA_PYTHON -m pip install -r requirements-benchmark.txt --progress-bar off
 
         # Mark install as complete
@@ -106,7 +106,7 @@ install_dep_exp: &install_dep_exp
         if [ -f /home/circleci/venv/check_version.py ]; then $CONDA_PYTHON  /home/circleci/venv/check_version.py torch gt 1.11 && exit 0; fi
         # start installing
         source activate /home/circleci/venv
-        conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch -q
+        conda install pytorch "torchvision>=0.13" torchaudio cudatoolkit=11.3 -c pytorch -q
         $CONDA_PYTHON -m pip install -r experimental/requirements.txt --progress-bar off
 
 install_repo: &install_repo

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/iterators/epilogue_predicated_tile_iterator.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/iterators/epilogue_predicated_tile_iterator.h
@@ -311,9 +311,9 @@ class PredicatedTileIteratorPrefetch {
             // on windows using unsigned long here gives the error
             // error: asm operand type size(4) does not match
             // type/size implied by constraint 'l'
-            uint64_t addr = (uint64_t)(
-                (void*)&memory_pointer
-                    [column * ThreadMap::Delta::kColumn / kElementsPerAccess]);
+            uint64_t addr = (uint64_t)((void*)&memory_pointer
+                                           [column * ThreadMap::Delta::kColumn /
+                                            kElementsPerAccess]);
             asm volatile("prefetch.global.L1 [ %1 ];" : "=l"(addr) : "l"(addr));
           }
 


### PR DESCRIPTION
We were using torchvision `0.2.2` before, which is fairly old - not sure why.

For some reason, this also updates the clang-format version (I guess?), so I needed to apply it again. Now it matches the output of my local clang-format at least - the difference was only for a single file