### PR TITLE
Try fix ck decoder compilation in fbcode (2/n)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -377,6 +377,8 @@ def get_extensions():
                 "-U__CUDA_NO_HALF_CONVERSIONS__",
                 "-DCK_FMHA_FWD_FAST_EXP2=1",
                 "-fgpu-flush-denormals-to-zero",
+                "-Werror",
+                "-Woverloaded-virtual",
             ]
             + generator_flag
             + cc_flag,

--- a/xformers/csrc/attention/hip_fmha/attention_forward_decoder.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_decoder.cpp
@@ -149,7 +149,7 @@ at::Tensor& efficient_attention_forward_decoder_ck_out_impl(
             lds_bytes);
 
         auto invoker = device_op_t::Invoker{};
-        (void)invoker.Run(arg, {stream});
+        (void)invoker.Run(&arg, {stream});
       });
 
   return O;

--- a/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
@@ -159,7 +159,7 @@ at::Tensor& efficient_attention_forward_decoder_splitk_ck_out_impl(
             lds_bytes);
 
         auto invoker = device_op_t::Invoker{};
-        (void)invoker.Run(arg, {stream});
+        (void)invoker.Run(&arg, {stream});
       });
 
   return O;

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
@@ -432,9 +432,11 @@ struct FMHADecoderSeqlen1DeviceOp : public BaseOperator {
 
   struct Invoker : public BaseInvoker {
     using Argument = DeviceOp::Argument;
-    float Run(
-        const Argument& arg,
-        const StreamConfig& stream_config = StreamConfig{}) {
+    virtual float Run(
+        const BaseArgument* base_arg,
+        const StreamConfig& stream_config = StreamConfig{}) override {
+      // copy so it's alive while being used
+      auto arg = *dynamic_cast<const Argument*>(base_arg);
       auto threads_per_wavefront = arg.block_dim.x;
 
       auto Q_size_k_alignment_necessary = 0;

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
@@ -6,7 +6,7 @@
  */
 #pragma once
 
-#include <ck/host_utility/kernel_launch_hip.hpp>
+#include <ck/host_utility/kernel_launch.hpp>
 #include <ck/stream_config.hpp>
 #include <ck/tensor_operation/gpu/device/device_base.hpp>
 #include <ck/utility/data_type.hpp>

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
@@ -586,9 +586,12 @@ struct FMHADecoderSplitKDeviceOp : public BaseOperator {
 
   struct Invoker : public BaseInvoker {
     using Argument = DeviceOp::Argument;
-    float Run(
-        const Argument& arg,
-        const StreamConfig& stream_config = StreamConfig{}) {
+    virtual float Run(
+        const BaseArgument* base_arg,
+        const StreamConfig& stream_config = StreamConfig{}) override {
+      // copy so it's alive while being used
+      auto arg = *dynamic_cast<const Argument*>(base_arg);
+
       auto threads_per_wavefront = arg.block_dim.x;
       auto Q_size_k_alignment_necessary = 0;
 

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <ck/host_utility/kernel_launch_hip.hpp>
+#include <ck/host_utility/kernel_launch.hpp>
 #include <ck/stream_config.hpp>
 #include <ck/tensor_operation/gpu/device/device_base.hpp>
 #include <ck/utility/data_type.hpp>


### PR DESCRIPTION
## What does this PR do?
Fixes compilation error in cpp extensions for decoder and splitk decoder.
A few issues were fixed
* fbcode has `-Werror` flag enabled, but OSS did not
* the kernel wrapper definitions hid the virtual functions defined at base invoker
* while hiding, the signature was also changed, so I had to add an extra casting step to make the compiler happy
* while testing the change I got spurious accuracy errors, which I got rid of by copying the args struct instead of using a reference, as it's allocated on stack somewhere and the existing way is not safe
## Test plan

`# pytest /xformers/tests/test_mem_eff_attention.py -k decoder` (a few times)


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
cc @jianyuh @qianfengz 