### PR TITLE
Change workspace size in fmha backward

### DIFF
--- a/xformers/csrc/attention/cuda/fmha/kernel_backward.h
+++ b/xformers/csrc/attention/cuda/fmha/kernel_backward.h
@@ -859,14 +859,14 @@ struct AttentionBackwardKernel {
       if (!kNeedsAccumGradK) {
         return 0;
       }
-      return num_splits_key * align_up(num_keys, (int32_t)kBlockSizeJ) *
+      return num_splits_key * kBlockSizeJ *
           align_up(head_dim, (int32_t)kBlockSizeI);
     }
     CUTLASS_HOST_DEVICE int64_t workspace_elements_gv() const {
       if (!kNeedsAccumGradV) {
         return 0;
       }
-      return num_splits_key * align_up(num_keys, (int32_t)kBlockSizeJ) *
+      return num_splits_key * kBlockSizeJ *
           align_up(head_dim_value, (int32_t)kBlockSizeI);
     }
     CUTLASS_HOST_DEVICE int64_t workspace_elements_gq() const {


### PR DESCRIPTION
## What does this PR do?
TLDR; I think the FMHA backward kernel uses more scratch memory than it needs, aside from padding due to 128-bit alignment and tile sizes.

FMHA backward's scratch space for gK and gV is set up to be: [num_k_splits * align_up(num_keys, kBlockSizeJ) * align_up(dim, kBlockSizeI)](https://github.com/facebookresearch/xformers/blob/main/xformers/csrc/attention/cuda/fmha/kernel_backward.h#L858-L871) repeated over batch and heads.

Given that each CTA computes unique tiles of gK and gV, this means for every gK/gV tile, `align_up(num_keys, kBlockSizeJ) * align_up(dim, kBlockSizeI)` accum elements are reserved.

I might be totally off, but my understanding is that the gK and gV accumulator pointers aren't even offset by something relating to key_start, which means the same `kBlockSizeJ` rows will be reused over an over.

This means that `align_up(num_keys, kBlockSizeJ)` can be replaced with just `kBlockSizeJ`.

My own use case works fine and passes a memcheck with this change. All unit tests passed for me locally (excluding the recent torch.compile test in test_mem_eff_attention; I think I need to be on torch nightly?).

Kernel archtags tested:
- [x] SM50
  - [x] SM61
- [ ] SM70
- [x] SM75
- [x] SM80:
  - [x] SM80
  - [x] SM86

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

@danthe3rd 
