### PR TITLE
Fix conda build

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -118,7 +118,6 @@ jobs:
           git config --global --add safe.directory "*"
           $PY -m pip install packaging
           version=`$PY packaging/compute_wheel_version.py`
-          echo $version > version.txt
           echo "BUILD_VERSION=$version" >> ${GITHUB_ENV}
           cat ${GITHUB_ENV}
       - name: Build & store/upload

--- a/packaging/compute_wheel_version.py
+++ b/packaging/compute_wheel_version.py
@@ -30,6 +30,7 @@ def get_tagged_version() -> Optional[str]:
 
 
 def get_dev_version() -> str:
+    assert ".dev" not in version_from_file
     num_commits = subprocess.check_output(
         ["git", "rev-list", "--count", "HEAD"], text=True
     ).strip()


### PR DESCRIPTION
We had this error because the version was defined twice:
```
Invalid version: '0.0.23.dev661.dev661+git.fbbfb38'.
```