### PR TITLE
Fix CI after torchmetrics update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ commands:
         # Cache the venv directory that contains dependencies
         - restore_cache:
             keys:
-              - cache-key-gpu-arch<<parameters.arch>>-{{ checksum "requirements-test.txt" }}-{{ checksum ".circleci/config.yml" }}
+              - cache-key-gpu-arch<<parameters.arch>>-{{ checksum "requirements-test.txt" }}-{{ checksum "requirements-benchmark.txt" }}-{{ checksum ".circleci/config.yml" }}
 
         - <<: *setup_conda
         - <<: *install_dep
@@ -317,7 +317,7 @@ commands:
               - ~/miniconda
               - ~/venv
 
-            key: cache-key-gpu-arch<<parameters.arch>>-{{ checksum "requirements-test.txt"}}-{{ checksum ".circleci/config.yml"}}
+            key: cache-key-gpu-arch<<parameters.arch>>-{{ checksum "requirements-test.txt"}}-{{ checksum "requirements-benchmark.txt" }}-{{ checksum ".circleci/config.yml"}}
 
         - <<: *install_repo
         - <<: *run_coverage
@@ -344,7 +344,7 @@ jobs:
       # Cache the venv directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-key-cpu-py38-{{ checksum "requirements-test.txt" }}-{{ checksum ".circleci/config.yml" }}
+            - cache-key-cpu-py38-{{ checksum "requirements-test.txt" }}-{{ checksum "requirements-benchmark.txt" }}-{{ checksum ".circleci/config.yml" }}
 
       - <<: *setup_conda
 
@@ -359,7 +359,7 @@ jobs:
             - ~/miniconda
             - ~/venv
 
-          key: cache-key-cpu-py38-{{ checksum "requirements-test.txt" }}-{{ checksum ".circleci/config.yml" }}
+          key: cache-key-cpu-py38-{{ checksum "requirements-test.txt" }}-{{ checksum "requirements-benchmark.txt" }}-{{ checksum ".circleci/config.yml" }}
 
       - <<: *install_repo
 
@@ -460,7 +460,7 @@ jobs:
       # Cache the venv directory that contains dependencies
       - restore_cache:
           keys:
-            - cache-key-gpu-exp-114-{{ checksum "experimental/requirements.txt" }}-{{ checksum ".circleci/config.yml" }}
+            - cache-key-gpu-exp-114-{{ checksum "experimental/requirements.txt" }}-{{ checksum "requirements-benchmark.txt" }}-{{ checksum ".circleci/config.yml" }}
 
       - <<: *setup_conda
       - <<: *install_dep_exp
@@ -475,7 +475,7 @@ jobs:
             - ~/miniconda
             - ~/venv
 
-          key: cache-key-gpu-exp-114-{{ checksum "experimental/requirements.txt" }}-{{ checksum ".circleci/config.yml" }}
+          key: cache-key-gpu-exp-114-{{ checksum "experimental/requirements.txt" }}-{{ checksum "requirements-benchmark.txt" }}-{{ checksum ".circleci/config.yml" }}
 
       - <<: *install_experimental_repo
       - <<: *run_experimental_unittests

--- a/requirements-benchmark.txt
+++ b/requirements-benchmark.txt
@@ -8,3 +8,4 @@ tqdm == 4.59.0
 pandas == 1.2.4
 seaborn == 0.11.1
 pytorch-lightning >= 1.3
+torchmetrics>=0.7.0, <0.10.1

--- a/xformers/benchmarks/benchmark_vit_timm.py
+++ b/xformers/benchmarks/benchmark_vit_timm.py
@@ -201,7 +201,7 @@ class VisionTransformer(pl.LightningModule):
             self.head = nn.Linear(dim, num_classes)
 
         self.criterion = torch.nn.CrossEntropyLoss()
-        self.val_accuracy = Accuracy()
+        self.val_accuracy = Accuracy(task="multiclass", num_classes=num_classes)
 
     @staticmethod
     def linear_warmup_cosine_decay(warmup_steps, total_steps):

--- a/xformers/benchmarks/benchmark_vit_timm.py
+++ b/xformers/benchmarks/benchmark_vit_timm.py
@@ -201,7 +201,9 @@ class VisionTransformer(pl.LightningModule):
             self.head = nn.Linear(dim, num_classes)
 
         self.criterion = torch.nn.CrossEntropyLoss()
-        self.val_accuracy = Accuracy(task="multiclass", num_classes=num_classes)
+        # For torchmetrics > 0.11:
+        # self.val_accuracy = Accuracy(task="multiclass", num_classes=num_classes)
+        self.val_accuracy = Accuracy()
 
     @staticmethod
     def linear_warmup_cosine_decay(warmup_steps, total_steps):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #571
* #570
* #568
* #561
* #560
* #557
* #495
* #555
* __->__ #567

It now takes an argument: https://torchmetrics.readthedocs.io/en/stable/classification/accuracy.html

Change in pytorch lightning:
https://github.com/Lightning-AI/metrics/commit/20eab4309b9bcde7a3157a1e3fb72711048d6c7c

Somehow this is failing with a SEGFAULT on my A100 (in a triton kernel):
```
#0  0x00007fffc0f62e10 in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#1  0x00007fffc0f9303c in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#2  0x00007fffc0f2ea13 in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#3  0x00007fffc0f94603 in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#4  0x00007fffc119e4a0 in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#5  0x00007fffc0f3728f in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#6  0x00007fffc0f3999f in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#7  0x00007fffc0fdb1c2 in ?? () from /lib/x86_64-linux-gnu/libcuda.so
#8  0x00007fff502234c0 in _launch ()
   from /data/home/XXXXX/.triton/cache/704a3e6949e60326bc68d18a620bee50/layer_norm_fw.so
#9  0x00007fff3c0eea25 in launch ()
   from /data/home/XXXXX/.triton/cache/2cebb5590a024a2e06fe9de08c6b7079/k_dropout_bw.so
#10 0x0000555555698422 in cfunction_call (func=0x7fff3c6e5760, args=<optimized out>, kwargs=<optimized out>)
    at /usr/local/src/conda/python-3.10.6/Objects/methodobject.c:552
```