### PR TITLE
update builds 12.6 and rocm 6.3

### DIFF
--- a/.github/actions/setup-build-cuda/action.yml
+++ b/.github/actions/setup-build-cuda/action.yml
@@ -23,15 +23,17 @@ runs:
         import sys
         print(sys.version)
         cushort = "${{ inputs.toolkit_short_version }}"
-        TORCH_CUDA_DEFAULT = "121"  # pytorch 2.4.1
+        TORCH_CUDA_DEFAULT = "126"  # pytorch 2.4.1
         # https://github.com/Jimver/cuda-toolkit/blob/master/src/links/linux-links.ts
         full_version, install_script = {
+          "128": ("12.8.0", "https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run"),
+          "126": ("12.6.3", "https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda_12.6.3_560.35.05_linux.run"),
           "124": ("12.4.1", "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run"),
           "121": ("12.1.0", "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run"),
           "118": ("11.8.0", "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"),
           "6.0": ("6.0.2", "https://repo.radeon.com/amdgpu-install/6.0.2/rhel/8.9/amdgpu-install-6.0.60002-1.el8.noarch.rpm"),
-          "6.1": ("6.1.2", "https://repo.radeon.com/amdgpu-install/6.1.3/rhel/8.9/amdgpu-install-6.1.60103-1.el8.noarch.rpm"),
-          "6.2": ("6.2.3", "https://repo.radeon.com/amdgpu-install/6.2.3/rhel/8.9/amdgpu-install-6.2.60203-1.el8.noarch.rpm"),
+          "6.2": ("6.2.4", "https://repo.radeon.com/amdgpu-install/6.2.4/rhel/8.9/amdgpu-install-6.2.60204-1.el8.noarch.rpm"),
+          "6.3": ("6.3.1", "https://repo.radeon.com/amdgpu-install/6.3.1/rhel/8.9/amdgpu-install-6.3.60301-1.el8.noarch.rpm"),
         }[cushort]
         with open(os.environ['GITHUB_OUTPUT'], "r+") as fp:
           fp.write("CUDA_VERSION=" + full_version + "\n")

--- a/.github/actions/setup-build-cuda/action.yml
+++ b/.github/actions/setup-build-cuda/action.yml
@@ -23,7 +23,7 @@ runs:
         import sys
         print(sys.version)
         cushort = "${{ inputs.toolkit_short_version }}"
-        TORCH_CUDA_DEFAULT = "126"  # pytorch 2.4.1
+        TORCH_CUDA_DEFAULT = "126"  # pytorch 2.6.0
         # https://github.com/Jimver/cuda-toolkit/blob/master/src/links/linux-links.ts
         full_version, install_script = {
           "128": ("12.8.0", "https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run"),

--- a/.github/actions/setup-build-cuda/action.yml
+++ b/.github/actions/setup-build-cuda/action.yml
@@ -29,7 +29,6 @@ runs:
           "128": ("12.8.0", "https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run"),
           "126": ("12.6.3", "https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda_12.6.3_560.35.05_linux.run"),
           "124": ("12.4.1", "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run"),
-          "121": ("12.1.0", "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run"),
           "118": ("11.8.0", "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"),
           "6.0": ("6.0.2", "https://repo.radeon.com/amdgpu-install/6.0.2/rhel/8.9/amdgpu-install-6.0.60002-1.el8.noarch.rpm"),
           "6.2": ("6.2.4", "https://repo.radeon.com/amdgpu-install/6.2.4/rhel/8.9/amdgpu-install-6.2.60204-1.el8.noarch.rpm"),
@@ -48,14 +47,14 @@ runs:
     # WINDOWS STEPS
     - name: Install cuda
       if: runner.os == 'Windows' && inputs.toolkit_type == 'cuda'
-      uses: Jimver/cuda-toolkit@v0.2.16
+      uses: Jimver/cuda-toolkit@v0.2.21
       with:
         cuda: ${{ steps.cuda_info.outputs.CUDA_VERSION }}
         method: network
 
     - name: Install python
       if: runner.os == 'Windows'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python }}
 

