### PR TITLE
Change schema of efficient_attention_forward_ck to have optional tensor return type for better compatibility with torch.export and AOTI 

### DIFF
--- a/xformers/csrc/attention/attention.cpp
+++ b/xformers/csrc/attention/attention.cpp
@@ -26,7 +26,7 @@ TORCH_LIBRARY_FRAGMENT(xformers, m) {
       "xformers::efficient_attention_forward_ck(Tensor query, "
       "Tensor key, Tensor value, Tensor? attn_bias, Tensor? seqstart_q, "
       "Tensor? seqstart_k, int? max_seqlen_q, float dropout_p, "
-      "bool compute_logsumexp, int custom_mask_type, float? scale, Tensor? seqlen_k, int? window_size, Tensor? block_tables, int? page_size) -> (Tensor, Tensor, int, int)"));
+      "bool compute_logsumexp, int custom_mask_type, float? scale, Tensor? seqlen_k, int? window_size, Tensor? block_tables, int? page_size) -> (Tensor, Tensor?, int, int)"));
   m.def(TORCH_SELECTIVE_SCHEMA(
       "xformers::efficient_attention_forward_decoder_ck(Tensor query, "
       "Tensor key, Tensor value, Tensor? seq_positions, float scale) -> Tensor"));

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -230,11 +230,11 @@ efficient_attention_forward_ck(
 
     if (p.compute_logsumexp) {
       logsumexp = at::empty({B, Hq, M}, opts.dtype(at::kFloat));
-      p.logsumexp_ptr = logsumexp.data_ptr();
+      p.logsumexp_ptr = logsumexp->data_ptr();
       p.lse_strides = {
-          static_cast<int>(logsumexp.stride(0)),
-          static_cast<int>(logsumexp.stride(1)),
-          static_cast<int>(logsumexp.stride(2))};
+          static_cast<int>(logsumexp->stride(0)),
+          static_cast<int>(logsumexp->stride(1)),
+          static_cast<int>(logsumexp->stride(2))};
     } else {
       p.logsumexp_ptr = nullptr;
       p.lse_strides = {0, 0, 0};
@@ -379,10 +379,10 @@ efficient_attention_forward_ck(
 
     if (p.compute_logsumexp) {
       logsumexp = at::empty({1, Hq, M}, opts.dtype(at::kFloat));
-      p.logsumexp_ptr = logsumexp.data_ptr();
+      p.logsumexp_ptr = logsumexp->data_ptr();
       p.lse_strides = {
-          static_cast<int>(logsumexp.stride(1)),
-          static_cast<int>(logsumexp.stride(2))};
+          static_cast<int>(logsumexp->stride(1)),
+          static_cast<int>(logsumexp->stride(2))};
     } else {
       p.logsumexp_ptr = nullptr;
       p.lse_strides = {0, 0};

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -495,16 +495,16 @@ efficient_attention_forward_ck_meta(
     const c10::optional<int64_t> window_size,
     const c10::optional<at::Tensor>& block_tables,
     const c10::optional<int64_t> page_size) {
-  int64_t B = query.size(0);
-  int64_t M = query.size(1);
-  int64_t N = key.size(1);
-  int64_t Hq = query.size(-2);
-  int64_t Hkv = key.size(-2);
-  int64_t K = query.size(-1);
-  int64_t Kv = value.size(-1);
+  at::SymInt B = query.sym_size(0);
+  at::SymInt M = query.sym_size(1);
+  at::SymInt N = key.sym_size(1);
+  at::SymInt Hq = query.sym_size(-2);
+  at::SymInt Hkv = key.sym_size(-2);
+  at::SymInt K = query.sym_size(-1);
+  at::SymInt Kv = value.sym_size(-1);
   auto opts = query.options();
   std::optional<at::Tensor> logsumexp = std::nullopt;
-  at::Tensor out = at::empty({B, M, Hq, Kv}, opts);
+  at::Tensor out = at::empty_symint({B, M, Hq, Kv}, opts);
   int64_t philox_seed = 0;
   int64_t philox_offset = 0;
   if (!seqstart_q.has_value()) { // input is batched

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -136,8 +136,8 @@ efficient_attention_forward_ck(
   at::Tensor out_acc;
 
   const bool use_dropout = std::fpclassify(dropout_p) != FP_ZERO;
-  int64_t philox_seed;
-  int64_t philox_offset;
+  int64_t philox_seed = 0;
+  int64_t philox_offset = 0;
 
   if (use_dropout) {
     at::PhiloxCudaState rng_engine_inputs;
@@ -509,11 +509,11 @@ efficient_attention_forward_ck_meta(
   int64_t philox_offset = 0;
   if (!seqstart_q.has_value()) { // input is batched
     if (compute_logsumexp) {
-      logsumexp = at::empty({B, Hq, M}, opts.dtype(at::kFloat));
+      logsumexp = at::empty_symint({B, Hq, M}, opts.dtype(at::kFloat));
     }
   } else {
     if (compute_logsumexp) {
-      logsumexp = at::empty({1, Hq, M}, opts.dtype(at::kFloat));
+      logsumexp = at::empty_symint({1, Hq, M}, opts.dtype(at::kFloat));
     }
   }
   return std::make_tuple(out, logsumexp, philox_seed, philox_offset);

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -48,7 +48,7 @@ namespace {
   (Mode BMHK) With all the heads having the same seqlen
   (Mode 1MHK) `batch=1` with all tokens across batches concatenated
 */
-std::tuple<at::Tensor, at::Tensor, int64_t, int64_t>
+std::tuple<at::Tensor, std::optional<at::Tensor>, int64_t, int64_t>
 efficient_attention_forward_ck(
     const at::Tensor& query, // [b, seqlen, num_heads_q, K]
     const at::Tensor& key, // [b, seqlen, num_heads_kv, K]
@@ -473,7 +473,7 @@ efficient_attention_forward_ck(
   (Mode BMHK) With all the heads having the same seqlen
   (Mode 1MHK) `batch=1` with all tokens across batches concatenated
 */
-std::tuple<at::Tensor, at::Tensor, int64_t, int64_t>
+std::tuple<at::Tensor, std::optional<at::Tensor>, int64_t, int64_t>
 efficient_attention_forward_ck_meta(
     const at::Tensor& query, // [b, seqlen, num_heads_q, K]
     const at::Tensor& key, // [b, seqlen, num_heads_kv, K]

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -128,7 +128,7 @@ efficient_attention_forward_ck(
 
   auto opts = query.options();
 
-  at::Tensor logsumexp;
+  std::optional<at::Tensor> logsumexp = std::nullopt;
 
   at::Tensor out = at::empty({B, M, Hq, Kv}, opts);
 
@@ -503,7 +503,7 @@ efficient_attention_forward_ck_meta(
   int64_t K = query.size(-1);
   int64_t Kv = value.size(-1);
   auto opts = query.options();
-  at::Tensor logsumexp;
+  std::optional<at::Tensor> logsumexp = std::nullopt;
   at::Tensor out = at::empty({B, M, Hq, Kv}, opts);
   int64_t philox_seed = 0;
   int64_t philox_offset = 0;


### PR DESCRIPTION
## What does this PR do?

Full list of changes:
1. Change schema of logsumexp to optional tensor
2. Initialize logsumexp to nullopt
3. Initialize philox_seed and philox_offset to 0
4. Symint'ify the meta function with SymInt and empty_symint (important for torch.compile as well)

## Motivation of 1 and 2

Context is https://github.com/ROCm/xformers/issues/65, but let me copy over.

Hi, we want to propose this change so the CK kernel is more compatible with pytorch (more precisely, torch.export and AOTI).

Right now, depending on `compute_logsumexp`, the second return of `efficient_attention_forward_ck`, i.e. logsumexp, is either an actual tensor or an uninitialized tensor. If it is an uninitialized tensor, it would be treated as None in Python. In other words, it functions more like an optional tensor return.

This causes some problems when using with torch.export and AOTI, since they see the schema is Tensor so didn't expect to get None.

We chatted with the xformers folks @bottler. Since the kernels are from AMD, so I want to start here. 

The change would look like the example in github.com/pytorch/pytorch/pull/154286
1. inside [attention_forward_generic_ck_tiled.hip](https://github.com/ROCm/xformers/blob/89967ff16d5103772c75160b83e756447be1e547/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp#L51), change `std::tuple<at::Tensor, at::Tensor, int64_t, int64_t>` to `std::tuple<at::Tensor, std::optional<at::Tensor>, int64_t, int64_t>` for both the main and the meta functions.
2. inside [attention.cpp](https://github.com/ROCm/xformers/blob/89967ff16d5103772c75160b83e756447be1e547/xformers/csrc/attention/attention.cpp#L26), change return schema from `(Tensor, Tensor, int, int)` to `(Tensor, Tensor?, int, int)`

An alternative, as @zou3519 pointed out, is to make AOTI treat `Tensor` as `Tensor?`. I tried that route, but folks like @yiming0416 prefers modifying the schema.

## Motivation of 3

Initialize them as 0 to avoid 
```
shim_common.cpp:1264] Exception in aoti_torch: Expect returned int value to match the serialized int value, but got retured int value: 140734043882480 and serialized int value: 0
```

## Motivation of 4: Symint'ify the meta function

Following https://docs.google.com/document/d/1GgvOe7C8_NVOMLOCwDaYV1mXXyHMXY7ExoewHqooxrs/edit?tab=t.0#heading=h.1pvztxcsyq0p. Previously I have done it for https://github.com/pytorch/FBGEMM/pull/3410

Also see Richard recent PR: https://github.com/pytorch/FBGEMM/pull/4322

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] Discussed offline and in github.com/pytorch/pytorch/pull/154286
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
