### PR TITLE
Build Wheels with NOVA

### DIFF
--- a/.github/workflows/nova-wheels.yml
+++ b/.github/workflows/nova-wheels.yml
@@ -1,0 +1,47 @@
+name: Nova - Build Wheels
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  generate-matrix-linux:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux
+      channel: release
+      with-cuda: enable
+
+  build-linux:
+    needs: generate-matrix-linux
+    name: build-linux
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      repository: ${{ github.repository }}
+      ref: ""
+      pre-script: packaging/workflow_env_setup.sh
+      post-script: ""
+      smoke-test-script: ""
+      package-name: xformers
+      build-matrix: ${{ needs.generate-matrix-linux.outputs.matrix }}
+      # will push to pytorch if event_name is 'push'
+      # trigger-event: ${{ github.event_name }}
+    # secrets:
+    #   AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+    #   AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}
+
+  # TODO: to be able to publish wheels we have to:
+  # change the suffix of linux wheels to manylinux
+  # use a version name compatible with pypi
+  # publish:
+  #   needs: build-linux
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/download-artifact@v3
+  #     - run: python3 -m pip install --upgrade twine
+  #     - run: |
+  #         shopt -s globstar
+  #         python3 -m twine upload --repository testpypi **/*.whl
+  #       env:
+  #         TWINE_USERNAME: __token__
+  #         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/packaging/workflow_env_setup.sh
+++ b/packaging/workflow_env_setup.sh
@@ -1,0 +1,5 @@
+cat <<EOT >>${BUILD_ENV_FILE}
+export TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6"
+export FORCE_CUDA=1
+export XFORMERS_BUILD_TYPE="Release"
+EOT

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ if __name__ == "__main__":
             "clean": clean,
         },
         url="https://facebookresearch.github.io/xformers/",
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         author="Facebook AI Research",
         author_email="oncall+xformers@xmail.facebook.com",
         long_description="XFormers: A collection of composable Transformer building blocks."
@@ -294,6 +294,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "License :: OSI Approved :: BSD License",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
             "Operating System :: OS Independent",


### PR DESCRIPTION
## What does this PR do?

Prototype building wheels with [NOVA](https://github.com/pytorch/test-infra/wiki/Using-Nova-Reusable-Build-Workflows)

Related to #533 


### NOVA complications

* The default build matrix contains all accelerators, we only build for cuda, so we have to have an additional step to filter out what we don't need.
* The default runners are github enterprise runners, which is good if you're facebook, but not good as an open source contributor. I had to build a way to override the runners.
  * it might be that timeouts / OOMs won't happen with the default enterprise runners, but I cannot test this.
* I could not find an easier way of defining environment variables for the job other than writing to `BUILD_ENV_FILE` which seems to be an internal thing.


### Current state

The attached workflow has multiple problems that I don't know how to solve:

* The linux build fails because of a timeout. [timeout source](https://github.com/pytorch/test-infra/blob/4849b22c01ead82da0a526969a3556b5d7878d2a/.github/workflows/build_wheels_linux.yml#L71), [error log](https://github.com/AbdBarho/xformers-wheels/actions/runs/3656817988)
* The windows build fails because our `setup.py` cannot detect `nvcc`. I am unsure if we need to install cuda toolkit separately in windows, since this was not necessary in linux. [workflow file](https://github.com/pytorch/test-infra/blob/main/.github/workflows/build_wheels_windows.yml), [error log](https://github.com/AbdBarho/xformers-wheels/actions/runs/3656597757/jobs/6179225069)


I am open for suggestions