### PR TITLE
Decouple the kernel_forward.h/kernel_backward.h from PyTorch Dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,6 @@ def get_extensions():
         sources += source_cuda
         include_dirs += [sputnik_dir, cutlass_dir, cutlass_examples_dir]
         nvcc_flags = [
-            "-DHAS_PYTORCH",
             "--use_fast_math",
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",

--- a/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
@@ -309,7 +309,6 @@ mem_efficient_attention_backward_cutlass(
     }
 
     if (use_dropout) {
-      p.rng_engine_inputs = rng_engine_inputs;
       p.dropout_prob = dropout_p;
       p.dropout_philox_seed = rng_seed;
       p.dropout_philox_offset = rng_offset;

--- a/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
@@ -152,7 +152,6 @@ mem_efficient_attention_backward_cutlass(
   at::Tensor workspace;
 
   const bool use_dropout = std::fpclassify(dropout_p) != FP_ZERO;
-  at::PhiloxCudaState rng_engine_inputs(rng_seed, rng_offset);
 
   cudaDeviceProp* p = at::cuda::getDeviceProperties(query.device().index());
   const int computeCapability = p->major * 10 + p->minor;
@@ -312,6 +311,8 @@ mem_efficient_attention_backward_cutlass(
     if (use_dropout) {
       p.rng_engine_inputs = rng_engine_inputs;
       p.dropout_prob = dropout_p;
+      p.dropout_philox_seed = rng_seed;
+      p.dropout_philox_offset = rng_offset;
     }
 
     // Heuristic for finding optimal number of splits

--- a/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_backward_generic.cu
@@ -310,8 +310,8 @@ mem_efficient_attention_backward_cutlass(
 
     if (use_dropout) {
       p.dropout_prob = dropout_p;
-      p.dropout_philox_seed = rng_seed;
-      p.dropout_philox_offset = rng_offset;
+      p.dropout_rng_seed = rng_seed;
+      p.dropout_rng_offset = rng_offset;
     }
 
     // Heuristic for finding optimal number of splits

--- a/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
@@ -265,9 +265,8 @@ efficient_attention_forward_cutlass(
 
     p.use_dropout = use_dropout;
     if (p.use_dropout) {
-      p.rng_engine_inputs = rng_engine_inputs;
       p.dropout_prob = dropout_p;
-      auto seeds = at::cuda::philox::unpack(p.rng_engine_inputs);
+      const auto seeds = at::cuda::philox::unpack(rng_engine_inputs);
       p.dropout_philox_seed = std::get<0>(seeds);
       p.dropout_philox_offset = std::get<1>(seeds);
     }

--- a/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
@@ -267,6 +267,9 @@ efficient_attention_forward_cutlass(
     if (p.use_dropout) {
       p.rng_engine_inputs = rng_engine_inputs;
       p.dropout_prob = dropout_p;
+      auto seeds = at::cuda::philox::unpack(p.rng_engine_inputs);
+      p.dropout_philox_seed = std::get<0>(seeds);
+      p.dropout_philox_offset = std::get<1>(seeds);
     }
 
     if (smem_bytes > 0xc000) {

--- a/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
@@ -266,9 +266,8 @@ efficient_attention_forward_cutlass(
     p.use_dropout = use_dropout;
     if (p.use_dropout) {
       p.dropout_prob = dropout_p;
-      const auto seeds = at::cuda::philox::unpack(rng_engine_inputs);
-      p.dropout_philox_seed = std::get<0>(seeds);
-      p.dropout_philox_offset = std::get<1>(seeds);
+      p.dropout_philox_seed = rng_engine_inputs.seed_;
+      p.dropout_philox_offset = rng_engine_inputs.offset_.val;
     }
 
     if (smem_bytes > 0xc000) {

--- a/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
+++ b/xformers/csrc/attention/cuda/fmha/attention_forward_generic.cu
@@ -266,8 +266,8 @@ efficient_attention_forward_cutlass(
     p.use_dropout = use_dropout;
     if (p.use_dropout) {
       p.dropout_prob = dropout_p;
-      p.dropout_philox_seed = rng_engine_inputs.seed_;
-      p.dropout_philox_offset = rng_engine_inputs.offset_.val;
+      p.dropout_rng_seed = rng_engine_inputs.seed_.val;
+      p.dropout_rng_offset = rng_engine_inputs.offset_.val;
     }
 
     if (smem_bytes > 0xc000) {

--- a/xformers/csrc/attention/cuda/fmha/kernel_backward.h
+++ b/xformers/csrc/attention/cuda/fmha/kernel_backward.h
@@ -667,8 +667,8 @@ struct AttentionBackwardKernel {
     int32_t gB_strideM = -1;
     int8_t gQKV_strideM_multiplier = 1; // 3 for packed, 1 otherwise
 
-    uint64_t dropout_philox_seed = 0;
-    uint64_t dropout_philox_offset = 0;
+    uint64_t dropout_rng_seed = 0;
+    uint64_t dropout_rng_offset = 0;
 
     // RNG sequence offset based on batch_id and head_id
     unsigned long long dropout_batch_head_rng_offset = 0;
@@ -1330,9 +1330,9 @@ struct AttentionBackwardKernel {
       // rather than once per iteration. each iteration takes a copy of the
       // initialized RNG state and offsets it as needed.
       curand_init(
-          p.dropout_philox_seed,
+          p.dropout_rng_seed,
           0,
-          p.dropout_philox_offset + p.dropout_batch_head_rng_offset,
+          p.dropout_rng_offset + p.dropout_batch_head_rng_offset,
           &rng_state_init);
     }
 

--- a/xformers/csrc/attention/cuda/fmha/kernel_forward.h
+++ b/xformers/csrc/attention/cuda/fmha/kernel_forward.h
@@ -201,8 +201,8 @@ struct AttentionKernel {
     unsigned long long dropout_batch_head_rng_offset = 0;
     float dropout_prob = 0.0f;
 
-    uint64_t dropout_philox_seed = 0;
-    uint64_t dropout_philox_offset = 0;
+    uint64_t dropout_rng_seed = 0;
+    uint64_t dropout_rng_offset = 0;
 
     // Moves pointers to what we should process
     // Returns "false" if there is no work to do
@@ -692,9 +692,9 @@ struct AttentionKernel {
       // rather than once per iteration. each iteration takes a copy of the
       // initialized RNG state and offsets it as needed.
       curand_init(
-          p.dropout_philox_seed,
+          p.dropout_rng_seed,
           0,
-          p.dropout_philox_offset + p.dropout_batch_head_rng_offset,
+          p.dropout_rng_offset + p.dropout_batch_head_rng_offset,
           &curand_state_init);
     }
 


### PR DESCRIPTION
## What does this PR do?
Currently, the Attention Dropout feature relies on some PyTorch functions, and the HAS_PYTORCH macro is used in the kernel_forward.h/kernel_backward.h files to indicate whether there is a PyTorch environment. If not, the Dropout feature cannot be used.
At present, the ***generic.cu files generate seed and offset using PhiloxCudaState, while the kernel_forward.h/kernel_backward.h obtain seed and offset through the unpack function.
Perhaps we can directly place the offset and seed in the Kernel::Params parameters to avoid the dependency on PyTorch in the kernel_forward.h/kernel_backward.h.

Background:
I would like to port the Attention implementation from XFormers to a framework other than PyTorch. Based on this PR, I only need to adapt to other frameworks according to the attention_*_generic.cu files, as the kernel_forward.h and kernel_backward.h files are framework-agnostic and no further modifications to other files are required.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
