### PR TITLE
Allow custom softmax in memory efficient attention

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -420,6 +420,7 @@ def test_cu_seqlen_forward(
         cu_seqlens_k=torch.tensor(cu_seqlen_k, dtype=torch.int32, device=device),
         compute_logsumexp=False,
         causal=attn_bias_type is xformers.ops.LowerTriangularMask,
+        scale=None,
     )
     ref = torch.cat(all_o, dim=1)
     assert_allclose(
@@ -484,6 +485,7 @@ def test_logsumexp(op_device_dtype_B_Mq_Mkv_H_K_Kv):
             cu_seqlens_k=None,
             compute_logsumexp=True,
             causal=False,
+            scale=None,
         )
         lse = lse[:, 0, :]
     else:

--- a/xformers/components/attention/csrc/attention.cpp
+++ b/xformers/components/attention/csrc/attention.cpp
@@ -17,11 +17,11 @@ TORCH_LIBRARY_FRAGMENT(xformers, m) {
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention(Tensor query, Tensor key, Tensor value, bool compute_logsumexp, Tensor? attn_bias, float p) -> (Tensor, Tensor, int, int)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention_forward_cutlass(Tensor query, Tensor key, Tensor value, Tensor? cu_seqlens_q, Tensor? cu_seqlens_k, int? max_seqlen_q, bool compute_logsumexp, bool causal) -> (Tensor, Tensor)"));
+      "xformers::efficient_attention_forward_cutlass(Tensor query, Tensor key, Tensor value, Tensor? cu_seqlens_q, Tensor? cu_seqlens_k, int? max_seqlen_q, bool compute_logsumexp, bool causal, float? scale) -> (Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_backward(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, Tensor? attn_bias, float p, int rng_seed, int rng_offset) -> (Tensor, Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
-      "xformers::efficient_attention_backward_cutlass(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, bool causal) -> (Tensor, Tensor, Tensor)"));
+      "xformers::efficient_attention_backward_cutlass(Tensor grad_out, Tensor query, Tensor key, Tensor value, Tensor logsumexp, Tensor output, bool causal, float? scale) -> (Tensor, Tensor, Tensor)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::_temp_dropout(Tensor out, float p) -> Tensor"));
 }

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -169,7 +169,6 @@ mem_efficient_attention_backward_cutlass(
     } else {
       p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
     }
