### PR TITLE
Use weights_only for load

### DIFF
--- a/examples/llama_inference/generate.py
+++ b/examples/llama_inference/generate.py
@@ -78,7 +78,7 @@ class FastGen:
         torch.set_default_dtype(torch.bfloat16)
 
         model = fast.Transformer(model_args)
-        checkpoint = torch.load(ckpt_path, map_location="cpu")
+        checkpoint = torch.load(ckpt_path, map_location="cpu", weights_only=True)
         model.load_state_dict(checkpoint, strict=False)
         print(f"loaded model in {time.time() - start_time:.2f} seconds")
 


### PR DESCRIPTION
`torch.load` without `weights_only` parameter is unsafe. Explicitly set `weights_only` to False only if you trust the data you load and full pickle functionality is needed, otherwise set `weights_only=True`.

If `weights_only=True` doesn't work for some cases, then explicit `weights_only=False` should be used.

Found with https://github.com/pytorch-labs/torchfix/