### PR TITLE
[chore] Add Windows ARM64 wheel release support

### DIFF
--- a/.github/actions/setup-build-cuda/action.yml
+++ b/.github/actions/setup-build-cuda/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Python version to install
     type: string
     default: "3.10"
+  architecture:
+    description: Target architecture for Python and MSVC
+    type: string
+    default: "x64"
 
 runs:
   using: composite
@@ -27,6 +31,7 @@ runs:
         TORCH_CUDA_DEFAULT = "128"  # since pytorch 2.9.0
         # https://github.com/Jimver/cuda-toolkit/blob/master/src/links/linux-links.ts
         full_version, install_script = {
+          "134": ("13.4.0rc1", ""),
           "130": ("13.0.1", "https://developer.download.nvidia.com/compute/cuda/13.0.1/local_installers/cuda_13.0.1_580.82.07_linux.run"),
           "129": ("12.9.1", "https://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_575.57.08_linux.run"),
           "128": ("12.8.1", "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run"),
@@ -53,14 +58,14 @@ runs:
 
     # WINDOWS STEPS
     - name: Install cuda
-      if: runner.os == 'Windows' && inputs.toolkit_type == 'cuda'
+      if: runner.os == 'Windows' && inputs.toolkit_type == 'cuda' && inputs.architecture != 'arm64'
       id: cuda-toolkit
       # Using N-Storm fork until https://github.com/Jimver/cuda-toolkit/issues/395 is resolved
       uses: N-Storm/cuda-toolkit@v0.2.28
       with:
         cuda: ${{ steps.cuda_info.outputs.CUDA_VERSION }}
         method: network
-    - if: runner.os == 'Windows' && inputs.toolkit_type == 'cuda'
+    - if: runner.os == 'Windows' && inputs.toolkit_type == 'cuda' && inputs.architecture != 'arm64'
       shell: bash
       run: |
         echo "Installed cuda version is: ${{ steps.cuda-toolkit.outputs.cuda }}"
@@ -70,13 +75,26 @@ runs:
 
     - name: Install python
       if: runner.os == 'Windows'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python }}
+        architecture: ${{ inputs.architecture }}
+
+    - name: Install CUDA for Windows ARM64
+      if: runner.os == 'Windows' && inputs.toolkit_type == 'cuda' && inputs.architecture == 'arm64'
+      shell: bash
+      run: |
+        python3 -m pip install --pre "cuda-toolkit[cccl,nvcc]==${{ steps.cuda_info.outputs.CUDA_VERSION }}" --index-url https://pypi.nvidia.com
+        CUDA_HOME="$(python3 -c "from pathlib import Path; import site; print((Path(site.getsitepackages()[-1]) / 'nvidia' / 'cu13').as_posix())")"
+        python3 -c "from pathlib import Path; p = Path(r'$CUDA_HOME'); assert (p / 'bin' / 'nvcc.exe').is_file(); assert (p / 'lib' / 'arm64' / 'cudart.lib').is_file()"
+        echo "CUDA_HOME=$CUDA_HOME" >> ${GITHUB_ENV}
+        echo "$CUDA_HOME/bin" >> ${GITHUB_PATH}
 
     - name: Setup MSVC
       if: runner.os == 'Windows'
       uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ inputs.architecture }}
 
     # really unfortunate: https://github.com/ilammy/msvc-dev-cmd#name-conflicts-with-shell-bash
     - name: Remove link.exe

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,8 +28,7 @@ jobs:
         import itertools
         environ = os.environ
 
-        # All builds are python-version agnostic,
-        # and built with python 3.10
+        # Existing x64 CUDA/ROCm builds are Python-version agnostic and use Python 3.10.
         PYTHON_VERSION = "3.10"
         # NOTE: Don't forget to update `upload_pt`'s matrix
         # when changing the CUDA/ROCM versions below!
@@ -46,8 +45,11 @@ jobs:
                 continue
               include.append(dict(
                 os=os,
+                architecture="x64",
                 python=PYTHON_VERSION,
                 torch_version=torch_version,
+                torch_requirement="",
+                pytorch_index_url="",
                 toolkit_type="cuda",
                 toolkit_short_version=cuda_short_version,
               ))
