### PR TITLE
Enabling Blackwell support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -176,7 +176,9 @@ def get_flash_attention2_nvcc_archs_flags(cuda_version: int):
         return []
     # Figure out default archs to target
     DEFAULT_ARCHS_LIST = ""
-    if cuda_version >= 1108:
+    if cuda_version >= 1208:
+        DEFAULT_ARCHS_LIST = "8.0;8.6;9.0;10.0;12.0"
+    elif cuda_version >= 1108:
         DEFAULT_ARCHS_LIST = "8.0;8.6;9.0"
     elif cuda_version > 1100:
         DEFAULT_ARCHS_LIST = "8.0;8.6"


### PR DESCRIPTION
Nvidia Blackwell cards have been out for a while bu xformers do not formally support them. This PR adds support for them by checking for CUDA12.8 and enabling capability 120. Even though higher capabilities are available in https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list, using 120 is a conservative approach that enables all 50 series cards. This PR definitely solves #1251 and possibly #1228