### PR TITLE
Updated FusedLinearLayer to FusedLinear in the triton tutorial page

### DIFF
--- a/docs/source/tutorials/triton.rst
+++ b/docs/source/tutorials/triton.rst
@@ -50,9 +50,9 @@ This is a drop-in replacement to two PyTorch operands: a `torch.nn.Linear`, and 
 
 .. code-block:: python
 
-    from xformers.triton import FusedLinearLayer
+    from xformers.triton import FusedLinear
 
-    my_linear_layer = FusedLinearLayer(in_features, out_features, bias=True/False, activation="squared_relu")
+    my_linear_layer = FusedLinear(in_features, out_features, bias=True/False, activation="squared_relu")
 
     ...
 


### PR DESCRIPTION
## What does this PR do?
Fixes issue #1055

The current documentation on triton fused linear layers used the wrong class name, FusedLinearLayer instead of FusedLinear, which is the name currently used in the module. This PR updates the docs to reflect the current name.