### PR TITLE
reduce overhead in stack_or_none

### DIFF
--- a/xformers/ops/unbind.py
+++ b/xformers/ops/unbind.py
@@ -37,7 +37,10 @@ def get_stack_strides(
             return None
         if x.stride() != tensors[0].stride():
             return None
-        if x.storage_offset() != tensors[0].storage_offset() + (i + 1) * final_stride[dim]:
+        if (
+            x.storage_offset()
+            != tensors[0].storage_offset() + (i + 1) * final_stride[dim]
+        ):
             return None
         if storage_data_ptr is None:
             storage_data_ptr = tensors[0].storage().data_ptr()

--- a/xformers/ops/unbind.py
+++ b/xformers/ops/unbind.py
@@ -30,16 +30,19 @@ def get_stack_strides(
             i -= 1
         final_stride.append(tensors[0].stride(i))
 
-    for i, x in enumerate(tensors):
+    storage_data_ptr: Optional[int] = None
+    for i, x in enumerate(tensors[1:]):
         # Sanity checks
         if x.shape != tensors[0].shape:
-            return None
-        # Actual storage check
-        if x.storage().data_ptr() != tensors[0].storage().data_ptr():
             return None
         if x.stride() != tensors[0].stride():
             return None
         if x.storage_offset() != tensors[0].storage_offset() + i * final_stride[dim]:
+            return None
+        if storage_data_ptr is None:
+            storage_data_ptr = tensors[0].storage().data_ptr()
+        # Actual storage check
+        if x.storage().data_ptr() != tensors[0].storage().data_ptr():
             return None
     return tuple(final_stride)
 

--- a/xformers/ops/unbind.py
+++ b/xformers/ops/unbind.py
@@ -42,7 +42,7 @@ def get_stack_strides(
         if storage_data_ptr is None:
             storage_data_ptr = tensors[0].storage().data_ptr()
         # Actual storage check
-        if x.storage().data_ptr() != tensors[0].storage().data_ptr():
+        if x.storage().data_ptr() != storage_data_ptr:
             return None
     return tuple(final_stride)
 

--- a/xformers/ops/unbind.py
+++ b/xformers/ops/unbind.py
@@ -37,7 +37,7 @@ def get_stack_strides(
             return None
         if x.stride() != tensors[0].stride():
             return None
-        if x.storage_offset() != tensors[0].storage_offset() + i * final_stride[dim]:
+        if x.storage_offset() != tensors[0].storage_offset() + (i + 1) * final_stride[dim]:
             return None
         if storage_data_ptr is None:
             storage_data_ptr = tensors[0].storage().data_ptr()


### PR DESCRIPTION
## What does this PR do?
Reduce overhead in stack_or_none, tensor.storage() is expensive (3us each call) since it needs to go across Python and Cython. Based on a local benchmark, this can reduce stack_or_none on two tensors from 20us into 12 us.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
