### PR TITLE
fix: handle CUDA arch major >= 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ def get_flash_attention_extensions(cuda_version: int, extra_compile_args):
         assert len(arch) >= 3, f"Invalid sm version: {arch}"
 
         arch_arr = arch.split('.')
-        num = 10 * int(arch_arr[0]) + int(arch_arr[1])
+        num = 10 * int(arch_arr[0]) + int(arch_arr[1].partition("+")[0])
         # Need at least 7.5
         if num < 75:
             continue

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,8 @@ def get_flash_attention_extensions(cuda_version: int, extra_compile_args):
     for arch in archs_list.replace(" ", ";").split(";"):
         assert len(arch) >= 3, f"Invalid sm version: {arch}"
 
-        num = 10 * int(arch[0]) + int(arch[2])
+        arch_arr = arch.split('.')
+        num = 10 * int(arch_arr[0]) + int(arch_arr[1])
         # Need at least 7.5
         if num < 75:
             continue


### PR DESCRIPTION
## What does this PR do?
Fixes an issue when `TORCH_CUDA_ARCH_LIST` contains a two-digit major version, e.g. `10.1`.  Hopefully fairly self-evident how it will now work (and how/why it was previously broken).

## Before submitting

- [X] Did you have fun?
  - Make sure you had fun coding 🙃
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [X] N/A
- [ ] Did you make sure to update the docs?
  - [X] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.