### PR TITLE
[WIP] Upgrade FlashAttention to 2.0

### DIFF
--- a/xformers/ops/fmha/flash.py
+++ b/xformers/ops/fmha/flash.py
@@ -192,7 +192,7 @@ class FwOp(AttentionFwOpBase):
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
     CUDA_MINIMUM_COMPUTE_CAPABILITY = (7, 5)
     SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16}
-    SUPPORTED_MAX_K = 128
+    SUPPORTED_MAX_K = 256
     SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
         type(None),
         LowerTriangularMask,
@@ -307,7 +307,7 @@ class BwOp(AttentionBwOpBase):
             if device_capability < (7, 5):
                 reasons.append("requires a GPU with compute capability > 7.5")
             is_sm80_or_sm90 = device_capability in [(8, 0), (9, 0)]
-            if max(d.key.shape[-1], d.query.shape[-1]) > 64 and not is_sm80_or_sm90:
+            if max(d.key.shape[-1], d.query.shape[-1]) > 192 and not is_sm80_or_sm90:
                 reasons.append(
                     "requires a GPU with compute capability 8.0 (A100) or 9.0 (H100) for 'query.shape[-1] > 64'"
                 )

--- a/xformers/ops/fmha/flash.py
+++ b/xformers/ops/fmha/flash.py
@@ -192,7 +192,7 @@ class FwOp(AttentionFwOpBase):
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
     CUDA_MINIMUM_COMPUTE_CAPABILITY = (7, 5)
     SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16}
-    SUPPORTED_MAX_K = 256
+    SUPPORTED_MAX_K = 128
     SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
         type(None),
         LowerTriangularMask,
@@ -307,7 +307,7 @@ class BwOp(AttentionBwOpBase):
             if device_capability < (7, 5):
                 reasons.append("requires a GPU with compute capability > 7.5")
             is_sm80_or_sm90 = device_capability in [(8, 0), (9, 0)]
-            if max(d.key.shape[-1], d.query.shape[-1]) > 192 and not is_sm80_or_sm90:
+            if max(d.key.shape[-1], d.query.shape[-1]) > 64 and not is_sm80_or_sm90:
                 reasons.append(
                     "requires a GPU with compute capability 8.0 (A100) or 9.0 (H100) for 'query.shape[-1] > 64'"
                 )


### PR DESCRIPTION
## What does this PR do?

This PR updates the symlink to FlashAttention 2.0 released in v1.0.9 of [flash-attention](https://github.com/Dao-AILab/flash-attention). All credit goes to Tridao for the implementation.

According to reported results, this can enable a **2-4x speed-up**.

![FlashAttention speedup on A100 80GB SXM5 with FP16/BF16](https://github.com/Dao-AILab/flash-attention/blob/main/assets/flash2_a100_fwd_bwd_benchmark.png?raw=true)

This PR is a WIP and still needs testing and documentation updates. Additionally, the heuristics for choosing the underlying implementation likely needs to be updated per [this comment](https://github.com/facebookresearch/xformers/issues/795#issuecomment-1638650830).

## Before submitting

- [Y] Did you have fun?
  - Make sure you had fun coding 🙃
- [Y] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [Y] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [Y] (https://github.com/facebookresearch/xformers/issues/795)
- [N] Did you make sure to update the docs?
- [N] Did you write any new necessary tests?
- [N] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
