### PR TITLE
C++17: Remove register kw

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/kernel_backward.h
@@ -852,11 +852,7 @@ struct AttentionBackwardKernel {
     return true;
   }
 
-  static CUTLASS_DEVICE void kernel(Params& p_) {
-    // Hint to nvcc to store points & tensor shapes in registers
-    // as we use them a lot
-    register const Params p = p_;
-
+  static CUTLASS_DEVICE void kernel(Params const& p) {
     extern __shared__ char smem_buffer[];
     SharedStorage& shared_storage = *((SharedStorage*)smem_buffer);
 
@@ -882,7 +878,7 @@ struct AttentionBackwardKernel {
       __syncthreads();
     }
 
-    OutputFragments register output_frags;
+    OutputFragments output_frags;
     int32_t key_start = 0;
     int32_t key_end = p.num_keys / kBlockSizeJ * kBlockSizeJ;
     for (; key_start < key_end; key_start += kBlockSizeJ) {


### PR DESCRIPTION
Backport of https://github.com/pytorch/pytorch/pull/90389/files

**PERFORMANCE**
Does not seem to affect performance on A100

<details>
<summary>A100 BW</summary>

```
[------------- attention backward (attn_bias=<class 'NoneType'>) -------------]                                                                                                                                                                                                                                               
                                     |  no_register_kw  |  vanilla  |  cutlass 
1 threads: --------------------------------------------------------------------
      f16 B=384, M=197, H=1, K=88    |        616.1     |   2261.1  |     621.0
      f16 B=384, M=197, H=1, K=80    |        585.6     |   1918.6  |     589.4
      f16 B=384, M=197, H=1, K=64    |        404.4     |   1810.2  |     406.2
      f16 B=1024, M=197, H=1, K=88   |       1541.7     |   5950.5  |    1557.7
      f16 B=1024, M=197, H=1, K=80   |       1460.0     |   5026.5  |    1480.4
      f16 B=1024, M=197, H=1, K=64   |        928.2     |   4737.6  |     930.1
      f16 B=512, M=197, H=1, K=80    |        742.7     |   2538.9  |     749.0
      f16 B=32, M=197, H=16, K=80    |        744.4     |   2580.2  |     748.1
      f16 B=32, M=197, H=16, K=64    |        478.0     |   2431.5  |     480.1
      f16 B=32, M=197, H=16, K=128   |        889.5     |   4498.4  |     896.4
      f16 B=256, M=197, H=1, K=88    |        446.0     |   1527.0  |     449.9
      f16 B=16, M=197, H=16, K=88    |        442.1     |   1541.9  |     445.2
      f16 B=16, M=197, H=16, K=64    |        245.9     |   1244.1  |     246.4
      f16 B=16, M=197, H=16, K=128   |        499.1     |   2269.5  |     503.6
      f16 B=1, M=4096, H=160, K=128  |      55799.1     |  46001.7  |   56457.5
      f16 B=2, M=4096, H=160, K=128  |      93396.9     |           |   93553.0
      f16 B=1, M=8192, H=160, K=128  |     222854.0     |           |  222850.4
      f16 B=2, M=8192, H=160, K=128  |     364480.0     |           |  364220.8
      f16 B=1024, M=82, H=8, K=64    |       1883.2     |   3819.8  |    1886.9
      f16 B=150, M=256, H=16, K=64   |       2294.8     |   4558.6  |    2302.2
      f16 B=64, M=256, H=12, K=64    |        780.3     |   1498.8  |     778.4
      f16 B=1, M=4096, H=16, K=40    |      23393.6     |   4195.2  |   23526.2
      f16 B=1, M=16384, H=16, K=40   |     389211.2     |           |  389891.9
      f16 B=256, M=4096, H=16, K=64  |     729697.3     |           |  729981.6
      f16 B=8, M=2048, H=20, K=128   |      14459.5     |  12552.0  |          
      f16 B=16, M=128, H=16, K=16    |        128.3     |    278.0  |     129.3
      f16 B=16, M=128, H=16, K=32    |        129.7     |    282.6  |     128.8
      f16 B=16, M=128, H=16, K=64    |        125.4     |    281.1  |     129.9
      f16 B=16, M=128, H=16, K=128   |        181.7     |    298.8  |     182.2
      f16 B=16, M=512, H=16, K=16    |        623.5     |   1203.4  |     623.4
      f16 B=16, M=512, H=16, K=32    |        708.9     |   1306.8  |     711.6
      f16 B=16, M=512, H=16, K=64    |        919.3     |   1543.4  |     917.7
      f16 B=16, M=512, H=16, K=128   |       1652.4     |   1984.5  |    1656.5
      f16 B=16, M=1024, H=16, K=16   |       2422.9     |   4264.2  |    2422.2
      f16 B=16, M=1024, H=16, K=32   |       2683.4     |   4499.9  |    2697.4
      f16 B=16, M=1024, H=16, K=64   |       3339.1     |   4993.8  |    3341.4
      f16 B=16, M=1024, H=16, K=128  |       5910.7     |   5959.5  |    5903.8
      f16 B=64, M=128, H=16, K=16    |        159.2     |    439.9  |     158.3
      f16 B=64, M=128, H=16, K=32    |        209.3     |    545.2  |     209.4
      f16 B=64, M=128, H=16, K=64    |        328.6     |    766.9  |     328.6
      f16 B=64, M=128, H=16, K=128   |        636.5     |   1229.2  |     637.6
      f16 B=64, M=512, H=16, K=16    |       2335.4     |   4486.5  |    2313.9
      f16 B=64, M=512, H=16, K=32    |       2704.9     |   4978.1  |    2706.7
      f16 B=64, M=512, H=16, K=64    |       3466.7     |   5886.8  |    3464.0
      f16 B=64, M=512, H=16, K=128   |       5903.0     |   7711.0  |    5909.5
      f16 B=64, M=1024, H=16, K=16   |       9132.4     |  16918.6  |    9092.8
      f16 B=64, M=1024, H=16, K=32   |      10420.5     |  17902.8  |   10439.0
      f16 B=64, M=1024, H=16, K=64   |      12928.5     |  19930.7  |   12937.8
      f16 B=64, M=1024, H=16, K=128  |      20946.2     |  23709.7  |   20963.4
      f16 B=16, M=128, H=16, K=256   |                  |    545.0  |     774.4
      f16 B=16, M=512, H=16, K=256   |                  |   2901.2  |    8652.9
      f16 B=16, M=1024, H=16, K=256  |                  |   7891.3  |   31850.4
      f16 B=64, M=128, H=16, K=256   |                  |   2126.3  |    2839.0
      f16 B=64, M=512, H=16, K=256   |                  |  11501.8  |   30488.7
      f16 B=64, M=1024, H=16, K=256  |                  |  32729.8  |  113715.6

Times are in microseconds (us).
```
</details>