### PR TITLE
[fix] benchmark shows 0.00MB consumed

### DIFF
--- a/xformers/benchmarks/utils.py
+++ b/xformers/benchmarks/utils.py
@@ -530,31 +530,37 @@ def benchmark_run_and_compare(
 
         name = None
         try:
-            for benchmark_object in benchmarks_generator:
-                is_optimized = (
-                    benchmark_object._task_spec.description not in BASELINE_DESCRIPTIONS
-                )
-                metadata = {}
-                if is_optimized:
-                    metadata[META_ALGORITHM] = benchmark_object._task_spec.description
-                    benchmark_object._task_spec = replace(
-                        benchmark_object._task_spec, description=optimized_label
-                    )
-                elif (
-                    omit_baselines
-                    or (
-                        benchmark_object._task_spec.sub_label,
-                        benchmark_object._task_spec.num_threads,
-                    )
-                    in skip_vanilla_tasks
-                ):
-                    continue
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats()
+            mem_begin = torch.cuda.max_memory_allocated() / 2**20
 
+            for benchmark_object in benchmarks_generator:
                 memory = math.inf
                 try:
+
+                    is_optimized = (
+                        benchmark_object._task_spec.description
+                        not in BASELINE_DESCRIPTIONS
+                    )
+                    metadata = {}
+                    if is_optimized:
+                        metadata[
+                            META_ALGORITHM
+                        ] = benchmark_object._task_spec.description
+                        benchmark_object._task_spec = replace(
+                            benchmark_object._task_spec, description=optimized_label
+                        )
+                    elif (
+                        omit_baselines
+                        or (
+                            benchmark_object._task_spec.sub_label,
+                            benchmark_object._task_spec.num_threads,
+                        )
+                        in skip_vanilla_tasks
+                    ):
+                        continue
+
                     torch.cuda.synchronize()
-                    torch.cuda.reset_peak_memory_stats()
-                    mem_begin = torch.cuda.max_memory_allocated() / 2**20
                     benchmark_object._task_spec = replace(
                         benchmark_object._task_spec, env=env
                     )
@@ -566,6 +572,9 @@ def benchmark_run_and_compare(
                     name = measurement.task_spec.description
                     memory = torch.cuda.max_memory_allocated() / 2**20 - mem_begin
                     measurement.mem_use = memory
+
+                    torch.cuda.reset_peak_memory_stats()
+                    mem_begin = torch.cuda.max_memory_allocated() / 2**20
                 except RuntimeError as e:
                     if not _is_oom_error(e):
                         raise


### PR DESCRIPTION
## What does this PR do?
Fixes bugs: when run pytest, the memory consumption printed is 0.00MB.
This is because class creation (also weight creation) happens in `benchmarks_generator`. Which is outside the `torch.cuda.reset_peak_memory_stats()` and `torch.cuda.max_memory_allocated()` block.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