--- a/.github/workflows/rocm_build.yml
+++ b/.github/workflows/rocm_build.yml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         os: ['ubuntu-alola']
         python: ['3.11']
-        torch_version: ['2.5.1']
+        torch_version: ['2.6.0']
         toolkit_type: ['rocm']
-        toolkit_short_version: ['6.1', '6.2']
+        toolkit_short_version: ['6.1', '6.2', '6.3']
 
     uses: ./.github/workflows/wheels_build.yml
     if: github.repository == 'rocm/xformers'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,11 +28,11 @@ jobs:
         import itertools
         environ = os.environ
 
-        PY_VERSIONS = ['3.9', '3.10', '3.11', '3.12']
+        PY_VERSIONS = ['3.9', '3.10', '3.11', '3.12', '3.13']
         # NOTE: Don't forget to update `upload_pt`'s matrix
         # when changing the CUDA/ROCM versions below!
-        CU_VERSIONS = ['118', '121', '124']
-        ROCM_VERSIONS = ["6.1"] # <- 6.0 broken in `manylinux_2_28`
+        CU_VERSIONS = ['118', '121', '124', '126' '128']
+        ROCM_VERSIONS = ['6.1', '6.2', '6.3'] # <- 6.0 broken in `manylinux_2_28`
         PY_CU = list(itertools.product(PY_VERSIONS, CU_VERSIONS))
         PY_ROCM = list(itertools.product(PY_VERSIONS, ROCM_VERSIONS))
         print("Full matrix PY_CU", PY_CU)
@@ -42,11 +42,11 @@ jobs:
           for cu in CU_VERSIONS[1:]:
             PY_CU.append((PY_VERSIONS[-1], cu))
           print("Limited matrix PY_CU", PY_CU)
-          PY_ROCM = [(PY_VERSIONS[-1], ROCM_VERSIONS[-1])]
+          PY_ROCM = [(PY_VERSIONS[-1], ROCM_VERSIONS[-2])] # last is beta version
 
         include = []
         for os in ['8-core-ubuntu', 'windows-8-core']:
-          for torch_version in ['2.5.1']:
+          for torch_version in ['2.6.0']:
             # CUDA builds
             for python, cuda_short_version in PY_CU:
               if cuda_short_version != "124" and "windows" in os:
@@ -96,7 +96,7 @@ jobs:
     uses: ./.github/workflows/wheels_upload_pip.yml
     with:
       twine_username: __token__
-      filter: "*torch2.5.1+cu121*"
+      filter: "*torch2.6.0+cu126*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.event_name != 'pull_request' }}
     secrets:
       twine_password: ${{ secrets.PYPI_TOKEN }}
@@ -110,12 +110,14 @@ jobs:
           - cu118
           - cu121
           - cu124
+          - cu126
           - rocm6.1
+          - rocm6.2
     uses: ./.github/workflows/wheels_upload_s3.yml
     with:
       aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
       s3_path: s3://pytorch/whl/${{ matrix.suffix }}/
       aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.5.1+${{ matrix.suffix }}*"
+      filter: "*torch2.6.0+${{ matrix.suffix }}*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
         # NOTE: Don't forget to update `upload_pt`'s matrix
         # when changing the CUDA/ROCM versions below!
         CU_VERSIONS = ['118', '121', '124', '126' '128']
-        ROCM_VERSIONS = ['6.1', '6.2', '6.3'] # <- 6.0 broken in `manylinux_2_28`
+        ROCM_VERSIONS = ['6.1', '6.2', '6.3']
         PY_CU = list(itertools.product(PY_VERSIONS, CU_VERSIONS))
         PY_ROCM = list(itertools.product(PY_VERSIONS, ROCM_VERSIONS))
         print("Full matrix PY_CU", PY_CU)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
         PY_VERSIONS = ['3.9', '3.10', '3.11', '3.12', '3.13']
         # NOTE: Don't forget to update `upload_pt`'s matrix
         # when changing the CUDA/ROCM versions below!