@@ -58,12 +60,27 @@ jobs:
                 continue
               include.append(dict(
                 os="16-core-ubuntu",  # use for ROCm wheels only to avoid CI timeouts
+                architecture="x64",
                 python=PYTHON_VERSION,
                 torch_version=torch_version,
+                torch_requirement="",
+                pytorch_index_url="",
                 toolkit_type="rocm",
                 toolkit_short_version=rocm_short_version,
               ))
               print(include[-1])
+        # NVIDIA publishes its Windows ARM64 CUDA build as a PyTorch nightly.
+        include.append(dict(
+          os="windows-11-vs2026-arm",
+          architecture="arm64",
+          python="3.12",
+          torch_version="2.15.0.dev",
+          torch_requirement="torch>=2.15.0.dev0,<2.16",
+          pytorch_index_url="https://pypi.nvidia.com/nvtorch_oot_nightly/",
+          toolkit_type="cuda",
+          toolkit_short_version="134",
+        ))
+        print(include[-1])
         matrix = {'include': include}
         print(json.dumps(matrix))
         with open(environ["GITHUB_OUTPUT"], "a") as fd:
@@ -78,8 +95,11 @@ jobs:
     if: github.repository == 'facebookresearch/xformers' || github.event_name == 'pull_request'
     with:
       os: ${{ matrix.os }}
+      architecture: ${{ matrix.architecture }}
       python: ${{ matrix.python }}
       torch_version: ${{ matrix.torch_version }}
+      torch_requirement: ${{ matrix.torch_requirement }}
+      pytorch_index_url: ${{ matrix.pytorch_index_url }}
       toolkit_type: ${{ matrix.toolkit_type }}
       toolkit_short_version: ${{ matrix.toolkit_short_version }}
 
@@ -98,15 +118,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suffix:
-          - cu126
-          - cu128
-          - cu130
-          - rocm7.1
+        include:
+          - suffix: cu126
+            torch_version: "2.10.0"
+          - suffix: cu128
+            torch_version: "2.10.0"
+          - suffix: cu130
+            torch_version: "2.10.0"
+          - suffix: rocm7.1
+            torch_version: "2.10.0"
+          - suffix: cu134
+            torch_version: "2.15.0.dev"
     uses: ./.github/workflows/wheels_upload_s3.yml
     with:
       aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
       s3_path: s3://pytorch/whl/${{ matrix.suffix }}/
       aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.10.0+${{ matrix.suffix }}*"
+      filter: "*torch${{ matrix.torch_version }}+${{ matrix.suffix }}*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}

--- a/.github/workflows/wheels_build.yml
+++ b/.github/workflows/wheels_build.yml
@@ -6,6 +6,10 @@ on:
       os:
         required: true
         type: string
+      architecture:
+        default: "x64"
+        type: string
+        description: "Target architecture for Python and MSVC"
       python:
         required: true
         type: string
@@ -13,10 +17,20 @@ on:
         required: true
         type: string
         description: "Example: 1.13.1"
+      torch_requirement:
+        required: false
+        default: ""
+        type: string
+        description: "Override the PyTorch requirement for nonstandard indexes"
+      pytorch_index_url:
+        required: false
+        default: ""
+        type: string
+        description: "Override the PyTorch package index"
       toolkit_type:
         required: true
         type: string
-        description: "Example: cuda for cuda, rocm for rocm"
+        description: "Build toolkit: cuda or rocm"
       toolkit_short_version:
         required: true
         type: string
@@ -30,7 +44,7 @@ on:
 
 env:
   # you need at least cuda 5.0 for some of the stuff compiled here.
-  TORCH_CUDA_ARCH_LIST: ${{ contains(inputs.toolkit_type, 'cuda') && '7.5 8.0+PTX' || '' }}
+  TORCH_CUDA_ARCH_LIST: ${{ inputs.architecture == 'arm64' && '8.9 10.3a+PTX 12.0a 12.1a+PTX' || contains(inputs.toolkit_type, 'cuda') && '7.5 8.0+PTX' || '' }}
   HIP_ARCHITECTURES: ${{ contains(inputs.toolkit_type, 'rocm') && 'gfx90a gfx942' || '' }}
   MAX_JOBS: ${{ contains(inputs.os, 'ubuntu') && '2' || '3' }} # (FA3 is memory hungry!)
   DISTUTILS_USE_SDK: 1 # otherwise distutils will complain on windows about multiple versions of msvc
