### PR TITLE
Remove xlformers/ files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,4 @@ multirun
 outputs
 
 .benchmarks
-xformers/_flash_attn
 xformers/version.py
-xformers/cpp_lib.json

--- a/xformers/_flash_attn
+++ b/xformers/_flash_attn
@@ -1,0 +1,1 @@
+/mnt/efs/shared_home/xformers/third_party/flash-attention/flash_attn

--- a/xformers/cpp_lib.json
+++ b/xformers/cpp_lib.json
@@ -1,0 +1,1 @@
+{"version": {"cuda": 1107, "torch": "1.13.0", "python": "3.9.15"}, "env": {"TORCH_CUDA_ARCH_LIST": null, "XFORMERS_BUILD_TYPE": null, "XFORMERS_ENABLE_DEBUG_ASSERTIONS": null, "NVCC_FLAGS": null, "XFORMERS_PACKAGE_FROM": null}}


### PR DESCRIPTION
I couldn't find a way to generate these files in FB infra. So adding them to the git repo so they can be easily ported.