### PR TITLE
Enable support of seqlen_k == 0 for fmha forward

### DIFF
--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -76,7 +76,7 @@ struct batched_forward_causalmask_attnbias_dispatched {
           (MaxK == 64) ? 3 : ((MaxK == 256) ? 1 : 2);
 
       bool pad_seqlen_q = !(param.M % FmhaShape::kM0 == 0);
-      bool pad_seqlen_k = !(param.N % FmhaShape::kN0 == 0);
+      bool pad_seqlen_k = (param.N == 0) || !(param.N % FmhaShape::kN0 == 0);
       bool pad_headdim_q = !(param.K % FmhaShape::kK0BlockLength == 0);
       bool pad_headdim_v = !(param.Kv % FmhaShape::kN1 == 0);
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -76,7 +76,7 @@ struct batched_infer_causalmask_attnbias_dispatched {
           (MaxK == 64) ? 3 : ((MaxK == 256) ? 1 : 2);
 
       bool pad_seqlen_q = !(param.M % FmhaShape::kM0 == 0);
-      bool pad_seqlen_k = !(param.N % FmhaShape::kN0 == 0);
+      bool pad_seqlen_k = (param.N == 0) || !(param.N % FmhaShape::kN0 == 0);
       bool pad_headdim_v = !(param.Kv % FmhaShape::kN1 == 0);
       bool pad_headdim_q = !(param.K % FmhaShape::kK0BlockLength == 0);
 


### PR DESCRIPTION
Without the fixing,  `seqlen_k == 0` will lead to `NaN` in the fmha forward output.  

The following scripts can be used to verify the issue:

```bash
import torch
from xformers.ops import fmha


def main():
    xattn_q_seqlen=[1, 2, 1, 2]
    xattn_kv_seqlen=[0, 2, 0, 2]
    options = {
        'device': 'cuda',
        'dtype': torch.float16
    }
    axq = torch.randn((1, 6, 2, 68), **options)
    axk = torch.randn((1, 4, 2, 68), **options)
    axv = torch.randn((1, 4, 2, 68), **options)
    xattn_bias = fmha.attn_bias.BlockDiagonalMask.from_seqlens(
        q_seqlen=xattn_q_seqlen, kv_seqlen=xattn_kv_seqlen
    )

    print("seqstart_q:")
    print(xattn_bias.q_seqinfo.seqstart_py)
    print("seqstart_k:")
    print(xattn_bias.k_seqinfo.seqstart_py)

    print(f"{xattn_bias=}")
    y = fmha.memory_efficient_attention_forward(
        axq,
        axk,
        axv,
        attn_bias=xattn_bias,
        p=0.0,
        op=None,
    )
    print(f"@@@@@@@@@ {y.shape=} {y=}")
    # look for NaNs ^

if __name__ == "__main__":
    with torch.no_grad():
        main()
```