### PR TITLE
Repeat mask when batch dims don't match

### DIFF
--- a/tests/test_core_attention.py
+++ b/tests/test_core_attention.py
@@ -59,6 +59,15 @@ def test_core_attention_mask_types():
     # Now properly handled
     assert torch.allclose(r_dense_add, r_sparse_add)
 
+    # Test additive mask with mismatched batch dim
+    d = b // 2
+    mask = torch.rand(d, s, s) > prob
+    float_mask_add = torch.zeros_like(mask, dtype=torch.float)
+    float_mask_add = float_mask_add.masked_fill(mask, float("-inf"))
+
+    # Make sure masking doesn't return errors
+    r_dense_add = scaled_dot_product_attention(a, a, a, float_mask_add)
+
 
 @pytest.mark.parametrize("device", _devices)
 def test_amp_attention_dense_no_mask(device):

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -106,6 +106,15 @@ def _matmul_with_mask(
         att[~mask] = float("-inf")
     else:
         # mask is presumed additive
+        # repeat if batch sizes don't match
+        if (
+            mask.ndim == 3
+            and mask.shape[0] != att.shape[0]
+            and (att.shape[0] % mask.shape[0]) == 0
+        ):
+            repeat_factor = att.shape[0] // mask.shape[0]
+            mask = mask.repeat([repeat_factor, 1, 1])
+            logger.info("Mismatched batch dimensions for mask, repeating mask.")
         att += mask
     return att
 

--- a/xformers/components/attention/core.py
+++ b/xformers/components/attention/core.py
@@ -108,7 +108,8 @@ def _matmul_with_mask(
         # mask is presumed additive
         # repeat if batch sizes don't match
         if (
-            mask.ndim == 3
+            not isinstance(mask, SparseCS)
+            and mask.ndim == 3
             and mask.shape[0] != att.shape[0]
             and (att.shape[0] % mask.shape[0]) == 0
         ):


### PR DESCRIPTION
## What does this PR do?
Repeat mask when batch dims don't match. 
Should this be handled in the sparse case as well?

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
