### PR TITLE
update get_split_k to fix a performance regression on FA decode

### DIFF
--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -35,7 +35,7 @@ CASES = [
     # for hkv in (1, 2)
 ] + [
     # dict(B=i, Mq=1, Mkv=8448, Hq=8, Hkv=1, K=128, attn_bias_type=xops.fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask) for i in [2, 4, 8, 16, 32, 64] 
-    dict(B=i, Mq=1, Mkv=4161, Hq=8, Hkv=2, K=128, attn_bias_type=None) for i in [2, 4]
+    dict(B=i, Mq=1, Mkv=4097, Hq=8, Hkv=2, K=128, attn_bias_type=None) for i in [2, 4, 8, 16, 32, 64, 128]
 ]
 
 
@@ -296,19 +296,19 @@ if torch.version.cuda:
     BENCHMARKS["decoder"] = AttentionDecodingDecoder
     BENCHMARKS["cutlass"] = AttentionDecodingCUTLASS
 
-if torch.version.hip:
-    BENCHMARKS.update(
-        {
-            "ck": AttentionDecodingCK,
-            "ck-decoder": AttentionDecodingCKDecoder,
-            "ck_splitK": AttentionDecodingCKSplitKV,
-        }
-    )
+# if torch.version.hip:
+#     BENCHMARKS.update(
+#         {
+#             "ck": AttentionDecodingCK,
+#             "ck-decoder": AttentionDecodingCKDecoder,
+#             "ck_splitK": AttentionDecodingCKSplitKV,
+#         }
+#     )
 
 
 if (sys.version_info.major, sys.version_info.minor) >= (3, 9):
     BENCHMARKS["triton_splitK"] = AttentionDecodingSplitKV
-    BENCHMARKS["triton_int4KV"] = AttentionDecodingSplitInt4KV
+    # BENCHMARKS["triton_int4KV"] = AttentionDecodingSplitInt4KV
 
 try:
     import flash_attn

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -344,16 +344,18 @@ TEST_CASES = [
     dict(B=i, Mq=1, Mkv=4097, Hq=8, Hkv=1, K=128, attn_bias_type=None) for i in [2, 4, 8, 16, 32, 64, 128]
 ]
 
+
 def get_benchmark_names():
     decoder_names = list(BENCHMARKS.keys())
     decoder_names.remove("pytorch")
     return decoder_names
 
+
 # tests to verify correctness of each decoder implementation
 @pytest.mark.parametrize("name, case", [(name, case) for name in get_benchmark_names() for case in TEST_CASES])
 def test_flash_attention_decoder(name, case):
     baseline = AttentionDecodingPyTorchRepeat(case["B"], case["Mq"], case["Mkv"], case["Hq"],
-                                                case["Hkv"], case["K"], False, case["attn_bias_type"])
+                                              case["Hkv"], case["K"], False, case["attn_bias_type"])
     if name == "ck-decoder" and case["Mkv"] >= 2**14:
         pytest.skip("ck-decoder does not support Mkv >= 16K")
 
@@ -362,7 +364,7 @@ def test_flash_attention_decoder(name, case):
     decoder = BENCHMARKS[name]
 
     assert name in ["ck-decoder", "ck_splitK", "ck", "triton_splitK", "triton_int4KV"]
-    decoder_output,ctx = decoder.OP.apply(inputs, False)
+    decoder_output, ctx = decoder.OP.apply(inputs, False)
 
     q, k, v = inputs.get_qkv_in_bmghk()
     B, M, G, H, Kq = q.shape
@@ -377,6 +379,7 @@ def test_flash_attention_decoder(name, case):
     decoder_output = decoder_output.transpose(2, 1).contiguous()
     torch.testing.assert_close(decoder_output, baseline_out, atol=1e-2, rtol=0)
 
+
 # run benchmark performance
 if __name__ == "__main__":
     benchmark_main_helper2(
@@ -386,4 +389,3 @@ if __name__ == "__main__":
         functions=BENCHMARKS,
         min_run_time=min_run_time,
     )
