### PR TITLE
enable AttentionMask in Block Factory

### DIFF
--- a/xformers/components/attention/global_tokens.py
+++ b/xformers/components/attention/global_tokens.py
@@ -5,7 +5,7 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -88,7 +88,7 @@ class GlobalAttention(Attention):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        att_mask: Optional[torch.Tensor] = None,
+        att_mask: Optional[Union[torch.Tensor, AttentionMask]] = None,
         *_,
         **__,
     ):
@@ -101,7 +101,9 @@ class GlobalAttention(Attention):
             if att_mask.dtype == torch.bool and isinstance(
                 self.attention_mask, AttentionMask
             ):
-                mask = self.attention_mask + AttentionMask.from_bool(att_mask)
+                if not isinstance(att_mask, AttentionMask):
+                    att_mask = AttentionMask.from_bool(att_mask)
+                mask = self.attention_mask + att_mask
             else:
                 mask = self.attention_mask & att_mask
         else:

--- a/xformers/components/attention/ortho.py
+++ b/xformers/components/attention/ortho.py
@@ -7,14 +7,19 @@
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.autograd.profiler as profiler
 import torch.nn as nn
 import torch.nn.functional as Fn
 
-from xformers.components.attention import Attention, AttentionConfig, register_attention
+from xformers.components.attention import (
+    Attention,
+    AttentionConfig,
+    AttentionMask,
+    register_attention,
+)
 from xformers.components.attention.core import (
     scaled_dot_product_attention,
     scaled_query_key_softmax,
@@ -83,7 +88,7 @@ class OrthoFormerAttention(Attention):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        att_mask: Optional[torch.Tensor] = None,
+        att_mask: Optional[Union[AttentionMask, torch.Tensor]] = None,
         *args,
         **kwargs,
     ):

--- a/xformers/components/attention/random.py
+++ b/xformers/components/attention/random.py
@@ -5,7 +5,7 @@
 
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -91,7 +91,7 @@ class RandomAttention(Attention):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        att_mask: Optional[torch.Tensor] = None,
+        att_mask: Optional[Union[torch.Tensor, AttentionMask]] = None,
         *args,
         **kwargs,
     ):
@@ -106,6 +106,9 @@ class RandomAttention(Attention):
             ):
                 mask = self.rand_attention_mask + AttentionMask.from_bool(att_mask)
             else:
+                if isinstance(att_mask, AttentionMask):
+                    # Needed because & op not defined for SparseCS with AttentionMask
+                    att_mask = att_mask.to_bool()
                 mask = self.rand_attention_mask & att_mask
         else:
             mask = self.rand_attention_mask

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -20,6 +20,7 @@ from xformers.components import (
     build_multi_head_attention,
     build_patch_embedding,
 )
+from xformers.components.attention import AttentionMask
 from xformers.components.feedforward import build_feedforward
 from xformers.components.positional_embedding import build_positional_embedding
 from xformers.components.residual import get_deepnorm_coefficients
@@ -206,7 +207,7 @@ class xFormerEncoderBlock(torch.nn.Module):
     def forward(
         self,
         x: torch.Tensor,
-        att_mask: Optional[torch.Tensor] = None,
+        att_mask: Optional[Union[torch.Tensor, AttentionMask]] = None,
         input_mask: Optional[torch.Tensor] = None,
     ):
         if self.patch_emb is not None:
@@ -327,8 +328,8 @@ class xFormerDecoderBlock(torch.nn.Module):
         self,
         target: torch.Tensor,
         memory: torch.Tensor,
-        encoder_att_mask: Optional[torch.Tensor] = None,
-        decoder_att_mask: Optional[torch.Tensor] = None,
+        encoder_att_mask: Optional[Union[torch.Tensor, AttentionMask]] = None,
+        decoder_att_mask: Optional[Union[torch.Tensor, AttentionMask]] = None,
         input_mask: Optional[torch.Tensor] = None,
     ):
         if self.pose_encoding is not None:


### PR DESCRIPTION
## What does this PR do?
Issue with not being able to use AttentionMask with encoder and decoder blocks.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
