### PR TITLE
Resolve Python Logger warnings

### DIFF
--- a/xformers/profiler/profiler.py
+++ b/xformers/profiler/profiler.py
@@ -90,7 +90,7 @@ class PyTorchProfiler:
             self._analyze_trace(prof)
         except Exception as exc:
             self.main_profiler.summary.append(("TraceAnalysis", "Error"))
-            logger.warn("Exception analyzing kineto trace", exc_info=exc)
+            logger.warning("Exception analyzing kineto trace", exc_info=exc)
 
     def _analyze_trace(self, prof: torch.profiler.profiler.profile) -> None:
         if prof.profiler is None or prof.profiler.kineto_results is None:


### PR DESCRIPTION
## What does this PR do?
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
