### PR TITLE
memory_efficient_attention()  nondeterministic warning

### DIFF
--- a/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
@@ -4,6 +4,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/library.h>
+#include <ATen/Context.h>
 
 #include "kernel_backward.h"
 
@@ -67,6 +68,8 @@ mem_efficient_attention_backward_cutlass(
       false,
       "MemoryEfficient build has been disabled at build time with -DXFORMERS_MEM_EFF_ATTENTION_DISABLE_BACKWARD");
 #else
+  at::globalContext().alertNotDeterministic("mem_efficient_attention_backward_cutlass");
+
   // ndim
   TORCH_CHECK(query.dim() == grad_out_.dim());
   TORCH_CHECK(query.dim() == key.dim());

--- a/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
@@ -3,6 +3,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/library.h>
+#include <ATen/Context.h>
 
 #include "kernel_forward.h"
 
@@ -144,6 +145,8 @@ std::tuple<at::Tensor, at::Tensor> efficient_attention_forward_cutlass(
       false,
       "MemoryEfficient build has been disabled at build time with -DXFORMERS_MEM_EFF_ATTENTION_DISABLE_FORWARD");
 #else
+  at::globalContext().alertNotDeterministic("efficient_attention_forward_cutlass");
+
   TORCH_CHECK(query.dim() == 4);
   TORCH_CHECK(key.dim() == 4);
   TORCH_CHECK(value.dim() == 4);

--- a/xformers/ops/fmha/__init__.py
+++ b/xformers/ops/fmha/__init__.py
@@ -172,6 +172,12 @@ def memory_efficient_attention(
 
         NVIDIA GPUs with compute capability above 6.0 (P100+), datatype ``f16``, ``bf16`` and ``f32``.
 
+    :Note:
+
+        This function has been reported to exhibit non-deterministic behavior \
+        [`#618 <https://github.com/facebookresearch/xformers/issues/618>`_]. \ 
+        This may affects to the application such as diffusion models.
+
     Raises:
         NotImplementedError: if there is no operator available to compute the MHA
 

--- a/xformers/ops/fmha/__init__.py
+++ b/xformers/ops/fmha/__init__.py
@@ -174,9 +174,7 @@ def memory_efficient_attention(
 
     :Note:
 
-        This function has been reported to exhibit non-deterministic behavior \
-        [`#618 <https://github.com/facebookresearch/xformers/issues/618>`_]. \ 
-        This may affects to the application such as diffusion models.
+        This operator may be nondeterministic.
 
     Raises:
         NotImplementedError: if there is no operator available to compute the MHA


### PR DESCRIPTION
## What does this PR do?
The reproducibility issue mentioned in #618. It can be warned or the program can be stopped, especially in runtime environments where torch.use_deterministic_algorithms(True) is used. I have also included a sentence in the documentation.

For testing, I have run the script in the link below. The results are also included.
https://gist.github.com/takuma104/748c2d12abc4ce9111c1202b1f0efbc6

## Before submitting

- [Y] Did you have fun?
- [Y] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [Y] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [Y] Did you make sure to update the docs?
- [N] Did you write any new necessary tests?
- [N] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
