### PR TITLE
Support v prefix for tags

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v?[0-9]+.[0-9]+.[0-9]+"
 
 # this yaml file can be cleaned up using yaml anchors, but they're not supported in github actions yet
 # https://github.com/actions/runner/issues/1182

--- a/packaging/compute_wheel_version.py
+++ b/packaging/compute_wheel_version.py
@@ -11,12 +11,18 @@ version = (THIS_PATH.parents[1] / "version.txt").read_text().strip()
 
 
 try:
-    tag = subprocess.check_output(["git", "describe", "--tags"], text=True).strip()
+    tag = subprocess.check_output(
+        ["git", "describe", "--tags", "--exact-match", "HEAD"], text=True
+    ).strip()
 except subprocess.CalledProcessError:  # no tag
     tag = ""
 
 if tag:
-    assert version == tag, "The version in version.txt does not match the given tag"
+    if tag.startswith("v"):
+        tag = tag[1:]
+    assert (
+        version == tag
+    ), f"The version in version.txt ({version}) does not match the given tag ({tag})"
     print(tag, end="")
     exit(0)
 


### PR DESCRIPTION
## What does this PR do?

Support using `v` as prefix for a tagged version.

Fix RC release error.


The cpu test fails because of something unrelated to this PR.
