### PR TITLE
Windows build with Flash-Attention v0.2.4

### DIFF
--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -4,19 +4,24 @@ on:
   pull_request: {}
 
 env:
-  TORCH_CUDA_ARCH_LIST: "8.0"
   FORCE_CUDA: 1
   MAX_JOBS: 4
   DISTUTILS_USE_SDK: 1 # otherwise distutils will complain on windows about multiple versions of msvc
   XFORMERS_BUILD_TYPE: "Release"
-  XFORMERS_DISABLE_FLASH_ATTN: 1
 
 jobs:
   win_build:
-    name: win-build
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - "8.0"
+          - "7.0"
+    name: win-build-${{ matrix.arch }}
     runs-on: windows-2019
     env:
       PY: python3
+      TORCH_CUDA_ARCH_LIST: ${{ matrix.arch }}
 
     timeout-minutes: 360
     defaults:

--- a/setup.py
+++ b/setup.py
@@ -136,10 +136,6 @@ def get_flash_attention_extensions(cuda_version: int, extra_compile_args):
             "to run `git submodule update --init --recursive` ?"
         )
 
-    nvcc_platform_dependant_args: List[str] = []
-    if sys.platform == "win32":
-        nvcc_platform_dependant_args.append("-std=c++17")
-
     return [
         CUDAExtension(
             name="xformers._C_flashattention",
@@ -162,12 +158,12 @@ def get_flash_attention_extensions(cuda_version: int, extra_compile_args):
                 "nvcc": extra_compile_args.get("nvcc", [])
                 + [
                     "-O3",
+                    "-std=c++17",
                     "--expt-relaxed-constexpr",
                     "--expt-extended-lambda",
                     "--use_fast_math",
                     "--ptxas-options=-v",
                 ]
-                + nvcc_platform_dependant_args
                 + nvcc_archs_flags
                 + get_extra_nvcc_flags_for_build_type(),
             },


### PR DESCRIPTION
Windows build is currently broken (cc @AbdBarho ) - I've reached out to @tridao to get a fix in Flash-Attention repo.
This is because we updated flash to v0.2.4 (https://github.com/facebookresearch/xformers/commit/eaf8c2e90988216e72504b0fcb0f0d4f7020fcb3), which was needed to fix conda builds (because conda builds can't depend on `einops`, which is a pip-only package)