### PR TITLE
CUTLASS MHA 2D bias grad fix

### DIFF
--- a/xformers/ops/fmha/small_k.py
+++ b/xformers/ops/fmha/small_k.py
@@ -58,6 +58,10 @@ class FwOp(AttentionFwOpBase):
     @classmethod
     def not_supported_reasons(cls, d: Inputs) -> List[str]:
         reasons = super(FwOp, cls).not_supported_reasons(d)
+
+        if isinstance(d.attn_bias, torch.Tensor) and d.attn_bias.ndim != 3:
+            reasons.append("expected tensor bias to have format BMN")
+
         buffer_size = 8
         k = d.query.shape[-1]
         for pack in [1, 2, 4]:
@@ -116,6 +120,10 @@ class BwOp(AttentionBwOpBase):
     @classmethod
     def not_supported_reasons(cls, d: Inputs) -> List[str]:
         reasons = super(BwOp, cls).not_supported_reasons(d)
+
+        if isinstance(d.attn_bias, torch.Tensor) and d.attn_bias.ndim != 3:
+            reasons.append("expected tensor bias to have format BMN")
+
         buffer_size = 8
         k = d.query.shape[-1]
         for pack in [1, 2, 4]:


### PR DESCRIPTION
## What does this PR do?
disables support for bias grad with 2D bias. in general bias grad with broadcasted biases won't work because this would require reductions across broadcasted dimensions, which isn't currently supported.

## Before submitting

- [Y] Did you have fun?
  - Make sure you had fun coding 🙃
- [Y] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [N] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [N/A] Did you make sure to update the docs?
- [Y] Did you write any new necessary tests?
- [N/A] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
