### PR TITLE
SwiGLU: Support for no bias

### DIFF
--- a/xformers/components/swiglu/swiglu_op.cpp
+++ b/xformers/components/swiglu/swiglu_op.cpp
@@ -2,7 +2,7 @@
 
 TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::dual_gemm_silu_identity_mul(Tensor x, Tensor w1, Tensor b1, Tensor w2, Tensor b2) -> (Tensor, Tensor, Tensor)"));
+      "xformers::dual_gemm_silu_identity_mul(Tensor x, Tensor w1, Tensor? b1, Tensor w2, Tensor? b2) -> (Tensor, Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::silu_bw_fused(Tensor x1, Tensor x2, Tensor dx4) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #518
* #511
* #510
* #509
* #505
* #508
* __->__ #504
* #491
* #502
* #490
* #498
* #488
* #487
* #486


**PERFORMANCE**

```
[-------------------------- swiglu_fw --------------------------]
                                          |  optimized  |  eager 
1 threads: ------------------------------------------------------
      b16    B=9456, I=1536, H=4096 bias  |    1338.5   |  1568.4
      b16    B=9456, I=1536, H=4096 nobi  |    1268.3   |  1477.1
      f16    B=9456, I=1536, H=4096 bias  |    1305.3   |  1607.4
      f16    B=9456, I=1536, H=4096 nobi  |    1291.7   |  1493.0
      f16.ac B=9456, I=1536, H=4096 bias  |    1445.1   |  1754.7
      f16.ac B=9456, I=1536, H=4096 nobi  |    1434.0   |  1640.5
      b16    B=4440, I=1536, H=4096 bias  |     580.7   |   726.5
      b16    B=4440, I=1536, H=4096 nobi  |     578.7   |   725.1
      f16    B=4440, I=1536, H=4096 bias  |     597.4   |   736.5
      f16    B=4440, I=1536, H=4096 nobi  |     598.0   |   732.3
      f16.ac B=4440, I=1536, H=4096 bias  |     712.8   |   853.8
      f16.ac B=4440, I=1536, H=4096 nobi  |     701.0   |   841.7
      b16    B=4728, I=1536, H=4096 bias  |     620.3   |   772.6
      b16    B=4728, I=1536, H=4096 nobi  |     618.2   |   744.7
      f16    B=4728, I=1536, H=4096 bias  |     634.9   |   785.9
      f16    B=4728, I=1536, H=4096 nobi  |     633.7   |   750.8
      f16.ac B=4728, I=1536, H=4096 bias  |     746.8   |   897.1
      f16.ac B=4728, I=1536, H=4096 nobi  |     740.0   |   854.1
      b16    B=4728, I=1536, H=1024 bias  |     160.1   |   199.3
      b16    B=4728, I=1536, H=1024 nobi  |     158.6   |   196.4
      f16    B=4728, I=1536, H=1024 bias  |     163.6   |   202.1
      f16    B=4728, I=1536, H=1024 nobi  |     161.9   |   198.8
      f16.ac B=4728, I=1536, H=1024 bias  |     237.1   |   278.5
      f16.ac B=4728, I=1536, H=1024 nobi  |     227.3   |   265.1

Times are in microseconds (us).
```

```
[-------------------------- swiglu_bw --------------------------]
                                          |  optimized  |  eager 
1 threads: ------------------------------------------------------
      b16    B=9456, I=1536, H=4096 bias  |    2223.2   |  2705.4
      b16    B=9456, I=1536, H=4096 nobi  |    2192.1   |  2568.4
      f16    B=9456, I=1536, H=4096 bias  |    2292.8   |  2700.6
      f16    B=9456, I=1536, H=4096 nobi  |    2183.5   |  2560.7
      f16.ac B=9456, I=1536, H=4096 bias  |    2603.5   |  2992.8
      f16.ac B=9456, I=1536, H=4096 nobi  |    2457.3   |  2834.5
      b16    B=4440, I=1536, H=4096 bias  |    1176.6   |  1418.9
      b16    B=4440, I=1536, H=4096 nobi  |    1159.1   |  1339.6
      f16    B=4440, I=1536, H=4096 bias  |    1199.8   |  1416.1
      f16    B=4440, I=1536, H=4096 nobi  |    1154.0   |  1335.1
      f16.ac B=4440, I=1536, H=4096 bias  |    1407.7   |  1631.2
      f16.ac B=4440, I=1536, H=4096 nobi  |    1348.7   |  1535.2
      b16    B=4728, I=1536, H=4096 bias  |    1233.5   |  1491.8
      b16    B=4728, I=1536, H=4096 nobi  |    1215.1   |  1409.0
      f16    B=4728, I=1536, H=4096 bias  |    1248.2   |  1486.0
      f16    B=4728, I=1536, H=4096 nobi  |    1208.1   |  1404.2
      f16.ac B=4728, I=1536, H=4096 bias  |    1480.1   |  1705.0
      f16.ac B=4728, I=1536, H=4096 nobi  |    1408.5   |  1605.9
      b16    B=4728, I=1536, H=1024 bias  |     459.9   |   517.1
      b16    B=4728, I=1536, H=1024 nobi  |     425.2   |   461.0
      f16    B=4728, I=1536, H=1024 bias  |     436.6   |   495.9
      f16    B=4728, I=1536, H=1024 nobi  |     400.0   |   441.3
      f16.ac B=4728, I=1536, H=1024 bias  |     558.4   |   617.8
      f16.ac B=4728, I=1536, H=1024 nobi  |     512.6   |   555.2

Times are in microseconds (us).
```