### PR TITLE
[fix] Fix activation checkpointing of SwiGLU when AMP is enabled.

### DIFF
--- a/xformers/csrc/swiglu/swiglu_packedw.cpp
+++ b/xformers/csrc/swiglu/swiglu_packedw.cpp
@@ -111,11 +111,11 @@ class SwiGLUPackedWeights
   static torch::autograd::variable_list backward(
       torch::autograd::AutogradContext* ctx,
       torch::autograd::variable_list grad_outputs) {
+    auto saved = ctx->get_saved_variables();
     at::AutoDispatchBelowADInplaceOrView g;
 
     // Unpack variables
     auto dx5 = grad_outputs[0];
-    auto saved = ctx->get_saved_variables();
     auto x = saved[0];
     auto w1w2 = saved[1];
     auto w3 = saved[2];


### PR DESCRIPTION
Without this fix the number of tensors saved during recomputation is equal to 0. 

- moved at::AutoDispatchBelowADInplaceOrView guard after ctx->get_saved_variables().

## What does this PR do?
Fixes #1151.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A
