### PR TITLE
Fix/Workaround for: AttributeError: Cannot set attribute 'src' directly for torch nightly/CUDA 12.8 when using latest triton.

### DIFF
--- a/xformers/triton/vararg_kernel.py
+++ b/xformers/triton/vararg_kernel.py
@@ -241,7 +241,8 @@ def unroll_varargs(kernel, N: int, mode: VarargMode = VarargMode.UNROLL):
     fn = next(iter(_locals.values()))
 
     jitted_fn = triton.jit(fn)
-    jitted_fn.src = new_src
+    jitted_fn._unsafe_update_src(new_src)
+    jitted_fn.hash = None
     return jitted_fn
 
 


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/facebookresearch/xformers/issues/1229, when using latest Triton. Triton has changed it's API and with this Fix/workaround, this let both of these libraries work correctly.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
