### PR TITLE
Upload source distribution to PyPi

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,6 +43,11 @@ jobs:
             pip_index: https://download.pytorch.org/whl/cu116
             cuda_run_file: https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run
             publish: false
+        include:
+          # publish source distribution only from this runner
+          - os: ubuntu-22.04
+            python: "3.10"
+            sdist: true
 
     name: ${{ matrix.os }}-py${{ matrix.python }}-torch${{ matrix.config.torch_version }}
     runs-on: ${{ matrix.os }}
@@ -130,9 +135,19 @@ jobs:
           name: ${{ matrix.os }}-py${{ matrix.python }}-torch${{ matrix.config.torch_version }}.zip
           path: dist/*.whl
 
-      - name: Upload to PyPi
+      - name: Upload wheel to PyPi
         if: matrix.config.publish
         run: $PY -m twine upload dist/*.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+      - name: Upload source distribution to PyPi
+        if: matrix.config.publish && matrix.sdist
+        run: |
+          rm -rf dist/
+          $PY setup.py sdist -d sdist/
+          $PY -m twine upload sdist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Upload source distribution to PyPi. Continuation of #588 

I am unsure if this is strictly necessary since we basically upload wheels for every supported platform, but it won't hurt `¯\_(ツ)_/¯`

Related #533 

I have considered consoldating  the `env` from the last 2 steps to the global env, but I don't want any steps (especially external actions) to access the token.


Example sdist:
https://test.pypi.org/project/formers/0.0.16rc379/#files