### PR TITLE
Relax pytorch dependency version

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,15 +33,15 @@ jobs:
           - "3.9"
           - "3.10"
         config:
-          - torch_version: "1.13.0+cu117"
-            torch_version_constraint: "1.13"
+          - torch_version: "1.13.1+cu117"
+            torch_version_constraint: "1.13.1"
             cuda_version: "11.7.1"
             pip_index: https://download.pytorch.org/whl/cu117
             cuda_run_file: https://developer.download.nvidia.com/compute/cuda/11.7.1/local_installers/cuda_11.7.1_515.65.01_linux.run
             publish: true # publish only latest version
 
           - torch_version: "1.12.1+cu116"
-            torch_version_constraint: "1.12"
+            torch_version_constraint: "1.12.1"
             cuda_version: "11.6.2"
             pip_index: https://download.pytorch.org/whl/cu116
             cuda_run_file: https://developer.download.nvidia.com/compute/cuda/11.6.2/local_installers/cuda_11.6.2_510.47.03_linux.run
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.os }}-py${{ matrix.python }}-torch${{ matrix.config.torch_version }}.zip
+          name: ${{ matrix.os }}-py${{ matrix.python }}-torch${{ matrix.config.torch_version }}
           path: dist/*.whl
 
       - name: Upload wheel to PyPi
@@ -150,6 +150,8 @@ jobs:
         if: matrix.config.publish && matrix.sdist
         run: |
           rm -rf dist/
+          # unpin pytorch version
+          git checkout HEAD -- ./requirements.txt
           $PY setup.py sdist -d sdist/
           $PY -m twine upload sdist/*
         env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,10 @@
 include LICENSE
 include requirements.txt
+include version.txt
 recursive-include xformers/components/attention/csrc/ *
 recursive-include third_party/sputnik/ *
+recursive-include third_party/cutlass/include/ *
+recursive-include third_party/cutlass/examples/ *
+recursive-include third_party/flash-attention/csrc/ *
+recursive-exclude third_party/flash-attention/csrc/flash_attn/cutlass/ *
+recursive-include third_party/flash-attention/flash_attn/ *

--- a/setup.py
+++ b/setup.py
@@ -52,17 +52,7 @@ def get_local_version_suffix() -> str:
     return f"+{git_hash}.d{date_suffix}"
 
 
-if os.getenv("BUILD_VERSION"):
-    # In CI
-    version = os.getenv("BUILD_VERSION")
-else:
-    version_txt = os.path.join(this_dir, "version.txt")
-    with open(version_txt) as f:
-        version = f.readline().strip()
-    version += get_local_version_suffix()
-
-
-def write_version_file():
+def write_version_file(version: str):
     version_path = os.path.join(this_dir, "xformers", "version.py")
     with open(version_path, "w") as f:
         f.write("# noqa: C801\n")
@@ -77,16 +67,18 @@ def symlink_package(name: str, path: Path) -> None:
     path_from = cwd / path
     path_to = os.path.join(cwd, *name.split("."))
 
+    try:
+        if os.path.islink(path_to):
+            os.unlink(path_to)
+        elif os.path.isdir(path_to):
+            shutil.rmtree(path_to)
+        else:
+            os.remove(path_to)
+    except FileNotFoundError:
+        pass
     # OSError: [WinError 1314] A required privilege is not held by the client
     # Windows requires special permission to symlink. Fallback to copy
     use_symlink = os.name != "nt"
-    try:
-        if use_symlink:
-            os.remove(path_to)
-        else:
-            shutil.rmtree(path_to)
-    except FileNotFoundError:
-        pass
     if use_symlink:
         os.symlink(src=path_from, dst=path_to)
     else:
@@ -294,7 +286,21 @@ class clean(distutils.command.clean.clean):  # type: ignore
 
 
 if __name__ == "__main__":
-    write_version_file()
+
+    try:
+        # when installing as a source distribution, the version module should exist
+        from xformers.version import __version__
+
+        version = __version__
+    except ModuleNotFoundError:
+        if os.getenv("BUILD_VERSION"):  # In CI
+            version = os.getenv("BUILD_VERSION")
+        else:
+            version_txt = os.path.join(this_dir, "version.txt")
+            with open(version_txt) as f:
+                version = f.readline().strip()
+            version += get_local_version_suffix()
+        write_version_file(version)
     # Embed a fixed version of flash_attn
     # NOTE: The correct way to do this would be to use the `package_dir`
     # parameter in `setuptools.setup`, but this does not work when


### PR DESCRIPTION
## What does this PR do?

Fixes an issue introduced by #590

we pin pytorch's version while generating the wheels, and since we re-use the runner to generate the source distribution; the pinned version gets carried over.

This PR unpins the version.

Maybe it would make sense to use a different runner for the source distribution, but this change will be required nonetheless, since pytorch is pinned per default in requirements.txt.