@@ -40,7 +54,7 @@ env:
 
 jobs:
   build:
-    name: ${{ contains(inputs.os, 'ubuntu') && 'ubuntu' || 'win' }}-py${{ inputs.python }}-pt${{ inputs.torch_version }}+${{ contains(inputs.toolkit_type, 'cuda') && 'cu' || 'rocm' }}${{ inputs.toolkit_short_version }}
+    name: ${{ contains(inputs.os, 'ubuntu') && 'ubuntu' || 'win' }}${{ inputs.architecture == 'arm64' && '-arm64' || '' }}-py${{ inputs.python }}-pt${{ inputs.torch_version }}+${{ inputs.toolkit_type == 'cuda' && 'cu' || inputs.toolkit_type }}${{ inputs.toolkit_short_version }}
     runs-on: ${{ inputs.os }}
     env:
       # alias for the current python version
@@ -53,11 +67,11 @@ jobs:
       run:
         shell: bash
     steps:
-      - if: contains(inputs.toolkit_type, 'cuda') && fromJSON(inputs.toolkit_short_version) >= 120 && fromJSON(inputs.toolkit_short_version) < 130
+      - if: inputs.architecture != 'arm64' && contains(inputs.toolkit_type, 'cuda') && fromJSON(inputs.toolkit_short_version) >= 120 && fromJSON(inputs.toolkit_short_version) < 130
         run: |
           echo "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST 8.0 9.0a" >> ${GITHUB_ENV}
 
-      - if: contains(inputs.toolkit_type, 'cuda') && fromJSON(inputs.toolkit_short_version) >= 130
+      - if: inputs.architecture != 'arm64' && contains(inputs.toolkit_type, 'cuda') && fromJSON(inputs.toolkit_short_version) >= 130
         run: |
           echo "TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST 8.0 9.0a 10.0a 10.3a 11.0a 12.0a 12.1a" >> ${GITHUB_ENV}
 
@@ -82,6 +96,7 @@ jobs:
           toolkit_type: ${{ inputs.toolkit_type }}
           toolkit_short_version: ${{ inputs.toolkit_short_version }}
           python: ${{ inputs.python }}
+          architecture: ${{ inputs.architecture }}
       - if: runner.os == 'Linux'
         run: printenv
 
@@ -106,8 +121,8 @@ jobs:
           git config --global --add safe.directory "*"
           version=`python .github/compute_wheel_version.py --source $VERSION_SOURCE`
           echo $version > version.txt
-          echo "BUILD_VERSION=$version${{ steps.cuda_info.outputs.CUDA_VERSION_SUFFIX }}" >> ${GITHUB_ENV}
-          echo "BUILD_VERSION=$version${{ steps.cuda_info.outputs.CUDA_VERSION_SUFFIX }}" >> ${GITHUB_OUTPUT}
+          echo "BUILD_VERSION=$version${CUDA_VERSION_SUFFIX}" >> ${GITHUB_ENV}
+          echo "BUILD_VERSION=$version${CUDA_VERSION_SUFFIX}" >> ${GITHUB_OUTPUT}
           which ninja
           ninja --version
           cat ${GITHUB_ENV}
@@ -116,20 +131,31 @@ jobs:
         if: ${{ !contains(steps.xformers_version.outputs.BUILD_VERSION, '.dev') }}
 
       - name: Install corresponding PyTorch
+        env:
+          PYTORCH_INDEX_URL: ${{ inputs.pytorch_index_url }}
+          PYTORCH_REQUIREMENT: ${{ inputs.torch_requirement }}
         run: |
