### PR TITLE
[fix] Add back BlockDiagonalMask import

### DIFF
--- a/xformers/ops/fmha/__init__.py
+++ b/xformers/ops/fmha/__init__.py
@@ -17,7 +17,12 @@ from . import (
     flash3,
     triton_splitk,
 )
-from .attn_bias import VARLEN_BIASES, AttentionBias, LowerTriangularMask
+from .attn_bias import (
+    VARLEN_BIASES, 
+    AttentionBias, 
+    LowerTriangularMask, 
+    BlockDiagonalMask,
+)
 from .common import (
     AttentionBwOpBase,
     AttentionFwOpBase,
@@ -884,4 +889,5 @@ __all__ = [
     "attn_bias",
     "_get_use_fa3",
     "_set_use_fa3",
+    "BlockDiagonalMask",
 ]


### PR DESCRIPTION
It looks like BlockDiagonalMask import was accidentally removed in commit 166fd2e. This commit adds it back.

## What does this PR do?
Fixes # (issue).

## Before submitting

- [Yes] Did you have fun?
  - Make sure you had fun coding 🙃
- [Yes] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [No] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - I work at Meta; I discussed this change with xformer maintainer over chat.
- [No] Did you make sure to update the docs?
  - [V] N/A
- [No] Did you write any new necessary tests?
  - [V] N/A
- [No] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [V] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
