### PR TITLE
Adopted `gpus` parameter for newer version of pl

### DIFF
--- a/docs/source/xformers_mingpt.ipynb
+++ b/docs/source/xformers_mingpt.ipynb
@@ -433,7 +433,7 @@
         ")\n",
         "\n",
         "trainer = Trainer(\n",
-        "    gpus=1,\n",
+        "    devices=1, accelerator=\"gpu\",\n",
         "    max_epochs=EPOCHS,\n",
         "    precision=16,\n",
         "    gradient_clip_val=1,\n",

--- a/examples/microGPT.py
+++ b/examples/microGPT.py
@@ -310,7 +310,7 @@ if __name__ == "__main__":
     print(model)
 
     trainer = Trainer(
-        gpus=1,
+        gpusdevices=1, accelerator="gpu",
         max_epochs=EPOCHS,
         precision=16,
         log_every_n_steps=1,


### PR DESCRIPTION
## What does this PR do?
Fixes #818 

The pytorch lightning version introduced changes in `Trainer` class:
* keyword argument `gpus` is no longer used
* instead, you might use `devices=1` with `accelerator="gpu"`

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
