### PR TITLE
Bump pyre extensions versions

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,6 @@ sphinx==5.0.0
 git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
 torch>=1.6.0
 numpy>=1.19.5
-pyre-extensions == 0.0.23
+pyre-extensions == 0.0.29
 jinja2==3.0.3
 einops

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,7 +8,7 @@ flake8 == 3.8.4
 flake8-copyright
 isort == 5.7.0
 mypy == 0.982
-pyre-check == 0.9.8
+pyre-check == 0.9.16
 pyre-extensions == 0.0.29
 click == 8.0.4
 protobuf==3.20.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@ flake8-copyright
 isort == 5.7.0
 mypy == 0.982
 pyre-check == 0.9.8
-pyre-extensions == 0.0.23
+pyre-extensions == 0.0.29
 click == 8.0.4
 protobuf==3.20.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 # install with `pip install -r requirements.txt`, and make sure that CI does the same
 torch >= 1.12
 numpy
-pyre-extensions == 0.0.23
+pyre-extensions == 0.0.29


### PR DESCRIPTION
## What does this PR do?
Bump pyre-check and pyre-extensions versions, since the outdated current version blocks projects that use xformers to use newer Pyre versions.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
