### PR TITLE
[minor] Fix tracing a mem efficient attention enabled part

### DIFF
--- a/xformers/ops/memory_efficient_attention.py
+++ b/xformers/ops/memory_efficient_attention.py
@@ -104,7 +104,7 @@ class AttentionOpBase(torch.autograd.Function):
     }
     SUPPORTED_DEVICES: Set[str]
     SUPPORTED_DTYPES: Set[torch.dtype]
-    SUPPORTED_MAX_K: float
+    SUPPORTED_MAX_K: int
     SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {type(None)}
     SUPPORTS_DROPOUT: bool
     SUPPORTS_CUSTOM_SCALE: bool = False
@@ -149,7 +149,7 @@ class AttentionOpBase(torch.autograd.Function):
             return False
         if not cls.SUPPORTS_DIFFERENT_VALUE_EMBED and d.k != d.kv:
             return False
-        if max(d.k, d.kv) > cls.SUPPORTED_MAX_K:
+        if int(max(d.k, d.kv)) > cls.SUPPORTED_MAX_K:
             return False
         if d.attn_bias_type not in cls.SUPPORTED_ATTN_BIAS_TYPES:
             return False


### PR DESCRIPTION
## What does this PR do?
- Max_k is an int really (well, a uint)
- a float there results in ` RuntimeError: value cannot be converted to type int64_t without overflow` when tracing a model

Not that I'm really far from an expert there, so any other take welcome. I also know that TorchScript may not be here to stay, but it felt like a small enough fix

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
