### PR TITLE
[ROCm] prepare CK sources for pytorch hipify v2 APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,12 +162,15 @@ def get_hip_version(rocm_dir) -> Optional[str]:
 
 def detect_hipify_v2():
     try:
-        from torch.utils.hipify import __version__
         from packaging.version import Version
+        from torch.utils.hipify import __version__
+
         if Version(__version__) >= Version("2.0.0"):
             return True
     except Exception as e:
-        print("failed to detect pytorch hipify version, defaulting to version 1.0.0 behavior")
+        print(
+            "failed to detect pytorch hipify version, defaulting to version 1.0.0 behavior"
+        )
         print(e)
     return False
 
@@ -515,9 +518,7 @@ def get_extensions():
         if cuda_version < 1205:
             # swiglu_fairinternal.cu uses cuda::ptx::cp_async_bulk which requires
             # CUDA 12.5
-            sources.remove(
-                os.path.join(extensions_dir, "swiglu_fairinternal.cu")
-            )
+            sources.remove(os.path.join(extensions_dir, "swiglu_fairinternal.cu"))
         include_dirs += [
             sputnik_dir,
             cutlass_dir,

--- a/setup.py
+++ b/setup.py
@@ -160,6 +160,18 @@ def get_hip_version(rocm_dir) -> Optional[str]:
     return None
 
 
+def detect_hipify_v2():
+    try:
+        from torch.utils.hipify import __version__
+        from packaging.version import Version
+        if Version(__version__) >= Version("2.0.0"):
+            return True
+    except Exception as e:
+        print("failed to detect pytorch hipify version, defaulting to version 1.0.0 behavior")
+        print(e)
+    return False
+
+
 ######################################
 # FLASH-ATTENTION v2
 ######################################
@@ -605,6 +617,8 @@ def get_extensions():
         use_rtn_bf16_convert = os.getenv("ENABLE_HIP_FMHA_RTN_BF16_CONVERT", "0")
         if use_rtn_bf16_convert == "1":
             cc_flag += ["-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT=3"]
+        if detect_hipify_v2():
+            cc_flag += ["-DHIPIFY_V2"]
 
         arch_list = os.getenv("HIP_ARCHITECTURES", "native").split()
 

--- a/xformers/csrc/attention/hip_decoder/attention_forward_splitk.cpp
+++ b/xformers/csrc/attention/hip_decoder/attention_forward_splitk.cpp
@@ -139,7 +139,11 @@ at::Tensor& efficient_attention_forward_decoder_splitk_ck_out_impl(
       WavefrontsPerBlock; // 4 * threadsPerBlock * sizeof(float) ==
                           // sizeof(O[b][0][h][:])
   const size_t attn_lds_bytes = max(smem_softmax, smem_output);
+#ifdef HIPIFY_V2
+  auto stream = at::cuda::getCurrentCUDAStream().stream();
+#else
   auto stream = at::hip::getCurrentHIPStream().stream();
+#endif
 
   AT_DISPATCH_SWITCH_3(
       at::ScalarType::Half,

--- a/xformers/csrc/attention/hip_fmha/attention_backward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_backward_generic_ck_tiled.cpp
@@ -112,7 +112,11 @@ efficient_attention_backward_ck(
     TORCH_CHECK(max_seqlen_k_.has_value());
   }
 
+#ifdef HIPIFY_V2
+  hipStream_t stream = c10::cuda::getCurrentCUDAStream().stream();
+#else
   hipStream_t stream = c10::hip::getCurrentHIPStream().stream();
+#endif
 
   int64_t B = query.size(0);
   int64_t M = query.size(1);

--- a/xformers/csrc/attention/hip_fmha/attention_ck_rand_uniform.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_ck_rand_uniform.cpp
@@ -33,7 +33,11 @@ at::Tensor rand_uniform_int(
   int M = out_pattern.size(2);
   int N = out_pattern.size(3);
 
+#ifdef HIPIFY_V2
+  hipStream_t stream = c10::cuda::getCurrentCUDAStream().stream();
+#else
   hipStream_t stream = c10::hip::getCurrentHIPStream().stream();
+#endif
 
   at::CUDAGeneratorImpl* gen =
       at::get_generator_or_default<at::CUDAGeneratorImpl>(

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -115,7 +115,11 @@ efficient_attention_forward_ck(
   CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(key);
   CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(value);
 
+#ifdef HIPIFY_V2
+  hipStream_t stream = c10::cuda::getCurrentCUDAStream().stream();
+#else
   hipStream_t stream = c10::hip::getCurrentHIPStream().stream();
+#endif
 
   int64_t B = query.size(0);
   int64_t M = query.size(1);


### PR DESCRIPTION
Similar to https://github.com/Dao-AILab/flash-attention/pull/1944.

See https://github.com/pytorch/pytorch/pull/151845. pytorch has removed caffe2, but hipify still contained work-arounds for caffe2 vs torch compatibility.
As a result of hipify v2 changes, some torch APIs are changing.