### PR TITLE
Fix _round_nnz

### DIFF
--- a/xformers/sparse/utils.py
+++ b/xformers/sparse/utils.py
@@ -97,12 +97,11 @@ def _dense_to_sparse(matrix, device):
 
 
 def _round_nnz(mask, divisible_by=4):
-    nonzero = torch.where(mask)
-    nnz = nonzero[0].shape[0]
-    nonzero = tuple(n[: (nnz - nnz % divisible_by)] for n in nonzero)
-    nm = torch.zeros_like(mask)
-    nm[nonzero] = True
-    return nm
+    nnz = torch.count_nonzero(mask)
+    cunz = torch.cumsum(~mask.flatten(), dim=0)
+    flip = cunz <= (-nnz) % divisible_by
+
+    return torch.logical_or(mask, flip.reshape_as(mask))
 
 
 def _dense3d_to_sparse(matrix, device):


### PR DESCRIPTION
## What does this PR do?

Fixes #1124

The PR modifies `_round_nnz` to round the number of elements up instead of down in the mask. It also modifies `SparseCSRTensor` to take its values (bias) into account in `SparseCSRTensor._masked_matmul`.

I modified the tests for `SparseCS` to also test nnz that would not be divisible by 4, as it should now work for any mask.