### PR TITLE
[fix] Fix flash_attn_3 import order conflict

### DIFF
--- a/xformers/ops/fmha/flash3.py
+++ b/xformers/ops/fmha/flash3.py
@@ -105,16 +105,7 @@ FLASH3_HAS_PAGED_ATTENTION = True
 FLASH3_HAS_FLOAT8 = False
 FLASH3_HAS_DETERMINISTIC_MODE = False
 _C_flashattention3 = None
-if importlib.util.find_spec("...flash_attn_3._C", package=__package__):
-    from ..._cpp_lib import _build_metadata
-    from ...flash_attn_3 import _C  # type: ignore[attr-defined]  # noqa: F401
-
-    if _build_metadata is not None:
-        FLASH_VERSION = _build_metadata.flash_version.lstrip("v")
-    FLASH3_HAS_DETERMINISTIC_MODE = True
-    _C_flashattention3 = torch.ops.flash_attn_3
-
-elif importlib.util.find_spec("flash_attn_3") and importlib.util.find_spec(
+if importlib.util.find_spec("flash_attn_3") and importlib.util.find_spec(
     "flash_attn_3._C"
 ):
     import flash_attn_3._C  # type: ignore[attr-defined]  # noqa: F401
@@ -127,6 +118,15 @@ elif importlib.util.find_spec("flash_attn_3") and importlib.util.find_spec(
         FLASH3_HAS_FLOAT8 = True
     else:
         logger.warning(f"Flash-Attention 3 package can't be used: {incompat_reason}")
+
+elif importlib.util.find_spec("...flash_attn_3._C", package=__package__):
+    from ..._cpp_lib import _build_metadata
+    from ...flash_attn_3 import _C  # type: ignore[attr-defined]  # noqa: F401
+
+    if _build_metadata is not None:
+        FLASH_VERSION = _build_metadata.flash_version.lstrip("v")
+    FLASH3_HAS_DETERMINISTIC_MODE = True
+    _C_flashattention3 = torch.ops.flash_attn_3
 
 
 def _heuristic_kvsplit(


### PR DESCRIPTION
## What does this PR do?
Fixes #1348

Swap import order to prioritize global flash_attn_3 package over vendored version. This prevents torch extension namespace conflicts when flash_attn_3 is already imported by other libraries (e.g., diffusers).

The fix simply swaps the two import blocks so that:
- Global flash_attn_3 is checked first (if)
- Vendored version is only used if global is not available (elif)
- Maintains the original behavior and error handling

This allows xFormers to work alongside libraries that import flash_attn_3, such as diffusers.models.autoencoders, without RuntimeError about duplicate torch.ops registration.


## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] not needed
- [ ] Did you write any new necessary tests?
  - [ ] not easy as there is no released flash_attention_3 package
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


