### PR TITLE
Add RMSNorm

### DIFF
--- a/tests/test_triton_rmsnorm.py
+++ b/tests/test_triton_rmsnorm.py
@@ -1,0 +1,129 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import logging
+
+import pytest
+import torch
+from torch.cuda.amp.autocast_mode import autocast
+
+import xformers
+
+try:
+    from xformers.triton import FusedRMSNorm
+    from xformers.triton.utils import gpu_capabilities_older_than_70
+
+    _triton_available = xformers._is_triton_available()
+except ImportError:
+    logging.warning("Triton is not available, some optimizations will not be tested.")
+    _triton_available = False
+
+# Testing odd shapes on purpose
+SHAPES = [
+    (384, 128),
+    (8, 384, 128),
+    (8, 784, 512),
+    (4, 2048, 384),
+    (4, 3136, 1024),
+    (2, 1024, 2048),
+    (2, 2048, 4096),
+    (2, 4096, 4096),
+    (1, 2048, 12288),
+]
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, normalized_shape, eps=1e-5, device=None, dtype=None, **kwargs):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(normalized_shape, device=device, dtype=dtype))
+        self.eps = eps
+
+    def forward(self, hidden_states: torch.Tensor):
+        input_dtype = hidden_states.dtype
+        variance = hidden_states.to(torch.float32).pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.eps)
+
+        return (self.weight * hidden_states).to(input_dtype)
+
+
+@pytest.mark.skipif(not _triton_available, reason="Triton is not available")
+@pytest.mark.skipif(
+    not _triton_available or gpu_capabilities_older_than_70(),
+    reason="Triton requires a SM70+ GPU",
+)
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("amp", [True, False])
+def test_rmsnorm_parity(shape, amp):
+    """Check that PyTorch and Triton softmax give the same result"""
+
+    # Get the same inputs
+    torch.random.manual_seed(0)
+    X = torch.normal(0, 1, size=shape, device="cuda", requires_grad=True)
+
+    torch.random.manual_seed(0)
+    X_ = torch.normal(0, 1, size=shape, device="cuda", requires_grad=True)
+
+    eps = 1e-4
+
+    # Initialize the two layers, weights are 1 and 0 by default, no randomness
+    torch_rmsnorm = RMSNorm(X.shape[-1], eps=eps).to("cuda")
+    triton_rmsnorm = FusedRMSNorm(X.shape[-1], eps=eps).to("cuda")
+
+    with autocast(enabled=amp):
+        assert torch.allclose(X, X_)  # sanity checking, else all hell breaks loose
+
+        # Check the forward pass
+        y_torch = torch_rmsnorm(X)
+        y_triton = triton_rmsnorm(X_)
+        assert torch.allclose(
+            y_torch.norm(), y_triton.norm(), atol=1e-3
+        ), f"{torch.norm(y_torch)} vs. {torch.norm(y_triton)}"
+
+        # Check that BW also gives the same result
+        loss_torch = torch.norm(y_torch)
+        loss_torch.backward()
+
+        loss_triton = torch.norm(y_triton)
+        loss_triton.backward()
+
+        print(torch.norm(y_torch), torch.norm(y_triton))
+
+        print(y_torch[0, :])
+        print(y_triton[0, :])
+
+        # There are 2 items to check:
+        # - gradient on the inputs
+        assert torch.allclose(
+            X.grad, X_.grad
+        ), f"Inputs grad mismatch: {torch.norm(X.grad)} vs. {torch.norm(X_.grad)}"
+
+        # - gradient on the rmsnorm weight
+        assert torch.allclose(
+            torch_rmsnorm.weight.grad, triton_rmsnorm.weight.grad, atol=1e-3
+        ), (
+            f"Weight grad mismatch: {torch.norm(torch_rmsnorm.weight.grad)} vs."
+            + f" {torch.norm(triton_rmsnorm.weight.grad)}"
+        )
+
+
+@pytest.mark.skipif(not _triton_available, reason="Triton is not available")
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_no_contiguous(dtype):
+    """Check that we don't choke on non-contigous tensors"""
+    shape = (8, 384, 128)
+
+    # Get the same inputs
+    torch.random.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    X = torch.normal(0, 1, size=shape, device="cuda", requires_grad=True, dtype=dtype)
+    X = X.transpose(2, 1).contiguous().transpose(2, 1)
+
+    assert not X.is_contiguous()
+
+    triton_rmsnorm = FusedRMSNorm(X.shape[-1]).to(device="cuda", dtype=dtype)
+    _ = triton_rmsnorm(X)
+

