### PR TITLE
Fix the compilation error of XFORMERS_CHECK when PyTorch is not installed

### DIFF
--- a/xformers/csrc/attention/cuda/fmha/gemm_kernel_utils.h
+++ b/xformers/csrc/attention/cuda/fmha/gemm_kernel_utils.h
@@ -94,7 +94,7 @@
 
 template <typename... Args>
 void print_check_args(const Args&... args) {
-  (std::cout << ... << args) << std::endl;
+  (std::cerr << ... << args) << std::endl;
 }
 
 #define XFORMERS_CHECK(COND, ...)        \

--- a/xformers/csrc/attention/cuda/fmha/gemm_kernel_utils.h
+++ b/xformers/csrc/attention/cuda/fmha/gemm_kernel_utils.h
@@ -91,10 +91,17 @@
     std::cerr << #PTR " is not correctly aligned\n"; \
     return false;                                    \
   }
-#define XFORMERS_CHECK(COND, ERR)                       \
-  if (!(COND)) {                                        \
-    std::cerr << "'" #COND "' failed: " << ERR << "\n"; \
-    return false;                                       \
+
+template <typename... Args>
+void print_check_args(const Args&... args) {
+  (std::cout << ... << args) << std::endl;
+}
+
+#define XFORMERS_CHECK(COND, ...)        \
+  if (!(COND)) {                         \
+    std::cerr << "'" #COND "' failed: "; \
+    print_check_args(__VA_ARGS__);       \
+    return false;                        \
   }
 #endif
 


### PR DESCRIPTION
## What does this PR do?
Fix the compilation error of XFORMERS_CHECK when PyTorch is not installed

XFORMERS_CHECK can accept multiple arguments, but when PyTorch is not installed, that is, when the TORCH_CHECK macro is not defined, XFORMERS_CHECK has only one ERR argument, which leads to a compilation error. This PR uses fold expressions to support situations with multiple arguments.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
