### PR TITLE
Remove _check_large_shapes checking in fmha/ck.py

### DIFF
--- a/xformers/ops/fmha/ck.py
+++ b/xformers/ops/fmha/ck.py
@@ -101,6 +101,7 @@ Example: use `attn_bias = torch.zeros([1, 1, 5, 8])[:,:,:,:5]` instead of `torch
                 "you should call `.contiguous()` on the bias"
             )
 
+
 class _CustomMaskType(int, Enum):
     """
     (Matches CustomMaskType in C++.)


### PR DESCRIPTION
It makes no sense to use `_check_large_shapes()` to add unintended restriction to the input sizes of the CK fmha fwd/bwd operator.  So just remove it. 