### PR TITLE
Correct the condition for using merge_nhead_groups_seqlen_q

### DIFF
--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
@@ -80,7 +80,7 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
       // indicates to the splitkv kernel whether should it merge Hq/Hkv with
       // seqlen_q
       const bool merge_nhead_groups_seqlen_q =
-          ((param.M == 1) && (param.Hq > param.Hkv) && !kHasBias);
+          ((param.M == 1) && (param.Hq > param.Hkv) && !kHasBias && !kHasMask);
 
       if (merge_nhead_groups_seqlen_q) {
         using FmhaMaskNone = ck_tile::SimplifiedGenericAttentionMask<false>;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
@@ -78,7 +78,8 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
       // indicates to the splitkv kernel whether should it merge Hq/Hkv with
       // seqlen_q
       const bool merge_nhead_groups_seqlen_q =
-          ((param.max_seqlen_q == 1) && (param.Hq > param.Hkv) && !kHasBias);
+          ((param.max_seqlen_q == 1) && (param.Hq > param.Hkv) && !kHasBias &&
+           !kHasMask);
 
       if (merge_nhead_groups_seqlen_q) {
         using FmhaMaskNone = ck_tile::SimplifiedGenericAttentionMask<false>;


### PR DESCRIPTION
This PR corrects the condition checking codes for using `merge nhead_groups with seqlen_q`,  it fixes the failure of `test_forward_gqa`.  

`merge nhead_groups with seqlen_q` is an optimization for improving the performance of decoder inference with mqa/gqa enabled.  But utilizing this optimization requires causal mask is not used (since dimensions merging disturbs the logics for doing causal masking). 