### PR TITLE
Add torch compile support for ck attention op

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -3312,7 +3312,6 @@ def _merge_attentions_ref(attn_split, lse_split):
 
 
 @sm80_or_better_only
-@skip_if_rocm  # rocm doesn't support backward yet
 @pytest.mark.parametrize(
     "bias_t",
     [None, fmha.attn_bias.LowerTriangularMask, fmha.attn_bias.BlockDiagonalMask],


### PR DESCRIPTION
## What does this PR do?
Add torch.compile support for CK ops , to avoid graph break in pt2 workflow.

From [D61453034](https://www.internalfb.com/diff/D61453034)

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
