### PR TITLE
Fix incorrect error message and inconsistent ndim check

### DIFF
--- a/xformers/attn_bias_utils.py
+++ b/xformers/attn_bias_utils.py
@@ -361,7 +361,7 @@ def _rand_seqlens_padded_k(
     # will attend to nothing and have undefined result.
     # In addition every element of k_seqlens must be <= kv_len
     if q_len > kv_len:
-        raise ValueError("need more queries than keys")
+        raise ValueError("need more keys than queries (kv_len must be >= q_len)")
     if q_len == kv_len:
         # all key slots are needed so we cannot have padding
         q_seqlens = k_seqlens = [kv_len] * bs

--- a/xformers/ops/fmha/common.py
+++ b/xformers/ops/fmha/common.py
@@ -173,7 +173,7 @@ class Inputs:
                 self.key.unsqueeze(2),
                 self.value.unsqueeze(2),
             )
-        if self.value.ndim == 3:
+        if self.query.ndim == 3:
             return (
                 self.query[:, :, None, None],
                 self.key[:, :, None, None],


### PR DESCRIPTION
## Summary

- **Fix misleading error message in `_rand_seqlens_padded_k`** (`attn_bias_utils.py`): When `q_len > kv_len`, the function raises `ValueError("need more queries than keys")`, but the comments and logic clearly indicate the constraint is that there must be more **keys** than queries (bottom-right causal mask). Fixed the message to `"need more keys than queries (kv_len must be >= q_len)"`.

- **Fix inconsistent `ndim` check in `Inputs.get_qkv_in_bmghk`** (`ops/fmha/common.py`): The first two branches check `self.query.ndim` (for 5D and 4D), but the third branch checks `self.value.ndim == 3` instead of `self.query.ndim == 3`. While `validate_inputs()` ensures all tensors share the same ndim, this inconsistency could cause silent wrong behavior if `get_qkv_in_bmghk` is called without prior validation and the tensors have mismatched dimensions.

## Test plan

- [x] Verified the error message now correctly describes the constraint
- [x] Verified the ndim check is now consistent across all branches of `get_qkv_in_bmghk`
- [ ] Existing tests should continue to pass (both fixes are behavioral no-ops when inputs are well-formed)