-

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -35,7 +35,7 @@ CASES = [
     # for hkv in (1, 2)
 ] + [
     # dict(B=i, Mq=1, Mkv=8448, Hq=8, Hkv=1, K=128, attn_bias_type=xops.fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask) for i in [2, 4, 8, 16, 32, 64] 
-    dict(B=i, Mq=1, Mkv=4097, Hq=8, Hkv=2, K=128, attn_bias_type=None) for i in [2, 4, 8, 16, 32, 64, 128]
+    dict(B=i, Mq=1, Mkv=4097, Hq=8, Hkv=1, K=128, attn_bias_type=None) for i in [2, 4, 8, 16, 32, 64, 128]
 ]
 
 
@@ -347,7 +347,8 @@ def test_flash_attention_decoder(name, case):
     assert name in ["ck-decoder", "ck_splitK", "ck", "triton_splitK", "triton_int4KV"]
     decoder_output,ctx = decoder.OP.apply(baseline.get_inputs(), False)
     s = decoder_output.shape
-    decoder_output = decoder_output.reshape([s[0], s[1], -1, s[4]])
+    if name in ["ck-decoder", "ck_splitK"]:
+        decoder_output = decoder_output.reshape([s[0], s[1], -1, s[4]])
     decoder_output = decoder_output.transpose(2, 1).contiguous()
 
     torch.testing.assert_close(decoder_output, baseline_out, atol=1e-3, rtol=0)

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -320,9 +320,9 @@ try:
                 v = v[:, :, :, 0]
             return flash_attn.flash_attn_func(q, k, v)
 
-    BENCHMARKS[
-        f"flash-attention@{flash_attn.__version__}"
-    ] = AttentionDecodingFlashAttention
+    BENCHMARKS[f"flash-attention@{flash_attn.__version__}"] = (
+        AttentionDecodingFlashAttention
+    )
 except ImportError:
     pass
 
@@ -340,7 +340,8 @@ TEST_CASES = [
     for i in range(8, 18)
     for hkv in range(1, 3)
 ] + [
-    dict(B=i, Mq=1, Mkv=4097, Hq=8, Hkv=1, K=128, attn_bias_type=None) for i in [2, 4, 8, 16, 32, 64, 128]
+    dict(B=i, Mq=1, Mkv=4097, Hq=8, Hkv=1, K=128, attn_bias_type=None)
+    for i in [2, 4, 8, 16, 32, 64, 128]
 ]
 
 
@@ -351,10 +352,21 @@ def get_benchmark_names():
 
 
 # tests to verify correctness of each decoder implementation
-@pytest.mark.parametrize("name, case", [(name, case) for name in get_benchmark_names() for case in TEST_CASES])
+@pytest.mark.parametrize(
+    "name, case",
+    [(name, case) for name in get_benchmark_names() for case in TEST_CASES],
+)
 def test_flash_attention_decoder(name, case):
-    baseline = AttentionDecodingPyTorchRepeat(case["B"], case["Mq"], case["Mkv"], case["Hq"],
-                                              case["Hkv"], case["K"], False, case["attn_bias_type"])
+    baseline = AttentionDecodingPyTorchRepeat(
+        case["B"],
+        case["Mq"],
+        case["Mkv"],
+        case["Hq"],
+        case["Hkv"],
+        case["K"],
+        False,
+        case["attn_bias_type"],
+    )
     if name == "ck-decoder" and case["Mkv"] >= 2**14:
         pytest.skip("ck-decoder does not support Mkv >= 16K")
 
@@ -371,7 +383,9 @@ def test_flash_attention_decoder(name, case):
     if k.shape[3] > 1 and k.stride(3) == 0 and v.stride(3) == 0:
         mqa_swap_seqlen_head = True
     if mqa_swap_seqlen_head:
-        decoder_output = decoder_output.reshape(B, -1, M, Kq).transpose(1, 2).contiguous()
+        decoder_output = (
+            decoder_output.reshape(B, -1, M, Kq).transpose(1, 2).contiguous()
+        )
     else:
         decoder_output = decoder_output.reshape(B, H * G, -1, Kq).contiguous()
 

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -320,9 +320,9 @@ try:
                 v = v[:, :, :, 0]
             return flash_attn.flash_attn_func(q, k, v)
 
