### PR TITLE
adding blackwell support for precompiled wheels

### DIFF
--- a/.github/workflows/wheels_build.yml
+++ b/.github/workflows/wheels_build.yml
@@ -56,6 +56,9 @@ jobs:
       - if: contains(inputs.toolkit_type, 'cuda') && fromJSON(inputs.toolkit_short_version) >= 120
         run: |
           echo "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST 9.0a" >> ${GITHUB_ENV}
+      - if: contains(inputs.toolkit_type, 'cuda') && fromJSON(inputs.toolkit_short_version) >= 128
+        run: |
+          echo "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST 10.0 12.0" >> ${GITHUB_ENV}
 
       - if: runner.os == 'Windows'
         run: git config --system core.longpaths true


### PR DESCRIPTION
the current github wheel build process uses TORCH_CUDA_ARCH_LIST = 7.5 8.0+PTX 9.0a </br>this should be forwards compatible but on in some cases for blackwell it isnt (see #1251).</br> Currently the compilation code already supports blackwell.  Building with TORCH_CUDA_ARCH_LIST=12.0 solves the issue on #1251 but the pre-built wheels are not being compiled with that flag. Since the build process is done with CudaTK12.8 already i added capability 100 and 120 to the workflow. I already submitted a PR for the FA2 code path (#1254).</br>this PR adds support for blackwell on the main build workflow for the pipy builds.