### PR TITLE
Correction to the github actions to allow windows builds on CUDA other than 12.4 to build.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -51,7 +51,7 @@ jobs:
           for torch_version in ['2.6.0']:
             # CUDA builds
             for python, cuda_short_version in PY_CU:
-              if cuda_short_version != "124" and "windows" in os:
+              if fromJSON(cuda_short_version) < fromJSON("124") and "windows" in os:
                 print("Windows builder no longer compatible with cu<124")
                 continue
               include.append(dict(

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -98,7 +98,7 @@ jobs:
     uses: ./.github/workflows/wheels_upload_pip.yml
     with:
       twine_username: __token__
-      filter: "*torch2.6.0+cu124*"
+      filter: "*torch2.6.0+cu12*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.event_name != 'pull_request' }}
     secrets:
       twine_password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Correction to the github actions to allow windows builds on CUDA other than 12.4 to build.
It should now allow CUDA >=12.4.


## What does this PR do?
Fixes #1209 
Fixes #1207
Fixes #1205

## Before submitting

- [ X ] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ X ] N/A
- [ ] Did you make sure to update the docs?
  - [ X ] N/A
- [ ] Did you write any new necessary tests?
  - [ X ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ X ] N/A