-          PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${{ contains(inputs.toolkit_type, 'cuda') && 'cu' || 'rocm' }}${{ inputs.toolkit_short_version }}"
-          $PY -m pip install wheel -r requirements.txt --extra-index-url $PYTORCH_INDEX_URL
+          if [[ -n "$PYTORCH_INDEX_URL" ]]; then
+            $PY -m pip install --pre "$PYTORCH_REQUIREMENT" --index-url "$PYTORCH_INDEX_URL" --extra-index-url https://pypi.org/simple
+            $PY -m pip install wheel -r requirements.txt
+          else
+            PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${{ contains(inputs.toolkit_type, 'cuda') && 'cu' || 'rocm' }}${{ inputs.toolkit_short_version }}"
+            $PY -m pip install wheel -r requirements.txt --extra-index-url "$PYTORCH_INDEX_URL"
+          fi
+          if [[ "${{ inputs.toolkit_type }}" == "cuda" ]]; then
+            $PY -c "import torch; short = '${{ inputs.toolkit_short_version }}'; expected = f'{short[:-1]}.{short[-1]}'; assert torch.version.cuda == expected, (torch.__version__, torch.version.cuda, expected)"
+          fi
 
       - name: Build wheel
         shell: bash -l {0}
         run: |
           $PY setup.py bdist_wheel -d dist/ -k $PLAT_ARG
         env:
-          PLAT_ARG: ${{ contains(inputs.os, 'ubuntu') && '--plat-name manylinux_2_28_x86_64' || '' }}
+          PLAT_ARG: ${{ contains(inputs.os, 'ubuntu') && '--plat-name manylinux_2_28_x86_64' || inputs.architecture == 'arm64' && '--plat-name win_arm64' || '' }}
 
       - run: du -h dist/*
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.os }}-py${{ inputs.python }}-torch${{ inputs.torch_version }}+${{ contains(inputs.toolkit_type, 'cuda') && 'cu' || 'rocm' }}${{ inputs.toolkit_short_version }}_${{ inputs.artifact_tag }}
+          name: ${{ inputs.os }}-py${{ inputs.python }}-torch${{ inputs.torch_version }}+${{ inputs.toolkit_type == 'cuda' && 'cu' || inputs.toolkit_type }}${{ inputs.toolkit_short_version }}_${{ inputs.artifact_tag }}
           path: dist/*.whl
 # Note: it might be helpful to have additional steps that test if the built wheels actually work

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.36] - 2026-??-??
 
+### Added
+- Added experimental Windows ARM64 wheels for CUDA 13.4, built against NVIDIA PyTorch nightly releases.
+
 ### Improved
 - Selective activation checkpointing (`xformers.checkpoint`) now delegates to PyTorch's public `torch.utils.checkpoint.create_selective_checkpoint_contexts` instead of reaching into PyTorch private internals. This fixes an `IndexError` with recent PyTorch versions. The public API (`checkpoint`, `get_optimal_checkpoint_policy`, `list_operators`, `selective_checkpoint_wrapper`) is unchanged.
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu130
 pip3 install -U xformers --index-url https://download.pytorch.org/whl/rocm7.1
 ```
 
+* **(EXPERIMENTAL, Windows ARM64) Install the CUDA 13.4 wheel**:
+
+```bash
+pip3 install --pre -U xformers \
+    --index-url https://download.pytorch.org/whl/cu134 \
+    --extra-index-url https://pypi.nvidia.com/nvtorch_oot_nightly/ \
+    --extra-index-url https://pypi.org/simple
+```
+
 * **Development binaries**:
 
 ```bash


### PR DESCRIPTION
Hi @bottler , I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm.
So I updates the CI workflows to add support for Windows ARM64 build and release. Could you please help to review? Thanks.

## What does this PR do?

Adds experimental native Windows ARM64 CUDA wheels to the existing release pipeline.

- Adds a `windows-11-vs2026-arm` target using Python 3.12 and ARM64 MSVC.
- Installs the NVIDIA CUDA 13.4 ARM64 toolchain, including NVCC and CCCL.
- Builds against NVIDIA’s Windows ARM64 PyTorch nightly from `https://pypi.nvidia.com/nvtorch_oot_nightly/`.
- Uses the CUDA architectures supported by NVIDIA’s Windows ARM64 PyTorch build.
- Produces `win_arm64` wheels with the `+cu134` version suffix.
- Publishes the wheels to the existing `cu134` PyTorch S3 channel.
- Documents the Windows ARM64 installation command and updates the changelog.

Existing Linux, Windows x64, CUDA, and ROCm release targets remain unchanged.

Refs #1071.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A

## Validation

- Built a native `py39-none-win_arm64` wheel with CUDA 13.4.
- Installed the generated wheel against NVIDIA PyTorch `2.15.0.dev20260904+cu134`.
- Successfully loaded the xFormers CUDA extension on Windows ARM64.
- Validated the build matrix and release artifact filters.