### PR TITLE
The original code directly disabled the support for fused swiglu, but pytorch2.0.0 has fixed the issue in autocast of bf16.

### DIFF
--- a/xformers/ops/swiglu_op.py
+++ b/xformers/ops/swiglu_op.py
@@ -188,7 +188,7 @@ class _ForwardToPythonAutogradFunc(SwiGLUOp):
     def supports(self, op: "SwiGLUOpDispatch") -> bool:
         # Let's disable autocast in bf16 until this issue is fixed
         # https://github.com/pytorch/pytorch/issues/87979
-        if op.dtype_autocast_gpu == torch.bfloat16:
+        if op.dtype_autocast_gpu == torch.bfloat16 and torch.__version__ < "2.0.0":
             return False
         return super().supports(op)
 

--- a/xformers/ops/swiglu_op.py
+++ b/xformers/ops/swiglu_op.py
@@ -186,10 +186,6 @@ class SwiGLUOp:
 
 class _ForwardToPythonAutogradFunc(SwiGLUOp):
     def supports(self, op: "SwiGLUOpDispatch") -> bool:
-        # Let's disable autocast in bf16 until this issue is fixed
-        # https://github.com/pytorch/pytorch/issues/87979
-        if op.dtype_autocast_gpu == torch.bfloat16 and torch.__version__ < "2.0.0":
-            return False
         return super().supports(op)
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
A small PR. This PR addresses the issue of disabling fused swiglu in swiglu_op.py. The original code directly disabled the support for fused swiglu, with the comment "Let's disable autocast in bf16 until this issue is fixed". After my testing, PyTorch 2.0.0 has already fixed this bug. Therefore, we should add a judgment for the PyTorch version, and then determine whether to support fused swiglu, instead of directly disabling swiglu as before. This makes it more user-friendly.