### PR TITLE
TensorWithSeqLen: multiple fixes

### DIFF
--- a/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
+++ b/xformers/components/attention/csrc/cuda/mem_eff_attention/attention_forward_generic.cu
@@ -211,7 +211,7 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
     // not a good number for loading during backward
     constexpr decltype(M) kAlignLSE = Kernel::kAlignLSE;
     logsumexp = at::empty(
-        {B,
+        {cu_seqlens_q.has_value() ? cu_seqlens_q->size(0) - 1 : B,
          num_heads,
          compute_logsumexp ? ceil_div(max_seqlen_q, kAlignLSE) * kAlignLSE : 0},
         query.options().dtype(at::ScalarType::Float));

--- a/xformers/ops/fmha/__init__.py
+++ b/xformers/ops/fmha/__init__.py
@@ -339,9 +339,22 @@ def _memory_efficient_attention_backward(
     # LSE has shape [B, H, M] while query has shape [B, M, H, K]
     if (
         ctx.lse.ndim != 3
-        or ctx.lse.shape[0] != inp.query.shape[0]
+        # Dim 0
+        or (
+            not isinstance(inp.query, TensorWithSeqLen)
+            and ctx.lse.shape[0] != inp.query.shape[0]
+        )
+        or (
+            isinstance(inp.query, TensorWithSeqLen)
+            and ctx.lse.shape[0] != inp.query.cu_seqlen.shape[0] - 1
+        )
+        # Dim 1
         or ctx.lse.shape[1] != inp.query.shape[2]
-        or ctx.lse.shape[2] < inp.query.shape[1]
+        # Dim 2
+        or (
+            not isinstance(inp.query, TensorWithSeqLen)
+            and ctx.lse.shape[2] < inp.query.shape[1]
+        )
     ):
         raise ValueError(
             "Input tensors have incompatible shapes."

--- a/xformers/ops/fmha/flash.py
+++ b/xformers/ops/fmha/flash.py
@@ -170,9 +170,12 @@ class FwOp(AttentionFwOpBase):
             None,
         )
         if isinstance(inp.query, TensorWithSeqLen):
-            out = TensorWithSeqLen(out)
-            out.cu_seqlen = cu_seqlens_q
-            out.max_seqlen = max_seqlen_k
+            out = TensorWithSeqLen(
+                out,
+                max_seqlen=max_seqlen_k,
+                cu_seqlen=cu_seqlens_q,
+                cu_seqlen_py=inp.query.cu_seqlen_py,
+            )
 
         out = out.reshape(out_shape)
         ctx = Context(out=out, lse=softmax_lse)


### PR DESCRIPTION
* Fix wrong sanity check for LSE that didn't apply with varying seqlen
* CUTLASS: Fixed LSE shape when used with varying seqlen
* Add test for backward with `TensorWithSeqLen`
* Fix gradient flow through `TensorWithSeqLen.from_tensor_list` (+ add test)
* `TensorWithSeqLen`: fix with __getitem__ operation (and others with input tensors that are nested within the arguments)