### PR TITLE
Ensure correct dtype interpolation in error message

### DIFF
--- a/xformers/ops/sp24.py
+++ b/xformers/ops/sp24.py
@@ -526,7 +526,7 @@ class Sparse24TensorCuSparseLt(Sparse24Tensor):
         if bias is not None and bias.dtype != self.dtype:
             raise NotImplementedError(
                 f"`{self.__class__.__name__}` matmul: trying to do `A={tuple(self.shape)} @ B={tuple(B.shape)} + C`, "
-                "with A.dtype=B.dtype={self.dtype} and C.dtype={B.dtype}. "
+                f"with A.dtype=B.dtype={self.dtype} and C.dtype={B.dtype}. "
                 "This operation is only supported when A, B and C have the same data type."
             )
         assert _has_cusparseLt()


### PR DESCRIPTION
## What does this PR do?
This PR fixes an issue in the `Sparse24TensorCuSparseLt._mm()` method where an error message was incorrectly formatted due to a missing f-string prefix. The incorrect string prevented proper variable interpolation in the dtype mismatch error message.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
