### PR TITLE
fix mask-tying to sequence length

### DIFF
--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -98,14 +98,13 @@ class ScaledDotProduct(Attention):
 
         # Handle a possibly deferred causal mask handling
         mask = self.mask
-        if self.causal:
-            if self.mask is None:
-                mask = AttentionMask.make_causal(
-                    seq_len=q.shape[-2],
-                    to_seq_len=q.shape[-2],
-                    device=q.device,
-                    dtype=q.dtype,
-                )
+        if self.causal and self.mask is None:
+            mask = AttentionMask.make_causal(
+                seq_len=q.shape[-2],
+                to_seq_len=q.shape[-2],
+                device=q.device,
+                dtype=q.dtype,
+            )
 
         # Merge the optional causal mask and the user-provided mask
         if mask is not None:

--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -97,6 +97,7 @@ class ScaledDotProduct(Attention):
             )
 
         # Handle a possibly deferred causal mask handling
+        mask = self.mask
         if self.causal:
             if self.mask is None:
                 mask = AttentionMask.make_causal(
@@ -105,8 +106,6 @@ class ScaledDotProduct(Attention):
                     device=q.device,
                     dtype=q.dtype,
                 )
-            else:
-                mask = self.mask
 
         # Merge the optional causal mask and the user-provided mask
         if mask is not None:

--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -97,19 +97,22 @@ class ScaledDotProduct(Attention):
             )
 
         # Handle a possibly deferred causal mask handling
-        if self.causal and self.mask is None:
-            self.mask = AttentionMask.make_causal(
-                seq_len=q.shape[-2],
-                to_seq_len=q.shape[-2],
-                device=q.device,
-                dtype=q.dtype,
-            )
+        if self.causal:
+            if self.mask is None:
+                mask = AttentionMask.make_causal(
+                    seq_len=q.shape[-2],
+                    to_seq_len=q.shape[-2],
+                    device=q.device,
+                    dtype=q.dtype,
+                )
+            else:
+                mask = self.mask
 
         # Merge the optional causal mask and the user-provided mask
-        if self.mask is not None:
-            self.mask = self.mask.to(dtype=q.dtype, device=q.device)
+        if mask is not None:
+            mask = mask.to(dtype=q.dtype, device=q.device)
 
-            att_mask = att_mask + self.mask if att_mask is not None else self.mask
+            att_mask = att_mask + mask if att_mask is not None else mask
 
         # Try to handle a case where the sequence is smaller than the mask
         if (


### PR DESCRIPTION
## What does this PR do?
Fixes #655 

This PR allows a class-level causal attention mask for fixed sequence-length tasks; otherwise it creates a new mask on-the-fly in the forward pass to disentangle the mask from sequence length which can vary between batches in tasks like MT.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