-        CU_VERSIONS = ['118', '121', '124', '126', '128']
+        CU_VERSIONS = ['118', '124', '126', '128']
         ROCM_VERSIONS = ['6.1', '6.2', '6.3']
         PY_CU = list(itertools.product(PY_VERSIONS, CU_VERSIONS))
         PY_ROCM = list(itertools.product(PY_VERSIONS, ROCM_VERSIONS))
@@ -108,7 +108,6 @@ jobs:
       matrix:
         suffix:
           - cu118
-          - cu121
           - cu124
           - cu126
           - rocm6.1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,7 +31,7 @@ jobs:
         PY_VERSIONS = ['3.9', '3.10', '3.11', '3.12', '3.13']
         # NOTE: Don't forget to update `upload_pt`'s matrix
         # when changing the CUDA/ROCM versions below!
-        CU_VERSIONS = ['118', '121', '124', '126' '128']
+        CU_VERSIONS = ['118', '121', '124', '126', '128']
         ROCM_VERSIONS = ['6.1', '6.2', '6.3']
         PY_CU = list(itertools.product(PY_VERSIONS, CU_VERSIONS))
         PY_ROCM = list(itertools.product(PY_VERSIONS, ROCM_VERSIONS))

--- a/.github/workflows/wheels_upload_pip.yml
+++ b/.github/workflows/wheels_upload_pip.yml
@@ -15,7 +15,7 @@ on:
       filter:
         required: true
         type: string
-        description: Filter which runs to upload. Example '*+cu121*'
+        description: Filter which runs to upload. Example '*+cu126*'
       execute:
         required: true
         type: boolean
@@ -38,7 +38,7 @@ jobs:
         shell: bash
     steps:
       - name: Recursive checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           path: "."

--- a/.github/workflows/wheels_upload_pip.yml
+++ b/.github/workflows/wheels_upload_pip.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
     steps:
       - name: Recursive checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           path: "."

--- a/.github/workflows/wheels_upload_s3.yml
+++ b/.github/workflows/wheels_upload_s3.yml
@@ -18,7 +18,7 @@ on:
       filter:
         required: true
         type: string
-        description: Filter which runs to upload. Example '*+cu121*'
+        description: Filter which runs to upload. Example '*+cu126*'
       execute:
         required: true
         type: boolean

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/setup-build-cuda
         with:
           toolkit_type: "cuda"
-          toolkit_short_version: "124"
+          toolkit_short_version: "126"
           python: "3.9"
 
       - name: Remove internal code
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          $PY -m pip install wheel setuptools ninja torch==2.5.1 -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121
+          $PY -m pip install wheel setuptools ninja torch==2.6.0 -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu126
           git config --global --add safe.directory "*"
           $PY -c "import torch; print('torch', torch.__version__)"
           $PY -c "import torch; print('torch.cuda', torch.version.cuda)"

--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ xFormers is:
 ```bash
 # [linux only] cuda 11.8 version
 pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu118
-# [linux only] cuda 12.1 version
-pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu121
 # [linux & win] cuda 12.4 version
 pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu124
 # [linux & win] cuda 12.6 version

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu118
 pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu121
 # [linux & win] cuda 12.4 version
 pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu124
-# [linux only] (EXPERIMENTAL) rocm 6.1 version
-pip3 install -U xformers --index-url https://download.pytorch.org/whl/rocm6.1
+# [linux & win] cuda 12.6 version
+pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu126
+# [linux only] (EXPERIMENTAL) rocm 6.2 version
+pip3 install -U xformers --index-url https://download.pytorch.org/whl/rocm6.2
 ```
 
 * **Development binaries**:


### PR DESCRIPTION
- Pytorch supports cuda 12.6 and rocm 6.2.4, 6.3
Better performance rocm6.3 https://community.amd.com/t5/ai/unlocking-new-horizons-in-ai-and-hpc-with-the-release-of-amd/ba-p/726434

```bash
pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126
pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2
```

Blackwell and RDNA4 support
```bash
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3
````