-    BENCHMARKS[f"flash-attention@{flash_attn.__version__}"] = (
-        AttentionDecodingFlashAttention
-    )
+    BENCHMARKS[
+        f"flash-attention@{flash_attn.__version__}"
+    ] = AttentionDecodingFlashAttention
 except ImportError:
     pass
 

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -29,7 +29,7 @@ CASES = [
         Hq=16,
         Hkv=hkv,
         K=128,
-        attn_bias_type=None,
+        attn_bias_type=xops.fmha.attn_bias.BlockDiagonalCausalWithOffsetPaddedKeysMask,
     )
     for i in range(8, 18)
     for hkv in (1, 2)

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -9,13 +9,12 @@
 import sys
 from typing import Any, Dict, Type
 
+import pytest
 import torch
 
 import xformers.ops as xops
 from xformers.attn_bias_utils import create_attn_bias
 from xformers.benchmarks.utils import NotSupportedInputError, benchmark_main_helper2
-
-import pytest
 
 min_run_time = 0.5
 device = torch.device("cuda")

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -638,7 +638,7 @@ if TYPE_CHECKING or _has_triton21():
             x_[:, :, None, :] >> offsets
         )  # (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
 
-        quant_offset = tl.reshape(
+        quant_offset = tl.view(
             quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
         )
         # Trick - instead of converting int4 to float16 we view it as float16

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1336,11 +1336,6 @@ class FwOp(AttentionFwOpBase):
             return triton.cdiv(M, META["BLOCK_M"]), B * G * H, split_k
 
         split_size = (Mk + split_k - 1) // split_k
-        
-        # # align split_size to the multiple of 64
-        # split_size = (split_size + cls.BLOCK_N) // cls.BLOCK_N * cls.BLOCK_N
-        print(f"split_k = {split_k}, split_size = {split_size}, num_tiles = {B * G * H * split_k}")
-
         use_seq_len = seq_len is not None
 
         num_groups = cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1196,6 +1196,7 @@ class FwOp(AttentionFwOpBase):
 
         split_k = min(split_k, split_k_upper_bound)
         split_k = max(split_k, 1)
+        
         return split_k
 
     @classmethod

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1172,7 +1172,10 @@ class FwOp(AttentionFwOpBase):
         split_k = max(Mk, 1024) // bh
         if torch.version.hip:
             max_chunk_size = 64
-            split_k_stop_val = min(Mk / max_chunk_size, 1024 / (B * G * H))
+            split_k_stop_val = 1024 / (B * G * H)
+            while split_k > 0 and Mk / (split_k - 1) < max_chunk_size:
+                split_k = split_k - 1
+
             split_k_upper_bound = 512
         else:
             max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1181,9 +1181,13 @@ class FwOp(AttentionFwOpBase):
                 split_k = split_k // 2
 
             split_size = (Mk + split_k - 1) // split_k
+
             chunk_size = split_size // max_chunk_size * max_chunk_size
             if chunk_size < split_size:
                 split_k += 1
+
+            # split_size = (split_size + max_chunk_size - 1) // max_chunk_size * max_chunk_size
+            # split_k = (Mk + split_size - 1) // split_size
 
             split_k_upper_bound = 512
         else:
@@ -1339,6 +1343,7 @@ class FwOp(AttentionFwOpBase):
         
         # align split_size to the multiple of 64
         split_size = (split_size + 63) // 64 * 64
+        print(f"split_k = {split_k}, split_size = {split_size}, num_tiles = {B * G * H * split_k}")
 
         use_seq_len = seq_len is not None
 

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -638,7 +638,7 @@ if TYPE_CHECKING or _has_triton21():
             x_[:, :, None, :] >> offsets
         )  # (BLOCK_N, D // PACKED_PER_VAL, PACKED_PER_VAL)
 