-    std::cerr << "backward scale: " << p.scale << std::endl;
 
     ASSIGN_CHECK_OVERFLOW(p.gO_strideB, grad_out.stride(0));
     ASSIGN_CHECK_OVERFLOW(p.gO_strideM, grad_out.stride(1));

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -165,9 +165,9 @@ mem_efficient_attention_backward_cutlass(
     p.num_heads = nH;
     p.causal = causal;
     if (scale.has_value()) {
-        p.scale = float(*scale);
+      p.scale = float(*scale);
     } else {
-        p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
+      p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
     }
 
     ASSIGN_CHECK_OVERFLOW(p.gO_strideB, grad_out.stride(0));

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -169,6 +169,7 @@ mem_efficient_attention_backward_cutlass(
     } else {
       p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
     }
+    std::cerr << "backward scale: " << p.scale << std::endl;
 
     ASSIGN_CHECK_OVERFLOW(p.gO_strideB, grad_out.stride(0));
     ASSIGN_CHECK_OVERFLOW(p.gO_strideM, grad_out.stride(1));

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_backward_generic.cu
@@ -53,7 +53,8 @@ mem_efficient_attention_backward_cutlass(
     const at::Tensor& value,
     const at::Tensor& logsumexp,
     const at::Tensor& out,
-    bool causal) {
+    bool causal,
+    const c10::optional<double> scale) {
 #ifdef XFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD
   TORCH_CHECK(
       false,
@@ -163,6 +164,11 @@ mem_efficient_attention_backward_cutlass(
     p.num_batches = B;
     p.num_heads = nH;
     p.causal = causal;
+    if (scale.has_value()) {
+        p.scale = float(*scale);
+    } else {
+        p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
+    }
 
     ASSIGN_CHECK_OVERFLOW(p.gO_strideB, grad_out.stride(0));
     ASSIGN_CHECK_OVERFLOW(p.gO_strideM, grad_out.stride(1));

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -192,9 +192,9 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
     p.num_batches = cu_seqlens_q.has_value() ? cu_seqlens_q->size(0) - 1 : B;
     p.causal = causal;
     if (scale.has_value()) {
-        p.scale = float(*scale);
+      p.scale = float(*scale);
     } else {
-        p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
+      p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
     }
 
     ASSIGN_CHECK_OVERFLOW(p.q_strideB, query.stride(0));

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -183,7 +183,7 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
       p.cu_seqlens_q_ptr = (int32_t*)cu_seqlens_q->data_ptr();
       p.cu_seqlens_k_ptr = (int32_t*)cu_seqlens_k->data_ptr();
     }
-   
+
     p.num_heads = num_heads;
     p.head_dim = query.size(3);
     p.head_dim_value = value.size(3);
@@ -195,7 +195,6 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
         p.scale = float(*scale);
     } else {
         p.scale = float(1.0 / std::sqrt(float(p.head_dim)));
-        //p.scale = 1.0f / cutlass::fast_sqrt(float(p.head_dim));
     }
 
     ASSIGN_CHECK_OVERFLOW(p.q_strideB, query.stride(0));

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
@@ -87,6 +87,9 @@ struct AttentionBackwardKernel {
     output_t* grad_key_ptr; //    [Mk, nH, K]
     output_t* grad_value_ptr; //  [Mk, nH, Kv]
 
+    // Scale
+    float scale;
+
     // Dimensions/strides
     int32_t head_dim;
     int32_t head_dim_value;
@@ -783,7 +786,8 @@ struct AttentionBackwardKernel {
       int32_t query_start,
       int32_t key_start) {
     cutlass::MatrixCoord no_offset{0, 0};
-    accum_t scale = accum_t(1.0 / std::sqrt(float(p.head_dim)));
+    //accum_t scale = accum_t(1.0 / std::sqrt(float(p.head_dim)));
+    accum_t scale = p.scale;
     int16_t thread_id = threadIdx.x + threadIdx.y * blockDim.x;
     int8_t warp_id = warp_uniform(threadIdx.y);
     int8_t lane_id = threadIdx.x;

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
@@ -786,7 +786,6 @@ struct AttentionBackwardKernel {
       int32_t query_start,
       int32_t key_start) {
     cutlass::MatrixCoord no_offset{0, 0};
-    //accum_t scale = accum_t(1.0 / std::sqrt(float(p.head_dim)));
     accum_t scale = p.scale;
     int16_t thread_id = threadIdx.x + threadIdx.y * blockDim.x;
     int8_t warp_id = warp_uniform(threadIdx.y);

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
@@ -88,7 +88,7 @@ struct AttentionBackwardKernel {
     output_t* grad_value_ptr; //  [Mk, nH, Kv]
 
     // Scale
-    float scale;
+    accum_t scale;
 
     // Dimensions/strides
     int32_t head_dim;

--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_forward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_forward.h
@@ -105,7 +105,7 @@ struct AttentionKernel {
     lse_scalar_t* logsumexp_ptr; // [num_heads, num_queries] - can be null
 
     // Scale
-    float scale;
+    accum_t scale;
 
     // Dimensions/strides
     int32_t head_dim;
@@ -595,16 +595,6 @@ struct AttentionKernel {
             },
             [&](int accum_m) {});
       }
-
-      // Determine scale
-      float scale = p.scale;
-//      float scale;
-//      if (p.scale.has_value()) {
-//          scale = float(*p.scale);
-//      } else {
-//          scale = 1.0f / cutlass::fast_sqrt(float(p.head_dim));
-//      }
-
       DISPATCH_BOOL(iter_key_start == 0, kIsFirst, ([&] {
                       DISPATCH_BOOL(
                           p.num_keys - iter_key_start >= kKeysPerBlock,
@@ -629,7 +619,7 @@ struct AttentionKernel {
                                 warp_id(),
                                 p.num_keys - iter_key_start,
                                 iteratorC_tile_offset,
-                                scale);
+                                p.scale);
                           }));
                     }));
 

--- a/xformers/ops/memory_efficient_attention.py
+++ b/xformers/ops/memory_efficient_attention.py
@@ -751,7 +751,7 @@ class MemoryEfficientAttentionCutlassFwdFlashBwOp(MemoryEfficientAttentionCutlas
             ctx_flash, query, key, value
         )
         ctx_flash.kernel_output_shape = (query.shape[0], query.shape[1], value.shape[2])
-        ctx_flash.softmax_scale = ctx.scale
+        ctx_flash.softmax_scale = query.shape[-1] ** (-0.5) if ctx.scale is None else ctx.scale
         rng_state = None
 
         out = out.reshape(ctx_flash.kernel_output_shape)

--- a/xformers/ops/memory_efficient_attention.py
+++ b/xformers/ops/memory_efficient_attention.py
@@ -751,7 +751,9 @@ class MemoryEfficientAttentionCutlassFwdFlashBwOp(MemoryEfficientAttentionCutlas
             ctx_flash, query, key, value
         )
         ctx_flash.kernel_output_shape = (query.shape[0], query.shape[1], value.shape[2])
-        ctx_flash.softmax_scale = query.shape[-1] ** (-0.5) if ctx.scale is None else ctx.scale
+        ctx_flash.softmax_scale = (
+            query.shape[-1] ** (-0.5) if ctx.scale is None else ctx.scale
+        )
         rng_state = None
 
         out = out.reshape(ctx_flash.kernel_output_shape)

--- a/xformers/ops/memory_efficient_attention.py
+++ b/xformers/ops/memory_efficient_attention.py
@@ -486,8 +486,13 @@ class MemoryEfficientAttentionFlashAttentionOp(AttentionOpBase):
         has_custom_scale: bool,
     ) -> torch.Tensor:
         return cls.forward(
-            ctx=None, query=query, key=key, value=value, attn_bias=attn_bias, p=p,
-            has_custom_scale=has_custom_scale
+            ctx=None,
+            query=query,
+            key=key,
+            value=value,
+            attn_bias=attn_bias,
+            p=p,
+            has_custom_scale=has_custom_scale,
         )
 
     @classmethod
@@ -946,16 +951,24 @@ def memory_efficient_attention(
 
     if op is None:
         op = AttentionOpDispatch.from_arguments(
-            query=query, key=key, value=value, attn_bias=attn_bias, p=p,
-            has_custom_scale=has_custom_scale
+            query=query,
+            key=key,
+            value=value,
+            attn_bias=attn_bias,
+            p=p,
+            has_custom_scale=has_custom_scale,
         ).op
 
     # fast-path that doesn't require computing the logsumexp for backward computation
     if all(x.requires_grad is False for x in [query, key, value]):
         return op.forward_no_grad(
-            query=query, key=key, value=value, attn_bias=attn_bias, p=p,
-            has_custom_scale=has_custom_scale
+            query=query,
+            key=key,
+            value=value,
+            attn_bias=attn_bias,
+            p=p,
+            has_custom_scale=has_custom_scale,
         ).reshape(output_shape)
-    return op.apply(query, key, value, attn_bias, p,
-        has_custom_scale
-    ).reshape(output_shape)
+    return op.apply(query, key, value, attn_bias, p, has_custom_scale).reshape(
+        output_shape
+    )

--- a/xformers/ops/memory_efficient_attention.py
+++ b/xformers/ops/memory_efficient_attention.py
@@ -729,7 +729,7 @@ class MemoryEfficientAttentionCutlassFwdFlashBwOp(MemoryEfficientAttentionCutlas
 
     FW_OP = MemoryEfficientAttentionCutlassOp
     BW_OP = MemoryEfficientAttentionFlashAttentionOp
-    SUPPORTS_CUSTOM_SCALE = False
+    SUPPORTS_CUSTOM_SCALE = True
     SUPPORTED_DTYPES = BW_OP.SUPPORTED_DTYPES.intersection(FW_OP.SUPPORTED_DTYPES)
 
     NAME = "fctls_bflsh"
@@ -751,7 +751,7 @@ class MemoryEfficientAttentionCutlassFwdFlashBwOp(MemoryEfficientAttentionCutlas
             ctx_flash, query, key, value
         )
         ctx_flash.kernel_output_shape = (query.shape[0], query.shape[1], value.shape[2])
-        ctx_flash.softmax_scale = query.shape[-1] ** (-0.5)
+        ctx_flash.softmax_scale = ctx.scale
         rng_state = None
 
         out = out.reshape(ctx_flash.kernel_output_shape)
@@ -970,6 +970,4 @@ def memory_efficient_attention(
             p=p,
             scale=scale,
         ).reshape(output_shape)
-    return op.apply(query, key, value, attn_bias, p, scale).reshape(
-        output_shape
-    )
+    return op.apply(query, key, value, attn_bias, p, scale).reshape(output_shape)

--- a/xformers/ops/memory_efficient_attention.py
+++ b/xformers/ops/memory_efficient_attention.py
@@ -826,7 +826,7 @@ class AttentionOpDispatch:
         value: torch.Tensor,
         attn_bias: Optional[Union[torch.Tensor, AttentionMask]] = None,
         p: float = 0.0,
-        has_custom_scale: bool = False,
+        scale: Optional[float] = None,
     ) -> "AttentionOpDispatch":
         """Creates an :attr:`xformers.ops.AttentionOpDispatch` from :attr:`xformers.ops.memory_efficient_attention`'s
         arguments
@@ -837,7 +837,7 @@ class AttentionOpDispatch:
             value (torch.Tensor)
             attn_bias (Optional[Union[torch.Tensor, xformers.ops.AttentionMask]], optional): Defaults to None.
             p (float, optional): Defaults to 0.0.
-            has_custom_scale (bool, optional): Default to False.
+            scale (float, optional): Custom scale. Default to None (use q.shape[-1]**-0.5).
 
         Returns:
             AttentionOpDispatch
@@ -851,7 +851,7 @@ class AttentionOpDispatch:
             k=query.shape[-1],
             kv=value.shape[-1],
             has_dropout=p > 0.0,
-            has_custom_scale=has_custom_scale,
+            has_custom_scale=scale is not None,
             attn_bias_type=type(attn_bias),
             kv_len=value.shape[1],
             q_len=query.shape[1],
@@ -957,7 +957,7 @@ def memory_efficient_attention(
             value=value,
             attn_bias=attn_bias,
             p=p,
-            has_custom_scale=scale is not None,
+            scale=scale,
         ).op
 
     # fast-path that doesn't require computing the logsumexp for backward computation


### PR DESCRIPTION
## What does this PR do?
Implement #522.
- Add a new argument `has_custom_scale` to memory efficient attention `forward`. When it is true, we assume the query state weights are scaled in advance so they won't be scaled again in kernels. This is required especially for T5 models.
- Add a new flag `SUPPORTS_CUSTOM_SCALE` to indicate whether a memory efficient op supports custom scale. In this PR we only enable `MemoryEfficientFlashAttentionOp` to align the API change and experiments. If everything goes well, I'll support `MemoryEfficientAttentionOp` in a follow-up PR (I'm not sure if the CUTLASS one can be supported without first changing CUTLASS kernel. It'd be great if someone could help confirm).

Updated based on review comments:
- New attribute `has_custom_scale: bool = False` in `AttentionOpDispatch`.
- New attribute `SUPPORTS_CUSTOM_SCALE: bool = False` in `AttentionOpBase`.
- New argument `scale: Optional[float] = None` in `AttentionOpDispatch.from_argument` and `memory_efficient_attention`. When `None`, default scale value (`1.0 / q.shape[-1] ** 0.5`) will be used.
- Supported ops: All but `MemoryEfficientAttentionOp`.
- Unit test: Covered forward and backward of all supported ops.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
