### PR TITLE
[docs] blocksparse how-to update

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -230,7 +230,7 @@ dtype = torch.float16
 causal_mask = torch.tril(torch.ones((SEQ, SEQ), device=torch.device("cuda"), dtype=dtype))
 
 blocks = SEQ // BLOCK_SIZE
-causal_layout = torch.tril(torch.ones([HEADS, blocks, blocks]))
+causal_layout = torch.tril(torch.ones([HEADS, blocks, blocks])).long()
 
 # Let's build our blocksparse attention. Please note that the layout can be
 # [SEQ//BLOCK_SIZE, SEQ//BLOCK_SIZE] or  [HEADS, SEQ//BLOCK_SIZE, SEQ//BLOCK_SIZE]
@@ -256,7 +256,7 @@ multi_head = (
 query = torch.randn((BATCH, SEQ, EMB), requires_grad=True, device=torch.device("cuda"), dtype=dtype)
 
 # Self attention in this particular example, no limitations really
-att_val = multi_head(query=query, key=query, value=query, att_mask=causal_mask)
+att_val = multi_head(query=query, key=query, value=query)
 
 #########################################
 # Bonus: compare the memory use vs dense:
@@ -282,7 +282,7 @@ pytorch_multihead = torch.nn.MultiheadAttention(
     EMB, HEADS, batch_first=True, device=torch.device("cuda"), dtype=torch.float16
 )
 
-mem_use(multi_head, {"query": query, "key": query, "value": query, "att_mask": causal_mask}, "Blocksparse")
+mem_use(multi_head, {"query": query, "key": query, "value": query}, "Blocksparse")
 mem_use(pytorch_multihead, {"query": query, "key": query, "value": query, "attn_mask": causal_mask}, "PyTorch")
 ```
 


### PR DESCRIPTION
## What does this PR do?

Updates the code snippets in the [Blocksparse section in the HOWTO.md](https://github.com/facebookresearch/xformers/blob/main/HOWTO.md#blocksparseattention). In its current state, the tutorial runs into a couple of errors - 
1. The `causal_layout` needs to be a different type (int/long). Traceback - 
```
  File "/home/ubuntu/repos/sparse-attn-synthesizer/tests/test_xformer.py", line 60, in <module>
    att_val = multi_head(query=query, key=query, value=query)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/xformers/components/multi_head_dispatch.py", line 246, in forward
    y = self.attention(q, k, v, **kw_mask_args)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/xformers/components/attention/blocksparse.py", line 156, in forward
    self.create_triton_kernels(q.device)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/xformers/components/attention/blocksparse.py", line 110, in create_triton_kernels
    self.sparse_dot_sdd = blocksparse_matmul(
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/triton/ops/blocksparse/matmul.py", line 418, in __init__
    self.da_lut, self.da_width = dsd_lut(layout, block, step, True, device)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/triton/ops/blocksparse/matmul.py", line 295, in dsd_lut
    B_incs[offsets[segments > 0], 0] = B_idx[offsets[segments > 0]]
IndexError: tensors used as indices must be long, int, byte or bool tensors
```

2. The `BlockSparseAttention` class no longer supports an attention mask. Traceback -
```Traceback (most recent call last):
  File "/home/ubuntu/repos/sparse-attn-synthesizer/tests/test_xformer.py", line 59, in <module>
    att_val = multi_head(query=query, key=query, value=query, att_mask=causal_mask)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/ubuntu/miniconda3/envs/sparse/lib/python3.10/site-packages/xformers/components/multi_head_dispatch.py", line 193, in forward
    assert (
AssertionError: This attention does not support attention masks
```

I have updated the `causal_layout` type and removed the `att_mask` arg getting passed to the attention class init. 

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
