### PR TITLE
[docs only] Maybe fixed documentation formatting error

### DIFF
--- a/xformers/components/attention/scaled_dot_product.py
+++ b/xformers/components/attention/scaled_dot_product.py
@@ -76,12 +76,12 @@ class ScaledDotProduct(Attention):
         att_mask    A 2D or 3D mask which ignores attention at certain positions.
 
                     - If the mask is boolean, a value of True will keep the value,
-                        while a value of False will mask the value.
+                      while a value of False will mask the value.
 
-                        Key padding masks (dimension: batch x sequence length) and attention masks
-                        (dimension: sequence length x sequence length OR batch x sequence length x sequence length)
-                        can be combined and passed in here. Method maybe_merge_masks provided in the utils can be
-                        used for that merging.
+                      Key padding masks (dimension: batch x sequence length) and attention masks
+                      (dimension: sequence length x sequence length OR batch x sequence length x sequence length)
+                      can be combined and passed in here. Method maybe_merge_masks provided in the utils can be
+                      used for that merging.
 
                     - If the mask has the float type, then an additive mask is expected (masked values are -inf)
 


### PR DESCRIPTION
This is a docs only change. The documentation here https://facebookresearch.github.io/xformers/components/attentions.html seems incorrectly formatted. 

I am hopeful that this will fix it. But, as I don't see documentation in your contribution guidelines on how to build the documentation locally, I haven't tested it. 