-        quant_offset = tl.view(
+        quant_offset = tl.reshape(
             quant_offset, (BLOCK_N, BLOCK_DMODEL_PACKED * PACKED_PER_VAL)
         )
         # Trick - instead of converting int4 to float16 we view it as float16

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1335,6 +1335,10 @@ class FwOp(AttentionFwOpBase):
             return triton.cdiv(M, META["BLOCK_M"]), B * G * H, split_k
 
         split_size = (Mk + split_k - 1) // split_k
+        
+        # align split_size to the multiple of 64
+        split_size = (split_size + 63) // 64 * 64
+
         use_seq_len = seq_len is not None
 
         num_groups = cls.NUM_GROUPS if PACKED_PER_VAL > 1 else 1

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1173,7 +1173,7 @@ class FwOp(AttentionFwOpBase):
             split_k = max(Mk + bh - 1, 1024) // bh
             max_chunk_size = 64
             split_k_stop_val = 1024 / (B * G * H)
-            while split_k > 0 and Mk / (split_k - 1) < max_chunk_size:
+            while split_k > 1 and Mk / (split_k - 1) < max_chunk_size:
                 split_k = split_k - 1
 
             while split_k > split_k_stop_val:

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1169,8 +1169,8 @@ class FwOp(AttentionFwOpBase):
     def get_split_k(cls, B: int, G: int, H: int, Mk: int) -> int:
         """Heuristic for the number of splits"""
         bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
-        split_k = max(Mk + bh - 1, 1024) // bh
         if torch.version.hip:
+            split_k = max(Mk + bh - 1, 1024) // bh
             max_chunk_size = 64
             split_k_stop_val = 1024 / (B * G * H)
             while split_k > 0 and Mk / (split_k - 1) < max_chunk_size:
@@ -1187,6 +1187,7 @@ class FwOp(AttentionFwOpBase):
 
             split_k_upper_bound = 512
         else:
+            split_k = max(Mk, 1024) // bh
             max_chunk_size = 64 if Mk <= 512 and bh <= 64 else 128
             split_k_stop_val = Mk / max_chunk_size
             split_k_upper_bound = 64

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1168,7 +1168,6 @@ class FwOp(AttentionFwOpBase):
     @classmethod
     def get_split_k(cls, B: int, G: int, H: int, Mk: int) -> int:
         """Heuristic for the number of splits"""
-        print(f"B = {B}, G = {G}, H = {H}, Mk = {Mk}")
         bh = max(B * H, 1)  # NOTE: Handle B*h=0 case
         split_k = max(Mk + bh - 1, 1024) // bh
         if torch.version.hip:
@@ -1185,9 +1184,6 @@ class FwOp(AttentionFwOpBase):
             chunk_size = split_size // max_chunk_size * max_chunk_size
             if chunk_size < split_size:
                 split_k += 1
-
-            # split_size = (split_size + max_chunk_size - 1) // max_chunk_size * max_chunk_size
-            # split_k = (Mk + split_size - 1) // split_size
 
             split_k_upper_bound = 512
         else:
@@ -1341,8 +1337,8 @@ class FwOp(AttentionFwOpBase):
 
         split_size = (Mk + split_k - 1) // split_k
         
-        # align split_size to the multiple of 64
-        split_size = (split_size + 63) // 64 * 64
+        # # align split_size to the multiple of 64
+        # split_size = (split_size + cls.BLOCK_N) // cls.BLOCK_N * cls.BLOCK_N
         print(f"split_k = {split_k}, split_size = {split_size}, num_tiles = {B * G * H * split_k}")
 
         use_seq_len = seq_len is not None

--- a/xformers/ops/fmha/triton_splitk.py
+++ b/xformers/ops/fmha/triton_splitk.py
@@ -1196,7 +1196,7 @@ class FwOp(AttentionFwOpBase):
 
         split_k = min(split_k, split_k_upper_bound)
         split_k = max(split_k, 1)
-        
+
         return split_k
 
     @classmethod


### PR DESCRIPTION
## What does this PR do?
Fixes a performance regress for FA decode. Changes are related to the function `get_split_k()`, which is to compute the number of splitK in the fa decode in Triton.

This PR also added a test to verify the correctness of different implementations of FA decoders, you can run the tests as:
`pytest benchmark_attn_decoding.py -v`

## Before submitting

- [x] Did you have fun?
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
