### PR TITLE
[triton] bfloat16 aware blocksparse & softmax

### DIFF
--- a/tests/test_triton_softmax.py
+++ b/tests/test_triton_softmax.py
@@ -94,8 +94,8 @@ def test_softmax_parity(shape, amp, log, masking, causal, contiguous):
 
 @pytest.mark.skipif(not _triton_available, reason="Triton is not available")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
-def test_softmax_fp16(dtype):
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_softmax(dtype):
     b, s, d = 8, 64, 32
 
     a = torch.rand(b, s, d, device="cuda", dtype=dtype)

--- a/xformers/benchmarks/benchmark_triton_layernorm.py
+++ b/xformers/benchmarks/benchmark_triton_layernorm.py
@@ -32,6 +32,7 @@ def bench_layernorm(backward: bool):
 
     for dtype in [
         torch.float16,
+        torch.bfloat16,
         torch.float32,
     ]:
         results: Dict[str, Any] = {}

--- a/xformers/benchmarks/benchmark_triton_softmax.py
+++ b/xformers/benchmarks/benchmark_triton_softmax.py
@@ -72,7 +72,7 @@ bench_functions(
     SHAPES,
     to_gbs_fw,
     "GB/s",
-    "Softmax_Bandwidth_FW",
+    "Softmax_Bandwidth_FW_",
 )
 
 # Test FW+BW
@@ -87,5 +87,5 @@ bench_functions(
     SHAPES,
     to_gbs_fwbw,
     "GB/s",
-    "Softmax_Bandwidth_FW_BW",
+    "Softmax_Bandwidth_FW_BW_",
 )

--- a/xformers/benchmarks/utils.py
+++ b/xformers/benchmarks/utils.py
@@ -112,7 +112,7 @@ if _triton_is_available:
     ):
         device = torch.device("cuda")
 
-        for dtype in [torch.float16, torch.float32]:
+        for dtype in [torch.bfloat16, torch.float16, torch.float32]:
             results: Dict[str, Any] = {}
 
             for B, M, K in shapes:
@@ -134,8 +134,7 @@ if _triton_is_available:
                 title=" ------------- Type: {} ------------- ".format(dtype),
                 units=unit,
             )
-            _type = " fp16" if dtype == torch.float16 else " fp32"
-            pretty_plot(results, title + _type, unit, dash_key="pytorch")
+            pretty_plot(results, title + str(dtype), unit, dash_key="pytorch")
 
 
 def pretty_barplot(results, title, units: str, filename=None, dash_key=""):

--- a/xformers/components/attention/blocksparse.py
+++ b/xformers/components/attention/blocksparse.py
@@ -172,10 +172,6 @@ if _is_blocksparse_available:
                 q.shape[-2], self.block_size
             )
 
-            # Blocksparse only works on fp16
-            q_dtype = q.dtype
-            q, k, v = q.half(), k.half(), v.half()
-
             # Self-attend: (B, nh, S, hs) x (B, nh, hs, S) -> (B, nh, S, S)
             # When the computations are block sparse, the matrix types change along the way:
             # - (sparse) attention matrix = (dense) Kt * (dense) Q
@@ -191,4 +187,4 @@ if _is_blocksparse_available:
 
             # - then (dense) attention is (sparse) attention matrix * dense (value)
             a = self.sparse_dot_dsd(sparse_att_mat, v)
-            return a.to(q_dtype)
+            return a

--- a/xformers/triton/layer_norm.py
+++ b/xformers/triton/layer_norm.py
@@ -221,7 +221,7 @@ def layer_norm(
             and bias is not None
         ):
             return _LayerNorm.apply(x, weight, bias, eps)
-    except (triton.code_gen.OutOfResources, RuntimeError) as e:
+    except RuntimeError as e:
         # Catch cases where the current GPU does not have enough registers to hold a full tensor line
         # fallback to PyTorch's implementation, which streams the tensor in and out
         _triton_registered_warnings = True

--- a/xformers/triton/softmax.py
+++ b/xformers/triton/softmax.py
@@ -181,7 +181,7 @@ def _softmax_dispatch(
     try:
         if torch.cuda.is_available() and x.is_cuda and not _triton_registered_warnings:
             return _softmax_triton.apply(x, mask, log, causal)
-    except (triton.code_gen.OutOfResources, RuntimeError) as e:
+    except RuntimeError as e:
         # Catch cases where the current GPU does not have enough registers to hold a full tensor line
         # fallback to PyTorch's implementation, which streams the tensor in and out
         _triton_registered_warnings = True

--- a/xformers/triton/utils.py
+++ b/xformers/triton/utils.py
@@ -38,13 +38,3 @@ def get_current_cuda_device():
 
     logger.warning("Unsupported device, Triton code generation may fail")
     return "P100"  # default to an old GPU
-
-
-def assert_almost_equal(x, y, decimal=2, err_msg=""):
-    import numpy.testing as npt
-
-    if isinstance(x, torch.Tensor):
-        x = x.cpu().detach().numpy()
-    if isinstance(y, torch.Tensor):
-        y = y.cpu().detach().numpy()
-    npt.assert_array_almost_equal(x, y, err_msg=err_msg, decimal=decimal)


### PR DESCRIPTION
## What does this PR do?
Fixes #353. Goal was not to touch softmax initially, but it turns out that enabling bfloat16 can die on triton's softmax (tl.max() cannot be lowered in bf16), hence the double fix

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
