### PR TITLE
[FA3] Link to cuda library to fix the FA3 extension build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -356,6 +356,8 @@ def get_flash_attention3_extensions(cuda_version: int, extra_compile_args):
                     Path(flash_root) / "hopper",
                 ]
             ],
+            # Without this we get and error about cuTensorMapEncodeTiled not defined
+            libraries=["cuda"],
         )
     ]
 


### PR DESCRIPTION
## What does this PR do?
Fix the FA3 extension build by adding the cuda library.

The original flash-attn repo mentioned that `-lcuda` is required to build and install the FA3 library: https://github.com/Dao-AILab/flash-attention/blob/main/hopper/setup.py#L222C13-L223C31

We need to add the library to xformers too to build the correct so file.

Test Plan:

Before this PR:

```
$ pip install -e .
# install xformers from source...
$ python -c "import xformers._C_flashattention3"
ImportError: /data/users/xzhao9/tritonbench/submodules/xformers/xformers/_C_flashattention3.so: undefined symbol: cuTensorMapEncodeTiled
```

After this PR:

```
$ pip install -e .
# install xformers from source...
$ python -c "import xformers._C_flashattention3"
# success!
```

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [x] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