--- a/xformers/triton/__init__.py
+++ b/xformers/triton/__init__.py
@@ -12,6 +12,7 @@ if _triton_available:
         from .dropout import FusedDropoutBias, dropout  # noqa
         from .fused_linear_layer import FusedLinear  # noqa
         from .layer_norm import FusedLayerNorm, layer_norm  # noqa
+        from .rms_norm import FusedRMSNorm # noqa
         from .softmax import log_softmax, softmax  # noqa
 
         __all__ = [
@@ -21,6 +22,7 @@ if _triton_available:
             "FusedDropoutBias",
             "FusedLinear",
             "FusedLayerNorm",
+            "FusedRMSNorm",
             "layer_norm",
         ]
     except ImportError:

--- a/xformers/triton/k_rms_norm.py
+++ b/xformers/triton/k_rms_norm.py
@@ -118,7 +118,7 @@ def rms_norm_bwd_dx_fused(
 # Backward pass (total DW)
 # fmt: off
 @triton.jit
-def rms_norm_bwd_dwdb(
+def rms_norm_bwd_dw(
     DW, FINAL_DW,
     M, N,
     BLOCK_SIZE_M: tl.constexpr,

--- a/xformers/triton/k_rms_norm.py
+++ b/xformers/triton/k_rms_norm.py
@@ -1,0 +1,148 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# CREDITS: This comes almost as-is from the Triton layer norm tutorial
+# https://github.com/openai/triton/blob/master/python/tutorials/05-layer-norm.py
+
+
+import triton
+import triton.language as tl
+
+
+# fmt: off
+@triton.jit
+def rms_norm_fw(X, Y, W, V, stride, N, eps, BLOCK_SIZE_N: tl.constexpr):
+    # fmt: on
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_SIZE_N)
+    mask = cols < N
+
+    # Move to this row
+    x_ptrs = X + row * stride + cols
+    x = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
+    x_var = tl.sum(x * x, axis=0) / N
+    rstd = 1.0 / tl.sqrt(x_var + eps)
+
+    y = x * rstd
+    tl.store(V + row, rstd)
+
+    mask = cols < N
+    w = tl.load(W + cols, mask=mask, other=1.0)
+    y = y * w
+
+    y_ptrs = Y + row * stride + cols
+    tl.store(y_ptrs, y, mask=mask)
+
+
+# Backward pass (DX + partial DW)
+# fmt: off
+@triton.jit
+def rms_norm_bwd_dx_fused(
+    DX, DY, DW,
+    X, W, V,
+    Lock, stride, N,
+    # META-parameters
+    GROUP_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    # fmt: on
+
+    # position of elements processed by this program
+    row = tl.program_id(0)
+    cols = tl.arange(0, BLOCK_SIZE_N)
+    mask = cols < N
+
+    # offset data pointers to start at the row of interest
+    x_ptrs = X + row * stride + cols
+    dy_ptrs = DY + row * stride + cols
+
+    # load data to SRAM
+    x = tl.load(x_ptrs, mask=mask, other=0)
+    dy = tl.load(dy_ptrs, mask=mask, other=0)
+    rstd = tl.load(V + row)
+
+    # compute dx
+    xhat = x * rstd
+
+    w = tl.load(W + cols, mask=mask, other=0)
+    wdy = w * dy
+
+
+    xhat = tl.where(mask, xhat, 0.)
+    wdy = tl.where(mask, wdy, 0.)
+    mean1 = tl.sum(xhat * wdy, axis=0) / N
+    dx = (wdy - xhat * mean1) * rstd
+
+    # write-back dx
+    cols = tl.arange(0, BLOCK_SIZE_N)
+    mask = cols < N  # re-materialize the mask to save registers
+    dx_ptrs = DX + row * stride + cols
+    tl.store(dx_ptrs, dx, mask=mask)
+
+    # accumulate partial sums for dw
+    partial_dw = (dy * xhat).to(w.dtype)
+
+    # offset locks and weight/bias gradient pointer
+    # each kernel instance accumulates partial sums for
+    # DW into one of GROUP_SIZE_M independent buffers
+    # these buffers stay in the L2, which allow this kernel
+    # to be fast
+    lock_id = row % GROUP_SIZE_M
+    Lock += lock_id
+    Count = Lock + GROUP_SIZE_M
+
+    # - wait for a lock on the accumulated dw/db
+    while tl.atomic_cas(Lock, 0, 1) == 1:
+        pass
+    count = tl.load(Count)
+
+    # - we got the lock, accumulate this kernel's results with
+    # the stored values.
+    dw_ptrs = DW + lock_id * N + cols
+
+    if count == 0:
+        # first store doesn't accumulate
+        tl.atomic_xchg(Count, 1)
+    else:
+        partial_dw += tl.load(dw_ptrs, mask=mask, other=0.)
+
+    tl.store(dw_ptrs, partial_dw, mask=mask)
+
+    # release lock
+    tl.atomic_xchg(Lock, 0)
+
+
+# Backward pass (total DW)
+# fmt: off
+@triton.jit
+def rms_norm_bwd_dwdb(
+    DW, FINAL_DW,
+    M, N,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr
+):
+    # fmt: on
+    pid = tl.program_id(0)
+
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask_cols = cols < N
+
+    dw = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+    for i in range(0, M, BLOCK_SIZE_M):
+        rows = i + tl.arange(0, BLOCK_SIZE_M)
+        offs = rows[:, None] * N + cols[None, :]
+        mask_rm = rows < M
+
+        dw += tl.load(DW + offs, mask=mask_rm[:, None] & mask_cols[None, :], other=0.0)
+
+    sum_dw = tl.sum(dw, axis=0)
+
+    cols = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    mask_cols = cols < N
+
+    tl.store(FINAL_DW + cols, sum_dw, mask=mask_cols)
+

--- a/xformers/triton/rms_norm.py
+++ b/xformers/triton/rms_norm.py
@@ -1,0 +1,178 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+# CREDITS: the underlying kernel comes straight from the Triton tutorials
+# see https://github.com/openai/triton/blob/master/python/tutorials/05-layer-norm.py
+
+import logging
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import triton
+from torch.cuda.amp import custom_bwd, custom_fwd
+
+from xformers.triton.k_rms_norm import (
+    rms_norm_bwd_dwdb,
+    rms_norm_bwd_dx_fused,
+    rms_norm_fw,
+)
+
+logger = logging.getLogger("xformers")
+
+
+_triton_rmsnorm_fp16_enabled = False  # NOTE: PyTorch keeps layernorm as fp32
+_triton_registered_warnings = False
+
+
+class _RMSNorm(torch.autograd.Function):
+    @staticmethod
+    @custom_fwd(cast_inputs=torch.float16 if _triton_rmsnorm_fp16_enabled else None)
+    def forward(ctx, x, weight, eps):
+        # catch eps being too small if the tensors are fp16
+        if x.dtype == torch.float16:
+            eps = max(eps, 1.6e-5)
+
+        # allocate output
+        y = torch.empty_like(x)
+
+        # reshape input data into 2D tensor
+        x_arg = x.reshape(-1, x.shape[-1])
+        M, N = x_arg.shape
+
+        # allocate std, used in the backward pass
+        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+
+        # Less than 64KB per feature: enqueue fused kernel
+        MAX_FUSED_SIZE = 65536 // x.element_size()
+        BLOCK_SIZE_N = min(MAX_FUSED_SIZE, triton.next_power_of_2(N))
+        if N > BLOCK_SIZE_N:
+            raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+
+        if not x_arg.is_contiguous() or not y.is_contiguous():
+            global _triton_registered_warnings
+            if not _triton_registered_warnings:
+                logger.warning(
+                    "Non-contiguous input tensor found. Making it contiguous,"
+                    + " but could have perf or trainer implications"
+                )
+
+                _triton_registered_warnings = True
+
+            x_arg = x_arg.contiguous()
+            y = y.contiguous()
+
+        # heuristics for number of warps.
+        num_warps = min(max(BLOCK_SIZE_N // 256, 1), 16)
+
+        # enqueue kernel
+        # fmt: off
+        rms_norm_fw[(M,)](
+            x_arg, y, weight, rstd,
+            x_arg.stride(0),
+            N,
+            eps,
+            num_warps=num_warps,
+            BLOCK_SIZE_N=BLOCK_SIZE_N
+        )
+        # fmt: on
+
+        ctx.save_for_backward(x, rstd, weight)
+        ctx.BLOCK_SIZE_N = BLOCK_SIZE_N
+        ctx.num_warps = num_warps
+
+        return y.reshape_as(x)
+
+    @staticmethod
+    @custom_bwd
+    def backward(
+        ctx, dy
+    ):  # pragma: no cover  # this is covered, but called directly from C++
+        x, rstd, weight = ctx.saved_tensors
+
+        # flatten the batch dimension, if any.
+        # We're interested in 'samples' x norm_dimension
+        x = x.reshape(-1, x.size(-1))
+        M, N = x.size()
+
+        # heuristics for amount of parallel reduction stream for DG/DB
+        GROUP_SIZE_M = 32
+        if N <= 8192:
+            GROUP_SIZE_M = 64
+        if N <= 4096:
+            GROUP_SIZE_M = 96
+        if N <= 2048:
+            GROUP_SIZE_M = 128
+        if N <= 1024:
+            GROUP_SIZE_M = 256
+
+        if dy.dtype == torch.float32:
+            GROUP_SIZE_M = GROUP_SIZE_M // 2
+
+        # allocate output
+        locks = torch.zeros(2 * GROUP_SIZE_M, dtype=torch.int32, device="cuda")
+        t_args = {"dtype": x.dtype, "device": x.device}
+        _dw = torch.empty((GROUP_SIZE_M, x.size(-1)), **t_args)
+        dw = torch.empty((x.size(-1),), **t_args)
+        dy = dy.contiguous()
+        dx = torch.empty_like(dy)
+
+        # Check the tensor shapes and layouts
+        # we suppose in the kernel that they have the same size and are contiguous
+        assert (
+            dy.numel() == x.numel()
+        ), "Something is wrong in the backward graph, possibly because of an inplace operation after the rmsnorm"
+
+        # enqueue kernel using forward pass heuristics
+        # also compute partial sums for DW and DB
+        num_warps = min(max(ctx.BLOCK_SIZE_N // 256, 1), 16)
+
+        # fmt: off
+        rms_norm_bwd_dx_fused[(M,)](
+            dx, dy, _dw, x,
+            weight if weight is not None else x,
+            rstd,
+            locks,
+            x.stride(0),
+            N,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            BLOCK_SIZE_N=ctx.BLOCK_SIZE_N,
+            num_warps=num_warps
+        )
+        # fmt: on
+
+        def grid(meta):
+            return [triton.cdiv(N, meta["BLOCK_SIZE_N"])]
+
+        # accumulate partial sums in separate kernel
+        # fmt: off
+        rms_norm_bwd_dwdb[grid](
+            _dw, dw,
+            GROUP_SIZE_M,
+            N,
+            BLOCK_SIZE_M=32,
+            BLOCK_SIZE_N=64
+        )
+        # fmt: on
+
+        dx = dx.reshape_as(dy)
+        return dx, dw, None
+
+
+class FusedRMSNorm(nn.Module):
+
+    def __init__(self, normalized_shape, eps=1e-06):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(normalized_shape))
+        self.epsilon = eps
+
+    def forward(self, x):
+        return _RMSNorm.apply(x, self.weight, self.epsilon)
+
+    def init_weights(self, *args, **kwargs):
+        with torch.no_grad():
+            if self.weight is not None:
+                self.weight.fill_(1.0)
+


### PR DESCRIPTION
## What does this PR do?
RMSNorm is used in many popular models, e.g., [ChatGLM2](https://huggingface.co/THUDM/chatglm2-6b), [Baichuan](https://huggingface.co/baichuan-inc/Baichuan-13B-Base), Llama.

Made many duplicate codes with triton/k_layer_norm.py for clarity and a neat implementation. Would it be better if reorganizing LayerNorm and RMSNorm into a base class?

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
