### PR TITLE
SwiGLU further optimization in MLP bw

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/HazyResearch/flash-attention.git
 [submodule "third_party/cutlass"]
 	path = third_party/cutlass
-	url = https://github.com/NVIDIA/cutlass.git
+	url = https://github.com/hwu36/cutlass.git

--- a/tests/test_swiglu.py
+++ b/tests/test_swiglu.py
@@ -102,8 +102,8 @@ _dtypes = [torch.bfloat16, torch.float16]
 _ops: Sequence[xsw.SwiGLUOp] = [xsw.SwiGLUFusedOp, xsw.SwiGLUPackedFusedOp]
 
 
-@pytest.mark.parametrize("autocast", [False, True])
-@pytest.mark.parametrize("pack_weights", [False, True])
+@pytest.mark.parametrize("autocast", [False, True], ids=["regular", "autocast"])
+@pytest.mark.parametrize("pack_weights", [False, True], ids=["regular", "packed"])
 @pytest.mark.parametrize("op", _ops, ids=[x.NAME for x in _ops])
 @pytest.mark.parametrize("dtype", _dtypes, ids=[str(x) for x in _dtypes])
 @pytest.mark.parametrize("device", _devices)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #518
* #511
* #510
* #509
* #505
* #508
* #504
* #491
* __->__ #502
* #490
* #498
* #488
* #487
* #486

***PERFORMANCE A100**

```
operandfused_all <- THIS PR
SwiGLUPackedFusedOp <- previous pr
[--------------------------------------- swiglu_bw ---------------------------------------]
                                     |  operandfused_all  |  eager   |  SwiGLUPackedFusedOp
1 threads: --------------------------------------------------------------------------------
      b16    B=9456, I=1536, H=4096  |       2227.6       |  2708.3  |         2341.6      
      f16    B=9456, I=1536, H=4096  |       2337.5       |  2705.8  |         2339.1      
      f16.ac B=9456, I=1536, H=4096  |       2630.5       |  2998.5  |         2806.6      
      b16    B=4440, I=1536, H=4096  |       1177.9       |  1424.5  |         1246.4      
      f16    B=4440, I=1536, H=4096  |       1205.1       |  1418.8  |         1240.6      
      f16.ac B=4440, I=1536, H=4096  |       1409.0       |  1637.4  |         1541.7      
      b16    B=4728, I=1536, H=4096  |       1238.6       |  1493.5  |         1397.5      
      f16    B=4728, I=1536, H=4096  |       1274.8       |  1488.2  |         1392.7      
      f16.ac B=4728, I=1536, H=4096  |       1478.2       |  1710.3  |         1512.9      
      b16    B=4728, I=1536, H=1024  |        461.0       |   518.7  |          487.7      
      f16    B=4728, I=1536, H=1024  |        438.2       |   498.3  |          479.8      
      f16.ac B=4728, I=1536, H=1024  |        560.9       |   623.2  |          601.4      

Times are in microseconds (us).
```